### PR TITLE
fix: correct updater public key

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -62,7 +62,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDJDRkNCNTJBNEE2OEY2OUQKUldTZDltaEtLclg4TEYreXcycnllbUlGVFZ5WHJ2OVkxemhmS1pJZ05uZUtUSFZUU1ZuUklFamIK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEY5ODM1N0M5RUJBODQ0NTgKUldSWVJLanJ5VmVEK1dOZjg0WWVySGZJaFVPNTJpNjFwOEhlRXZ5Z2t5bzNoYUdEZ2tsaG1QekwK",
       "endpoints": [
         "https://github.com/soulduse/ai-token-monitor/releases/latest/download/latest.json"
       ],

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -336,7 +336,7 @@ function UpdateIndicator({ updater, t }: { updater: UpdaterState; t: ReturnType<
   if (error) {
     return (
       <div style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 11, fontWeight: 600 }}>
-        <span style={{ color: "var(--red, #ef4444)" }}>{t("update.error")}</span>
+        <span title={error} style={{ color: "var(--red, #ef4444)", cursor: "help" }}>{t("update.error")}</span>
         <button onClick={download} style={indicatorBtnStyle}>{t("update.download")}</button>
       </div>
     );


### PR DESCRIPTION
## Summary
- `tauri.conf.json`의 updater pubkey가 실제 서명 키 쌍과 불일치하여 업데이트 서명 검증 실패
- 올바른 public key로 교체
- 에러 상태에서 실제 에러 메시지를 tooltip으로 표시

## Root Cause
키 생성 시 사용된 pubkey와 config에 입력된 pubkey가 서로 다른 키 쌍이었음.
빌드 시 `The updater secret key does not match the public key` 경고로 확인.

## Test plan
- [x] 로컬 빌드에서 pubkey 불일치 경고 사라짐 확인
- [ ] 릴리스 후 실제 업데이트 동작 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)