### PR TITLE
fix: upgrade windows crate 0.58 → 0.61 for Tauri compatibility

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
- "windows 0.58.0",
+ "windows",
 ]
 
 [[package]]
@@ -3959,7 +3959,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -4030,7 +4030,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -4146,7 +4146,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "url",
- "windows 0.61.3",
+ "windows",
  "zbus",
 ]
 
@@ -4187,7 +4187,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -4212,7 +4212,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows 0.61.3",
+ "windows",
  "wry",
 ]
 
@@ -5103,10 +5103,10 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
 ]
 
 [[package]]
@@ -5127,7 +5127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
 ]
 
@@ -5185,16 +5185,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -5217,25 +5207,12 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -5247,8 +5224,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -5267,31 +5244,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5333,15 +5288,6 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -5356,16 +5302,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5822,7 +5758,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,7 +32,7 @@ cocoa = "0.26"
 objc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.58", features = [
+windows = { version = "0.61", features = [
     "Win32_Graphics_Gdi",
     "Win32_UI_WindowsAndMessaging",
     "Win32_System_DataExchange",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -178,16 +178,16 @@ pub fn capture_window(app: tauri::AppHandle) -> Result<(), String> {
         let width = rect.right - rect.left;
         let height = rect.bottom - rect.top;
 
-        let hdc_window = GetDC(Some(hwnd));
-        let hdc_mem = CreateCompatibleDC(Some(hdc_window));
+        let hdc_window = GetDC(hwnd);
+        let hdc_mem = CreateCompatibleDC(hdc_window);
         let hbm = CreateCompatibleBitmap(hdc_window, width, height);
         let old_obj = SelectObject(hdc_mem, hbm);
 
         // Try PrintWindow with PW_RENDERFULLCONTENT for WebView content
-        let print_result = PrintWindow(hwnd, Some(hdc_mem), PW_RENDERFULLCONTENT);
+        let print_result = PrintWindow(hwnd, hdc_mem, PW_RENDERFULLCONTENT);
         if !print_result.as_bool() {
             // Fallback to BitBlt
-            let _ = BitBlt(hdc_mem, 0, 0, width, height, Some(hdc_window), 0, 0, SRCCOPY);
+            let _ = BitBlt(hdc_mem, 0, 0, width, height, hdc_window, 0, 0, SRCCOPY);
         }
 
         // Deselect bitmap from DC before clipboard operations
@@ -195,16 +195,16 @@ pub fn capture_window(app: tauri::AppHandle) -> Result<(), String> {
 
         // Clean up GDI objects before clipboard (ensures cleanup on any clipboard error)
         DeleteDC(hdc_mem);
-        ReleaseDC(Some(hwnd), hdc_window);
+        ReleaseDC(hwnd, hdc_window);
 
         // Copy to clipboard
-        if OpenClipboard(Some(hwnd)).is_err() {
+        if OpenClipboard(hwnd).is_err() {
             DeleteObject(hbm);
             return Err("Failed to open clipboard".to_string());
         }
         let _ = EmptyClipboard();
         // CF_BITMAP = 2
-        let result = SetClipboardData(2, windows::Win32::Foundation::HANDLE(hbm.0 as isize));
+        let result = SetClipboardData(2, windows::Win32::Foundation::HANDLE(hbm.0));
         let _ = CloseClipboard();
         // Do NOT delete hbm — clipboard owns it after SetClipboardData
 


### PR DESCRIPTION
## Summary
- `windows` 크레이트를 0.58 → 0.61로 업그레이드
- Tauri 내부의 `windows-core 0.61.2`와 버전 충돌 해소
- Win32 API 호출 시그니처 0.61에 맞게 수정 (Option 래핑 제거, HANDLE 타입 수정)

## Root cause
`windows 0.58`은 `windows-core 0.58`을 사용하지만, Tauri가 `windows-core 0.61.2`를 사용하여 `HWND`, `Param` 등 trait이 호환되지 않았음

🤖 Generated with [Claude Code](https://claude.com/claude-code)