### PR TITLE
ci: remove redundant main push trigger from test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: CI Tests
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   schedule:


### PR DESCRIPTION
## Summary
- test.yml에서 `push: branches: [main]` 트리거 제거
- PR 단계에서 이미 테스트하므로 main 머지 후 중복 테스트 불필요
- 주간 스케줄(월요일 9am UTC)은 유지

## Before → After
| 이벤트 | Before | After |
|--------|--------|-------|
| PR 생성/업데이트 | CI Tests 실행 | CI Tests 실행 |
| main 머지 | CI Tests + Release 동시 실행 | Release만 실행 |
| 주간 스케줄 | CI Tests 실행 | CI Tests 실행 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)