### PR TITLE
feat: add light/dark mode toggle independent of system setting

### DIFF
--- a/src-tauri/src/providers/types.rs
+++ b/src-tauri/src/providers/types.rs
@@ -40,10 +40,16 @@ pub struct UserPreferences {
     pub leaderboard_opted_in: bool,
     #[serde(default = "default_theme")]
     pub theme: String,
+    #[serde(default = "default_color_mode")]
+    pub color_mode: String,
 }
 
 fn default_theme() -> String {
     "github".to_string()
+}
+
+fn default_color_mode() -> String {
+    "system".to_string()
 }
 
 impl Default for UserPreferences {
@@ -53,6 +59,7 @@ impl Default for UserPreferences {
             show_tray_cost: true,
             leaderboard_opted_in: false,
             theme: default_theme(),
+            color_mode: default_color_mode(),
         }
     }
 }

--- a/src/components/SettingsOverlay.tsx
+++ b/src/components/SettingsOverlay.tsx
@@ -61,6 +61,13 @@ export function SettingsOverlay({ visible, onClose }: Props) {
           />
         </SettingRow>
 
+        <SettingRow label="Appearance">
+          <ColorModeToggle
+            value={prefs.color_mode}
+            onChange={(v) => updatePrefs({ color_mode: v })}
+          />
+        </SettingRow>
+
         <SettingRow
           label="Number Format"
           description={prefs.number_format === "compact" ? "377.0K" : "377,000"}
@@ -355,6 +362,49 @@ function ThemeSelector({
             flexShrink: 0,
           }}
         />
+      ))}
+    </div>
+  );
+}
+
+const COLOR_MODES: { id: "system" | "light" | "dark"; label: string }[] = [
+  { id: "system", label: "Auto" },
+  { id: "light", label: "Light" },
+  { id: "dark", label: "Dark" },
+];
+
+function ColorModeToggle({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: "system" | "light" | "dark") => void;
+}) {
+  return (
+    <div style={{
+      display: "flex",
+      background: "var(--heat-0)",
+      borderRadius: 6,
+      padding: 2,
+    }}>
+      {COLOR_MODES.map((m) => (
+        <button
+          key={m.id}
+          onClick={() => onChange(m.id)}
+          style={{
+            fontSize: 10,
+            fontWeight: 600,
+            padding: "3px 8px",
+            borderRadius: 4,
+            border: "none",
+            cursor: "pointer",
+            background: value === m.id ? "var(--accent-purple)" : "transparent",
+            color: value === m.id ? "#fff" : "var(--text-secondary)",
+            transition: "all 0.15s ease",
+          }}
+        >
+          {m.label}
+        </button>
       ))}
     </div>
   );

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -14,6 +14,7 @@ const defaultPrefs: UserPreferences = {
   show_tray_cost: true,
   leaderboard_opted_in: false,
   theme: "github",
+  color_mode: "system",
 };
 
 const SettingsContext = createContext<SettingsContextType>({
@@ -42,6 +43,29 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     document.documentElement.setAttribute("data-theme", prefs.theme);
   }, [prefs.theme]);
+
+  // Apply color mode (light/dark/system)
+  useEffect(() => {
+    const root = document.documentElement;
+    const apply = (isDark: boolean) => {
+      root.setAttribute("data-color-mode", isDark ? "dark" : "light");
+    };
+
+    if (prefs.color_mode === "dark") {
+      apply(true);
+      return;
+    }
+    if (prefs.color_mode === "light") {
+      apply(false);
+      return;
+    }
+    // system: follow OS preference
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    apply(mq.matches);
+    const handler = (e: MediaQueryListEvent) => apply(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, [prefs.color_mode]);
 
   // Persist to disk when prefs change
   useEffect(() => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -32,4 +32,5 @@ export interface UserPreferences {
   show_tray_cost: boolean;
   leaderboard_opted_in: boolean;
   theme: "github" | "purple" | "ocean" | "sunset";
+  color_mode: "system" | "light" | "dark";
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -28,22 +28,20 @@
   background: var(--bg-primary);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme]),
-  [data-theme="github"] {
-    --bg-primary: #0d1117;
-    --bg-card: #161b22;
-    --text-primary: #e6edf3;
-    --text-secondary: #9ca3af;
-    --shadow-soft: 0 2px 12px rgba(0, 0, 0, 0.3);
-    --shadow-card: 0 4px 16px rgba(0, 0, 0, 0.25);
+[data-color-mode="dark"][data-theme="github"],
+[data-color-mode="dark"]:not([data-theme]) {
+  --bg-primary: #0d1117;
+  --bg-card: #161b22;
+  --text-primary: #e6edf3;
+  --text-secondary: #9ca3af;
+  --shadow-soft: 0 2px 12px rgba(0, 0, 0, 0.3);
+  --shadow-card: 0 4px 16px rgba(0, 0, 0, 0.25);
 
-    --heat-0: #161b22;
-    --heat-1: #0e4429;
-    --heat-2: #006d32;
-    --heat-3: #26a641;
-    --heat-4: #39d353;
-  }
+  --heat-0: #161b22;
+  --heat-1: #0e4429;
+  --heat-2: #006d32;
+  --heat-3: #26a641;
+  --heat-4: #39d353;
 }
 
 /* ===== Theme: Purple ===== */
@@ -66,21 +64,19 @@
   --heat-4: #7C5CFC;
 }
 
-@media (prefers-color-scheme: dark) {
-  [data-theme="purple"] {
-    --bg-primary: #1A1825;
-    --bg-card: #252336;
-    --text-primary: #EEEAF7;
-    --text-secondary: #a8a4bc;
-    --shadow-soft: 0 2px 12px rgba(0, 0, 0, 0.2);
-    --shadow-card: 0 4px 16px rgba(0, 0, 0, 0.15);
+[data-color-mode="dark"][data-theme="purple"] {
+  --bg-primary: #1A1825;
+  --bg-card: #252336;
+  --text-primary: #EEEAF7;
+  --text-secondary: #a8a4bc;
+  --shadow-soft: 0 2px 12px rgba(0, 0, 0, 0.2);
+  --shadow-card: 0 4px 16px rgba(0, 0, 0, 0.15);
 
-    --heat-0: #2A2740;
-    --heat-1: #3D3660;
-    --heat-2: #5A4590;
-    --heat-3: #7558C0;
-    --heat-4: #9B7AFF;
-  }
+  --heat-0: #2A2740;
+  --heat-1: #3D3660;
+  --heat-2: #5A4590;
+  --heat-3: #7558C0;
+  --heat-4: #9B7AFF;
 }
 
 /* ===== Theme: Ocean ===== */
@@ -103,21 +99,19 @@
   --heat-4: #0369a1;
 }
 
-@media (prefers-color-scheme: dark) {
-  [data-theme="ocean"] {
-    --bg-primary: #0f172a;
-    --bg-card: #1e293b;
-    --text-primary: #e2e8f0;
-    --text-secondary: #94a3b8;
-    --shadow-soft: 0 2px 12px rgba(0, 0, 0, 0.3);
-    --shadow-card: 0 4px 16px rgba(0, 0, 0, 0.25);
+[data-color-mode="dark"][data-theme="ocean"] {
+  --bg-primary: #0f172a;
+  --bg-card: #1e293b;
+  --text-primary: #e2e8f0;
+  --text-secondary: #94a3b8;
+  --shadow-soft: 0 2px 12px rgba(0, 0, 0, 0.3);
+  --shadow-card: 0 4px 16px rgba(0, 0, 0, 0.25);
 
-    --heat-0: #1e293b;
-    --heat-1: #0c4a6e;
-    --heat-2: #0369a1;
-    --heat-3: #0284c7;
-    --heat-4: #38bdf8;
-  }
+  --heat-0: #1e293b;
+  --heat-1: #0c4a6e;
+  --heat-2: #0369a1;
+  --heat-3: #0284c7;
+  --heat-4: #38bdf8;
 }
 
 /* ===== Theme: Sunset ===== */
@@ -140,21 +134,19 @@
   --heat-4: #b45309;
 }
 
-@media (prefers-color-scheme: dark) {
-  [data-theme="sunset"] {
-    --bg-primary: #1c1917;
-    --bg-card: #292524;
-    --text-primary: #fef3c7;
-    --text-secondary: #a8a29e;
-    --shadow-soft: 0 2px 12px rgba(0, 0, 0, 0.3);
-    --shadow-card: 0 4px 16px rgba(0, 0, 0, 0.25);
+[data-color-mode="dark"][data-theme="sunset"] {
+  --bg-primary: #1c1917;
+  --bg-card: #292524;
+  --text-primary: #fef3c7;
+  --text-secondary: #a8a29e;
+  --shadow-soft: 0 2px 12px rgba(0, 0, 0, 0.3);
+  --shadow-card: 0 4px 16px rgba(0, 0, 0, 0.25);
 
-    --heat-0: #292524;
-    --heat-1: #78350f;
-    --heat-2: #b45309;
-    --heat-3: #d97706;
-    --heat-4: #fbbf24;
-  }
+  --heat-0: #292524;
+  --heat-1: #78350f;
+  --heat-2: #b45309;
+  --heat-3: #d97706;
+  --heat-4: #fbbf24;
 }
 
 * {


### PR DESCRIPTION
## Summary
- Add `color_mode` preference with System / Light / Dark options
- Replace CSS `@media (prefers-color-scheme: dark)` with `[data-color-mode=\"dark\"]` attribute selectors
- System mode listens to `matchMedia` changes and auto-switches
- Add `ColorModeToggle` component in Settings overlay

Fixes #6

## Test plan
- [ ] Default (System): follows OS dark/light mode
- [ ] Select Light: stays light even when OS is in dark mode
- [ ] Select Dark: stays dark even when OS is in light mode
- [ ] Preference persists across app restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)