### PR TITLE
fix: update tray cost after stats loaded

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -18,8 +18,8 @@ fn prefs_path() -> PathBuf {
 }
 
 #[tauri::command]
-pub async fn get_all_stats() -> Result<AllStats, String> {
-    tauri::async_runtime::spawn_blocking(|| {
+pub async fn get_all_stats(app: tauri::AppHandle) -> Result<AllStats, String> {
+    let result = tauri::async_runtime::spawn_blocking(|| {
         let prefs = get_preferences();
         let provider = ClaudeCodeProvider::new(prefs.config_dirs);
         if !provider.is_available() {
@@ -28,12 +28,17 @@ pub async fn get_all_stats() -> Result<AllStats, String> {
         provider.fetch_stats()
     })
     .await
-    .map_err(|e| e.to_string())?
+    .map_err(|e| e.to_string())?;
+
+    if result.is_ok() {
+        crate::update_tray_title(&app);
+    }
+    result
 }
 
 #[tauri::command]
-pub async fn get_codex_stats() -> Result<AllStats, String> {
-    tauri::async_runtime::spawn_blocking(|| {
+pub async fn get_codex_stats(app: tauri::AppHandle) -> Result<AllStats, String> {
+    let result = tauri::async_runtime::spawn_blocking(|| {
         let provider = CodexProvider::new();
         if !provider.is_available() {
             return Err("Codex stats not available".to_string());
@@ -41,7 +46,12 @@ pub async fn get_codex_stats() -> Result<AllStats, String> {
         provider.fetch_stats()
     })
     .await
-    .map_err(|e| e.to_string())?
+    .map_err(|e| e.to_string())?;
+
+    if result.is_ok() {
+        crate::update_tray_title(&app);
+    }
+    result
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Summary
- 앱 시작/재시작 후 트레이에 $0.00 표시되는 문제 수정
- `get_all_stats()`/`get_codex_stats()` 성공 시 `update_tray_title()` 호출 추가

## Root Cause
`update_tray_title()`은 캐시된 stats만 사용하는데, 앱 초기화 시점에는 캐시가 비어있어 항상 $0.00 표시

## Test plan
- [ ] 앱 재시작 후 트레이 비용이 올바르게 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)