### PR TITLE
fix: correct timezone date parsing and sync weekly leaderboard

### DIFF
--- a/src-tauri/src/providers/claude_code.rs
+++ b/src-tauri/src/providers/claude_code.rs
@@ -81,8 +81,15 @@ fn calculate_cost(pricing: &ModelPricing, input: u64, output: u64, cache_read: u
 
 // --- Persistent disk cache for historical month data ---
 
+/// Cache version — bump when the stored date format changes to force a full rebuild.
+/// v1 (missing/0): dates stored as UTC strings (bug)
+/// v2: dates stored as local-timezone strings (correct)
+const CACHE_VERSION: u32 = 2;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct DiskCache {
+    #[serde(default)]
+    version: u32,
     months: HashMap<String, MonthData>,
 }
 
@@ -97,10 +104,17 @@ fn disk_cache_path(claude_dir: &PathBuf) -> PathBuf {
     claude_dir.join("ai-token-monitor-cache.json")
 }
 
+/// Load disk cache, returning None if missing or built with an older version.
+/// An outdated cache is also deleted so it gets rebuilt cleanly on next save.
 fn load_disk_cache(claude_dir: &PathBuf) -> Option<DiskCache> {
     let path = disk_cache_path(claude_dir);
     let content = fs::read_to_string(&path).ok()?;
-    serde_json::from_str(&content).ok()
+    let cache: DiskCache = serde_json::from_str(&content).ok()?;
+    if cache.version < CACHE_VERSION {
+        let _ = fs::remove_file(&path);
+        return None;
+    }
+    Some(cache)
 }
 
 fn save_disk_cache(claude_dir: &PathBuf, cache: &DiskCache) {
@@ -256,7 +270,16 @@ fn parse_session_line(line: &str) -> Option<SessionEntry> {
     usage.get("input_tokens")?;
 
     let timestamp = value.get("timestamp")?.as_str()?;
-    let date = timestamp.get(..10)?.to_string();
+    // Convert UTC timestamp to local date so early-morning sessions (before midnight UTC)
+    // are attributed to the correct local calendar day.
+    let date = {
+        use chrono::{DateTime, Utc};
+        if let Ok(utc_dt) = timestamp.parse::<DateTime<Utc>>() {
+            utc_dt.with_timezone(&chrono::Local).format("%Y-%m-%d").to_string()
+        } else {
+            timestamp.get(..10)?.to_string()
+        }
+    };
 
     let model = message.get("model")?.as_str()?.to_string();
 
@@ -564,7 +587,7 @@ impl ClaudeCodeProvider {
         }
 
         // Merge with disk cache
-        let disk_cache = load_disk_cache(&self.primary_dir).unwrap_or(DiskCache { months: HashMap::new() });
+        let disk_cache = load_disk_cache(&self.primary_dir).unwrap_or(DiskCache { version: CACHE_VERSION, months: HashMap::new() });
         let result = self.merge_and_finalize(
             state.daily_map.clone(),
             state.model_usage_map.clone(),
@@ -581,6 +604,7 @@ impl ClaudeCodeProvider {
         let current_month = current_month_str();
 
         let mut disk_cache = load_disk_cache(&self.primary_dir).unwrap_or(DiskCache {
+            version: CACHE_VERSION,
             months: HashMap::new(),
         });
         let has_historical = !disk_cache.months.is_empty();
@@ -603,7 +627,7 @@ impl ClaudeCodeProvider {
                 }
             }
 
-            let mut new_cache = DiskCache { months: HashMap::new() };
+            let mut new_cache = DiskCache { version: CACHE_VERSION, months: HashMap::new() };
             for (month, month_data) in &month_entries {
                 let (daily_map, model_map, messages, _) = aggregate_entries(month_data);
                 new_cache.months.insert(month.clone(), MonthData {
@@ -704,7 +728,9 @@ mod tests {
     #[test]
     fn parse_session_line_extracts_fields() {
         let entry = parse_session_line(sample_jsonl_line()).expect("should parse");
-        assert_eq!(entry.date, "2026-03-23");
+        // Date depends on local timezone: UTC 10:00 may be 23rd or 24th depending on offset.
+        // Just verify it is a valid date string in YYYY-MM-DD format.
+        assert!(entry.date.starts_with("2026-03-2"), "unexpected date: {}", entry.date);
         assert!(entry.model.contains("sonnet"));
         assert_eq!(entry.session_id, "abc-123");
         assert_eq!(entry.message_id, "msg-1");

--- a/src/hooks/useLeaderboardSync.ts
+++ b/src/hooks/useLeaderboardSync.ts
@@ -50,25 +50,13 @@ export function useLeaderboardSync({ stats, user, optedIn }: UseLeaderboardSyncP
   const [period, setPeriod] = useState<"today" | "week">("today");
   const [loading, setLoading] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  // Track which past days (before today) have already been synced this session
+  const syncedPastDatesRef = useRef<Set<string>>(new Set());
   const cacheRef = useRef<{
     data: LeaderboardEntry[];
     fetchedAt: number;
     period: "today" | "week";
   } | null>(null);
-
-  // Upload today's snapshot (debounced)
-  useEffect(() => {
-    if (!supabase || !user || !optedIn || !stats) return;
-
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      uploadSnapshot(user.id, stats);
-    }, 500);
-
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-  }, [stats, user, optedIn]);
 
   // Fetch leaderboard data
   const fetchLeaderboard = useCallback(async (forceRefresh = false) => {
@@ -142,6 +130,21 @@ export function useLeaderboardSync({ stats, user, optedIn }: UseLeaderboardSyncP
     }
   }, [period]);
 
+  // Upload snapshot (debounced), then immediately refresh leaderboard
+  useEffect(() => {
+    if (!supabase || !user || !optedIn || !stats) return;
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      await uploadSnapshot(user.id, stats, syncedPastDatesRef.current);
+      fetchLeaderboard(true);
+    }, 500);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [stats, user, optedIn, fetchLeaderboard]);
+
   // Auto-refresh every 60s (force refresh to bypass cache on interval)
   useEffect(() => {
     fetchLeaderboard();
@@ -152,21 +155,38 @@ export function useLeaderboardSync({ stats, user, optedIn }: UseLeaderboardSyncP
   return { leaderboard, loading, period, setPeriod, refetch: () => fetchLeaderboard(true) };
 }
 
-async function uploadSnapshot(userId: string, stats: AllStats) {
+async function uploadSnapshot(userId: string, stats: AllStats, syncedPastDates: Set<string>) {
   if (!supabase) return;
 
-  const today = toLocalDateStr(new Date());
-  const todayData = stats.daily.find((d) => d.date === today);
-  if (!todayData) return;
+  const now = new Date();
+  const today = toLocalDateStr(now);
+  const dow = now.getDay();
+  const mondayOffset = dow === 0 ? 6 : dow - 1;
+  const monday = new Date(now);
+  monday.setDate(now.getDate() - mondayOffset);
+  const weekStart = toLocalDateStr(monday);
 
-  const totalTokens = getTotalTokens(todayData.tokens);
+  // Always upload today; upload past days of this week only once per session
+  const toSync = stats.daily.filter(
+    (d) => d.date >= weekStart && d.date <= today &&
+      (d.date === today || !syncedPastDates.has(d.date))
+  );
+  if (toSync.length === 0) return;
 
-  await supabase.from("daily_snapshots").upsert({
+  const rows = toSync.map((d) => ({
     user_id: userId,
-    date: today,
-    total_tokens: totalTokens,
-    cost_usd: todayData.cost_usd,
-    messages: todayData.messages,
-    sessions: todayData.sessions,
-  }, { onConflict: "user_id,date" });
+    date: d.date,
+    total_tokens: getTotalTokens(d.tokens),
+    cost_usd: d.cost_usd,
+    messages: d.messages,
+    sessions: d.sessions,
+  }));
+
+  const { error } = await supabase.from("daily_snapshots").upsert(rows, { onConflict: "user_id,date" });
+
+  // Mark past days as synced so they won't be re-uploaded until next session
+  // Only mark if upsert succeeded — on failure, retry is needed next time
+  if (!error) {
+    toSync.forEach((d) => { if (d.date !== today) syncedPastDates.add(d.date); });
+  }
 }


### PR DESCRIPTION
## Summary

- **UTC→로컬 타임존 변환**: JSONL 타임스탬프가 UTC여서 KST 00:00~08:59 사이 사용량이 전날로 집계되던 버그 수정
- **CACHE_VERSION 도입**: 구버전(UTC 기준) 디스크 캐시를 자동 감지하여 삭제 후 재빌드 → 기존 사용자 수동 캐시 삭제 불필요
- **리더보드 주간 sync**: 앱 실행 시 이번 주 전체(월~오늘) 업로드, 이후에는 오늘 데이터만 반복. 업로드 후 즉시 리더보드 새로고침

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `src-tauri/src/providers/claude_code.rs` | UTC→Local 변환, CACHE_VERSION=2, 테스트 타임존 독립성 |
| `src/hooks/useLeaderboardSync.ts` | 주간 데이터 sync, 세션당 1회 과거 업로드, 에러 핸들링 |

## Related

- Closes #41
- Supersedes #39 (동일 수정 + 리더보드 sync)
- Supersedes #40 의 타임존 수정 부분 (성능 최적화는 별도 후속)

## Test plan

- [x] `cargo test` — 7개 전체 통과
- [x] `npm run build` — tsc + vite 빌드 성공
- [ ] `npm run tauri dev` — 로컬에서 Today 통계가 로컬 타임존 기준인지 확인
- [ ] 디스크 캐시 재빌드 확인 (기존 캐시 자동 무효화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)