### PR TITLE
fix: add macOS code signing and notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,32 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      - name: Import Apple certificate
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          CERTIFICATE_PATH=$RUNNER_TEMP/certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+          echo -n "$APPLE_CERTIFICATE" | base64 --decode -o $CERTIFICATE_PATH
+
+          security create-keychain -p "" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "" $KEYCHAIN_PATH
+
+          security import $CERTIFICATE_PATH -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple: -k "" $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+
       - name: Build Tauri app
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: ${{ github.ref_name }}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -41,9 +41,9 @@
     ],
     "macOS": {
       "frameworks": [],
-      "minimumSystemVersion": "",
+      "minimumSystemVersion": "10.15",
       "exceptionDomain": "",
-      "signingIdentity": null,
+      "signingIdentity": "-",
       "entitlements": null
     }
   },


### PR DESCRIPTION
## Summary
- Release workflow에 Apple Developer ID Application 인증서 import 단계 추가
- tauri-action에 코드 서명 및 공증(notarization) 환경변수 설정
- `minimumSystemVersion`을 10.15(Catalina)로 명시

## Why
macOS Catalina 이상에서 Gatekeeper가 서명/공증 없는 DMG를 차단하여 "손상된 파일" 오류 발생. macOS Sequoia에서는 우클릭 우회도 불가.

## Changes
- `.github/workflows/release.yml`: 인증서 import 단계 + 서명/공증 환경변수 추가
- `src-tauri/tauri.conf.json`: `signingIdentity: "-"`, `minimumSystemVersion: "10.15"`

## Test plan
- [ ] 새 버전 태그 push 후 release workflow에서 서명/공증 성공 확인
- [ ] 릴리스된 DMG를 macOS에서 다운로드 후 Gatekeeper 경고 없이 실행 확인

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)