### PR TITLE
security: enable Content Security Policy in Tauri webview

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://avatars.githubusercontent.com; connect-src 'self' https://giunmtxxvapcgrpxjopq.supabase.co https://api.github.com"
     },
     "macOSPrivateApi": true
   },


### PR DESCRIPTION
## Summary
- Replace `"csp": null` with a strict Content Security Policy in `tauri.conf.json`
- Restricts script sources to `'self'`, allows only Supabase and GitHub API for connections
- Allows GitHub avatar images and inline styles (required by React inline styles)

Fixes #11

## Test plan
- [ ] Build and run the app — all features should work normally
- [ ] Verify GitHub avatars load in leaderboard
- [ ] Verify Supabase leaderboard sync works
- [ ] Verify no CSP violations in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)