### PR TITLE
fix: resolve GitHub OAuth login failure on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "ai-token-monitor",
-  "version": "0.8.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-token-monitor",
-      "version": "0.8.1",
+      "version": "0.9.2",
       "dependencies": {
         "@supabase/supabase-js": "^2.99.3",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
+        "@tauri-apps/plugin-deep-link": "^2.4.7",
         "@tauri-apps/plugin-dialog": "^2.6.0",
         "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-process": "^2.3.1",
@@ -1473,6 +1474,15 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-deep-link": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-deep-link/-/plugin-deep-link-2.4.7.tgz",
+      "integrity": "sha512-K0FQlLM6BoV7Ws2xfkh+Tnwi5VZVdkI4Vw/3AGLSf0Xvu2y86AMBzd9w/SpzKhw9ai2B6ES8di/OoGDCExkOzg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@tauri-apps/plugin-dialog": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@supabase/supabase-js": "^2.99.3",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
+    "@tauri-apps/plugin-deep-link": "^2.4.7",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "ai-token-monitor"
-version = "0.8.5"
+version = "0.9.2"
 dependencies = [
  "chrono",
  "cocoa",
@@ -32,6 +32,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
+ "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-process",
@@ -581,6 +582,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +933,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1646,6 +1676,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2706,6 +2742,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3490,6 +3536,16 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -4372,6 +4428,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94deb2e2e4641514ac496db2cddcfc850d6fc9d51ea17b82292a0490bd20ba5b"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4708,6 +4785,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -5635,6 +5721,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ tauri-plugin-single-instance = "2.4.0"
 tauri-plugin-dialog = "2.6.0"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+tauri-plugin-deep-link = "2"
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(feature, values("cargo-clippy"))'] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "clipboard-manager:allow-write-text",
     "dialog:allow-open",
     "updater:default",
-    "process:allow-restart"
+    "process:allow-restart",
+    "deep-link:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -270,6 +270,7 @@ pub fn run() {
             }
         }))
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -61,6 +61,12 @@
     }
   },
   "plugins": {
+    "deep-link": {
+      "mobile": [],
+      "desktop": {
+        "schemes": ["ai-token-monitor"]
+      }
+    },
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEY5ODM1N0M5RUJBODQ0NTgKUldSWVJLanJ5VmVEK1dOZjg0WWVySGZJaFVPNTJpNjFwOEhlRXZ5Z2t5bzNoYUdEZ2tsaG1QekwK",
       "endpoints": [

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,7 +1,17 @@
-import { createContext, useContext, useEffect, useState, useCallback } from "react";
+import { createContext, useContext, useEffect, useState, useCallback, useRef } from "react";
 import type { ReactNode } from "react";
 import { supabase } from "../lib/supabase";
+import { onOpenUrl } from "@tauri-apps/plugin-deep-link";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import type { User } from "@supabase/supabase-js";
+
+const DEEP_LINK_CALLBACK = "ai-token-monitor://auth/callback";
+const AUTH_TIMEOUT_MS = 120_000;
+
+function isWindowsProduction(): boolean {
+  if (window.location.protocol === "http:") return false;
+  return /windows/i.test(navigator.userAgent);
+}
 
 interface AuthContextType {
   user: User | null;
@@ -26,6 +36,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [profile, setProfile] = useState<{ nickname: string; avatar_url: string | null } | null>(null);
   const [loading, setLoading] = useState(true);
   const available = supabase !== null;
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (!supabase) {
@@ -53,6 +64,46 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => subscription.unsubscribe();
   }, []);
 
+  // Windows production: listen for deep link OAuth callback
+  useEffect(() => {
+    if (!isWindowsProduction() || !supabase) return;
+
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+
+    onOpenUrl(async (urls: string[]) => {
+      for (const url of urls) {
+        if (!url.startsWith(DEEP_LINK_CALLBACK)) continue;
+        const code = new URL(url).searchParams.get("code");
+        if (code) {
+          try {
+            await supabase.auth.exchangeCodeForSession(code);
+          } catch (err) {
+            console.error("Session exchange failed:", err);
+          } finally {
+            if (timeoutRef.current) clearTimeout(timeoutRef.current);
+            setLoading(false);
+          }
+        }
+      }
+    }).then((fn) => {
+      if (cancelled) fn();
+      else unlisten = fn;
+    });
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
+
+  // Cleanup auth timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
   const upsertProfile = useCallback(async (u: User) => {
     if (!supabase) return;
 
@@ -73,11 +124,37 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const signIn = useCallback(async () => {
     if (!supabase) return;
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
     setLoading(true);
-    await supabase.auth.signInWithOAuth({
+
+    if (!isWindowsProduction()) {
+      // macOS production + dev mode: existing implicit flow
+      await supabase.auth.signInWithOAuth({
+        provider: "github",
+        options: { redirectTo: window.location.origin },
+      });
+      return;
+    }
+
+    // Windows production: PKCE + deep link
+    const { data, error } = await supabase.auth.signInWithOAuth({
       provider: "github",
-      options: { redirectTo: window.location.origin },
+      options: {
+        skipBrowserRedirect: true,
+        redirectTo: DEEP_LINK_CALLBACK,
+      },
     });
+
+    if (error || !data.url) {
+      console.error("OAuth error:", error);
+      setLoading(false);
+      return;
+    }
+
+    await openUrl(data.url);
+
+    // Timeout: reset loading if no callback received
+    timeoutRef.current = setTimeout(() => setLoading(false), AUTH_TIMEOUT_MS);
   }, []);
 
   const signOut = useCallback(async () => {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -153,7 +153,7 @@ enabled = true
 # in emails.
 site_url = "http://localhost:1420"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["http://localhost:1420", "http://127.0.0.1:1420"]
+additional_redirect_urls = ["http://localhost:1420", "http://127.0.0.1:1420", "ai-token-monitor://auth/callback"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).


### PR DESCRIPTION
## Summary
- Windows 프로덕션 빌드에서 GitHub OAuth 로그인 시 `https://tauri.localhost`로 리다이렉트되어 connection refused 에러 발생하는 문제 수정
- `tauri-plugin-deep-link`을 추가하여 `ai-token-monitor://auth/callback` 커스텀 스킴으로 OAuth 콜백 처리
- Windows에서만 PKCE + deep link 플로우 사용, macOS는 기존 implicit flow 유지

## Changes
- `tauri-plugin-deep-link` 설치 (Rust + npm)
- `tauri.conf.json`에 deep-link 스킴 등록
- `AuthContext.tsx`에 OS별 분기 로직 + deep link 리스너 추가
- Supabase redirect URL에 `ai-token-monitor://auth/callback` 추가

## Platform Impact
| Platform | Before | After |
|----------|--------|-------|
| macOS production | ✅ Working | ✅ No change |
| Windows production | ❌ Connection refused | ✅ PKCE + deep link |
| Dev mode (both) | ✅ Working | ✅ No change |

## Test plan
- [ ] macOS 개발 모드에서 기존 GitHub 로그인 정상 동작 확인
- [ ] macOS 프로덕션 빌드에서 기존 로그인 플로우 회귀 없음 확인
- [ ] Windows 프로덕션 빌드에서 GitHub 로그인 → deep link 콜백 → 세션 완성 확인
- [ ] 인증 취소 시 2분 후 loading 상태 자동 복구 확인

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)