### PR TITLE
fix: use system locale for date labels

### DIFF
--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -15,7 +15,7 @@ export function formatCost(usd: number): string {
 
 export function formatDate(dateStr: string): string {
   const date = new Date(dateStr + "T00:00:00");
-  return date.toLocaleDateString("ko-KR", {
+  return date.toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",
   });


### PR DESCRIPTION
## Summary
- Remove hardcoded `"ko-KR"` locale from `formatDate()` in `src/lib/format.ts`
- Use `undefined` (system locale) so date labels display in the user's own language

Fixes #7

## Test plan
- [ ] Build and run the app on different locale systems
- [ ] Verify chart date labels display in the system's language

🤖 Generated with [Claude Code](https://claude.com/claude-code)