### PR TITLE
chore: release v0.3.0 — Windows support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,41 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches: [main]
+    paths:
+      - 'package.json'
 
 jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      changed: ${{ steps.check.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Get current version
+        id: version
+        run: echo "version=v$(node -p 'require("./package.json").version')" >> $GITHUB_OUTPUT
+
+      - name: Check if version changed
+        id: check
+        run: |
+          CURRENT=$(node -p 'require("./package.json").version')
+          PREVIOUS=$(git show HEAD~1:package.json | node -p 'JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")).version')
+          if [ "$CURRENT" != "$PREVIOUS" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "Version changed: $PREVIOUS -> $CURRENT"
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "Version unchanged: $CURRENT"
+          fi
+
   build-macos:
+    needs: check-version
+    if: needs.check-version.outputs.changed == 'true'
     runs-on: macos-latest
     permissions:
       contents: write
@@ -58,22 +88,23 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
-          tagName: ${{ github.ref_name }}
-          releaseName: ${{ github.ref_name }}
+          tagName: ${{ needs.check-version.outputs.version }}
+          releaseName: ${{ needs.check-version.outputs.version }}
           releaseBody: |
-            ## AI Token Monitor ${{ github.ref_name }}
+            ## AI Token Monitor ${{ needs.check-version.outputs.version }}
 
             ### Download
             - macOS (Apple Silicon): `.dmg` 파일을 다운로드하세요.
             - Windows: `.exe` 인스톨러를 다운로드하세요.
 
             ### Changes
-            See [commit history](https://github.com/${{ github.repository }}/commits/${{ github.ref_name }}) for details.
+            See [commit history](https://github.com/${{ github.repository }}/commits/main) for details.
           releaseDraft: false
           prerelease: false
 
   build-windows:
-    needs: build-macos
+    needs: [check-version, build-macos]
+    if: needs.check-version.outputs.changed == 'true'
     runs-on: windows-latest
     permissions:
       contents: write
@@ -103,16 +134,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: ${{ github.ref_name }}
-          releaseName: ${{ github.ref_name }}
+          tagName: ${{ needs.check-version.outputs.version }}
+          releaseName: ${{ needs.check-version.outputs.version }}
           releaseBody: |
-            ## AI Token Monitor ${{ github.ref_name }}
+            ## AI Token Monitor ${{ needs.check-version.outputs.version }}
 
             ### Download
             - macOS (Apple Silicon): `.dmg` 파일을 다운로드하세요.
             - Windows: `.exe` 인스톨러를 다운로드하세요.
 
             ### Changes
-            See [commit history](https://github.com/${{ github.repository }}/commits/${{ github.ref_name }}) for details.
+            See [commit history](https://github.com/${{ github.repository }}/commits/main) for details.
           releaseDraft: false
           prerelease: false

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-token-monitor",
   "private": true,
-  "version": "0.2.5",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "ai-token-monitor"
-version = "0.2.5"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "cocoa",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ai-token-monitor"
-version = "0.2.5"
+version = "0.3.0"
 description = "AI Token Monitor - System Tray App"
 authors = ["soul"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AI Token Monitor",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "identifier": "com.soul.ai-token-monitor",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -52,7 +52,10 @@
       },
       "nsis": {
         "installMode": "currentUser",
-        "languages": ["English", "Korean"]
+        "languages": [
+          "English",
+          "Korean"
+        ]
       }
     }
   },


### PR DESCRIPTION
## Summary
- 버전 0.2.5 → 0.3.0 (Windows 플랫폼 지원 추가)
- 릴리스 워크플로우를 태그 기반에서 **main 머지 시 버전 변경 감지** 방식으로 변경

## Release workflow 변경
- **Before**: `v*` 태그 푸시 시 릴리스 빌드 트리거
- **After**: main에 push 될 때 `package.json` 버전이 변경되었으면 릴리스 빌드 트리거
- `check-version` 잡에서 이전 커밋과 현재 커밋의 버전을 비교
- 버전 미변경 시 빌드 스킵

## Test plan
- [ ] main 머지 후 Release 워크플로우 자동 트리거 확인
- [ ] macOS + Windows 빌드 성공 확인
- [ ] GitHub Releases에 v0.3.0 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)