### PR TITLE
fix: correct timezone date parsing, sync weekly leaderboard, and refresh after upload

### DIFF
--- a/src-tauri/src/providers/claude_code.rs
+++ b/src-tauri/src/providers/claude_code.rs
@@ -81,8 +81,15 @@ fn calculate_cost(pricing: &ModelPricing, input: u64, output: u64, cache_read: u
 
 // --- Persistent disk cache for historical month data ---
 
+/// Cache version — bump when the stored date format changes to force a full rebuild.
+/// v1 (missing/0): dates stored as UTC strings (bug)
+/// v2: dates stored as local-timezone strings (correct)
+const CACHE_VERSION: u32 = 2;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct DiskCache {
+    #[serde(default)]
+    version: u32,
     months: HashMap<String, MonthData>,
 }
 
@@ -97,10 +104,17 @@ fn disk_cache_path(claude_dir: &PathBuf) -> PathBuf {
     claude_dir.join("ai-token-monitor-cache.json")
 }
 
+/// Load disk cache, returning None if missing or built with an older version.
+/// An outdated cache is also deleted so it gets rebuilt cleanly on next save.
 fn load_disk_cache(claude_dir: &PathBuf) -> Option<DiskCache> {
     let path = disk_cache_path(claude_dir);
     let content = fs::read_to_string(&path).ok()?;
-    serde_json::from_str(&content).ok()
+    let cache: DiskCache = serde_json::from_str(&content).ok()?;
+    if cache.version < CACHE_VERSION {
+        let _ = fs::remove_file(&path);
+        return None;
+    }
+    Some(cache)
 }
 
 fn save_disk_cache(claude_dir: &PathBuf, cache: &DiskCache) {
@@ -256,7 +270,16 @@ fn parse_session_line(line: &str) -> Option<SessionEntry> {
     usage.get("input_tokens")?;
 
     let timestamp = value.get("timestamp")?.as_str()?;
-    let date = timestamp.get(..10)?.to_string();
+    // Convert UTC timestamp to local date so early-morning sessions (before midnight UTC)
+    // are attributed to the correct local calendar day.
+    let date = {
+        use chrono::{DateTime, Utc};
+        if let Ok(utc_dt) = timestamp.parse::<DateTime<Utc>>() {
+            utc_dt.with_timezone(&chrono::Local).format("%Y-%m-%d").to_string()
+        } else {
+            timestamp.get(..10)?.to_string()
+        }
+    };
 
     let model = message.get("model")?.as_str()?.to_string();
 
@@ -564,7 +587,7 @@ impl ClaudeCodeProvider {
         }
 
         // Merge with disk cache
-        let disk_cache = load_disk_cache(&self.primary_dir).unwrap_or(DiskCache { months: HashMap::new() });
+        let disk_cache = load_disk_cache(&self.primary_dir).unwrap_or(DiskCache { version: CACHE_VERSION, months: HashMap::new() });
         let result = self.merge_and_finalize(
             state.daily_map.clone(),
             state.model_usage_map.clone(),
@@ -581,6 +604,7 @@ impl ClaudeCodeProvider {
         let current_month = current_month_str();
 
         let mut disk_cache = load_disk_cache(&self.primary_dir).unwrap_or(DiskCache {
+            version: CACHE_VERSION,
             months: HashMap::new(),
         });
         let has_historical = !disk_cache.months.is_empty();
@@ -603,7 +627,7 @@ impl ClaudeCodeProvider {
                 }
             }
 
-            let mut new_cache = DiskCache { months: HashMap::new() };
+            let mut new_cache = DiskCache { version: CACHE_VERSION, months: HashMap::new() };
             for (month, month_data) in &month_entries {
                 let (daily_map, model_map, messages, _) = aggregate_entries(month_data);
                 new_cache.months.insert(month.clone(), MonthData {

--- a/src/hooks/useLeaderboardSync.ts
+++ b/src/hooks/useLeaderboardSync.ts
@@ -50,25 +50,13 @@ export function useLeaderboardSync({ stats, user, optedIn }: UseLeaderboardSyncP
   const [period, setPeriod] = useState<"today" | "week">("today");
   const [loading, setLoading] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  // Track which past days (before today) have already been synced this session
+  const syncedPastDatesRef = useRef<Set<string>>(new Set());
   const cacheRef = useRef<{
     data: LeaderboardEntry[];
     fetchedAt: number;
     period: "today" | "week";
   } | null>(null);
-
-  // Upload today's snapshot (debounced)
-  useEffect(() => {
-    if (!supabase || !user || !optedIn || !stats) return;
-
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      uploadSnapshot(user.id, stats);
-    }, 500);
-
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-  }, [stats, user, optedIn]);
 
   // Fetch leaderboard data
   const fetchLeaderboard = useCallback(async (forceRefresh = false) => {
@@ -149,24 +137,53 @@ export function useLeaderboardSync({ stats, user, optedIn }: UseLeaderboardSyncP
     return () => clearInterval(interval);
   }, [fetchLeaderboard]);
 
+  // Upload snapshot (debounced), then immediately refresh leaderboard
+  useEffect(() => {
+    if (!supabase || !user || !optedIn || !stats) return;
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      await uploadSnapshot(user.id, stats, syncedPastDatesRef.current);
+      fetchLeaderboard(true);
+    }, 500);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [stats, user, optedIn, fetchLeaderboard]);
+
   return { leaderboard, loading, period, setPeriod, refetch: () => fetchLeaderboard(true) };
 }
 
-async function uploadSnapshot(userId: string, stats: AllStats) {
+async function uploadSnapshot(userId: string, stats: AllStats, syncedPastDates: Set<string>) {
   if (!supabase) return;
 
-  const today = toLocalDateStr(new Date());
-  const todayData = stats.daily.find((d) => d.date === today);
-  if (!todayData) return;
+  const now = new Date();
+  const today = toLocalDateStr(now);
+  const dow = now.getDay();
+  const mondayOffset = dow === 0 ? 6 : dow - 1;
+  const monday = new Date(now);
+  monday.setDate(now.getDate() - mondayOffset);
+  const weekStart = toLocalDateStr(monday);
 
-  const totalTokens = getTotalTokens(todayData.tokens);
+  // Always upload today; upload past days of this week only once per session
+  const toSync = stats.daily.filter(
+    (d) => d.date >= weekStart && d.date <= today &&
+      (d.date === today || !syncedPastDates.has(d.date))
+  );
+  if (toSync.length === 0) return;
 
-  await supabase.from("daily_snapshots").upsert({
+  const rows = toSync.map((d) => ({
     user_id: userId,
-    date: today,
-    total_tokens: totalTokens,
-    cost_usd: todayData.cost_usd,
-    messages: todayData.messages,
-    sessions: todayData.sessions,
-  }, { onConflict: "user_id,date" });
+    date: d.date,
+    total_tokens: getTotalTokens(d.tokens),
+    cost_usd: d.cost_usd,
+    messages: d.messages,
+    sessions: d.sessions,
+  }));
+
+  await supabase.from("daily_snapshots").upsert(rows, { onConflict: "user_id,date" });
+
+  // Mark past days as synced so they won't be re-uploaded until next session
+  toSync.forEach((d) => { if (d.date !== today) syncedPastDates.add(d.date); });
 }


### PR DESCRIPTION
## 문제

### 1. 타임존 버그 — UTC+ 사용자 오늘 통계 \$0.00 표시
JSONL 타임스탬프(UTC)에서 날짜를 추출할 때 앞 10글자를 그대로 슬라이싱하고 있었습니다.

\`\`\`
2026-03-23T23:44:59Z  →  "2026-03-23"  (UTC 날짜)
실제 KST(UTC+9)로는  →  2026-03-24 08:44:59
\`\`\`

오전 9시 이전 세션이 전날로 집계되어 오늘 통계가 \$0.00 으로 표시됩니다.
UTC+1 이상 사용자(한국, 일본, 유럽 등) 전체에 해당합니다.

### 2. 신규/중간 설치 시 리더보드 이번 주 집계 불완전
`uploadSnapshot`이 오늘 데이터만 업로드하는 구조라, 수요일에 처음 설치하면 월·화 데이터가 리더보드에 없습니다. 매일 앱을 열어야만 주간 집계가 완성되는 구조입니다.

### 3. 리더보드 업로드 후 즉시 반영 안됨
업로드 완료 후 60초 polling까지 기다려야 반영됩니다.

---

## 수정 내용

### `src-tauri/src/providers/claude_code.rs`
- UTC 타임스탬프 → 로컬 타임존 변환 후 날짜 추출
- `CACHE_VERSION = 2` 도입: 구버전 캐시(UTC 기준) 자동 감지 및 재빌드 → 기존 사용자 수동 캐시 삭제 불필요

### `src/hooks/useLeaderboardSync.ts`
- 앱 실행 시 이번 주 전체(월~오늘)를 Supabase에 업로드 → 신규/중간 설치 사용자도 첫 실행부터 주간 집계 완성
- 과거 날짜는 session-scoped `Set`으로 추적, 세션당 1회만 업로드 (불필요한 DB 쓰기 방지)
- 업로드 완료 후 즉시 `fetchLeaderboard(true)` 호출 → 바로 반영

---

## 테스트 환경
- macOS, KST (UTC+9)
- Claude Code v2.1.52 / 약 285,000개 메시지 기준 검증