### PR TITLE
fix: correct Windows 0.61 API signatures for screenshot

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -182,7 +182,7 @@ pub fn capture_window(app: tauri::AppHandle) -> Result<(), String> {
 
         let hdc_mem = CreateCompatibleDC(Some(hdc_window));
         let hbm = CreateCompatibleBitmap(hdc_window, width, height);
-        let old_obj = SelectObject(hdc_mem, hbm);
+        let old_obj = SelectObject(hdc_mem, hbm.into());
 
         // Capture window content via BitBlt
         let _ = BitBlt(hdc_mem, 0, 0, width, height, Some(hdc_window), 0, 0, SRCCOPY);


### PR DESCRIPTION
## Summary
- `PrintWindow` 제거 (windows 0.61에서 삭제됨) → `GetWindowDC` + `BitBlt`로 대체
- `Option` 래핑 수정: `OpenClipboard(Some(hwnd))`, `SetClipboardData(2, Some(...))` 등
- `DeleteObject(hbm.into())`: HBITMAP → HGDIOBJ 변환 추가

## Test plan
- [x] macOS cargo check 통과
- [ ] Windows CI 빌드 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)