### PR TITLE
fix: release workflow permissions and manual dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     paths:
       - 'package.json'
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   check-version:
@@ -24,6 +28,11 @@ jobs:
       - name: Check if version changed
         id: check
         run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "Manual dispatch — skipping version check"
+            exit 0
+          fi
           CURRENT=$(node -p 'require("./package.json").version')
           PREVIOUS=$(git show HEAD~1:package.json | node -p 'JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")).version')
           if [ "$CURRENT" != "$PREVIOUS" ]; then
@@ -38,9 +47,6 @@ jobs:
     needs: check-version
     if: needs.check-version.outputs.changed == 'true'
     runs-on: macos-latest
-    permissions:
-      contents: write
-
     steps:
       - uses: actions/checkout@v4
 
@@ -106,9 +112,6 @@ jobs:
     needs: [check-version, build-macos]
     if: needs.check-version.outputs.changed == 'true'
     runs-on: windows-latest
-    permissions:
-      contents: write
-
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- 릴리스 워크플로우 권한 오류 수정 (`Resource not accessible by integration`)
- 워크플로우 최상단에 `permissions: contents: write` 추가
- `workflow_dispatch` 트리거 추가 (수동 재실행 가능)
- 수동 실행 시 버전 비교 스킵

## Root cause
태그 기반에서 push 기반으로 변경 시, GitHub 기본 토큰 권한이 read-only여서 릴리스 생성 실패

🤖 Generated with [Claude Code](https://claude.com/claude-code)