### PR TITLE
fix: Windows OAuth 로그인 실패 수정 - single-instance 플러그인에 deep-link feature flag 추가

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "ai-token-monitor"
-version = "0.9.2"
+version = "0.9.6"
 dependencies = [
  "chrono",
  "cocoa",
@@ -4529,6 +4529,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri",
+ "tauri-plugin-deep-link",
  "thiserror 2.0.18",
  "tracing",
  "windows-sys 0.60.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ chrono = { version = "0.4", features = ["serde"] }
 dirs = "6"
 notify = "7"
 tauri-plugin-clipboard-manager = "2.3.2"
-tauri-plugin-single-instance = "2.4.0"
+tauri-plugin-single-instance = { version = "2.4.0", features = ["deep-link"] }
 tauri-plugin-dialog = "2.6.0"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -4,4 +4,8 @@ import { createClient } from "@supabase/supabase-js";
 const SUPABASE_URL = "https://giunmtxxvapcgrpxjopq.supabase.co";
 const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdpdW5tdHh4dmFwY2dycHhqb3BxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzQwNTY1NTgsImV4cCI6MjA4OTYzMjU1OH0.Hr_xtU1FGUrlNjWS8g4KeiYQWt0vC3bd16VVlAZdldk";
 
-export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  auth: {
+    flowType: 'pkce',
+  },
+});


### PR DESCRIPTION
## Summary
- `tauri-plugin-single-instance`에 `features = ["deep-link"]` 추가하여 Windows에서 OAuth deep link 콜백이 정상 전달되도록 수정
- Supabase 클라이언트에 `flowType: 'pkce'` 명시적 설정

## Root Cause
`tauri-plugin-single-instance`에 `deep-link` feature flag가 누락되어 있었습니다.

플러그인 내부의 `#[cfg(feature = "deep-link")]` 가드에 의해 `handle_cli_arguments()` 호출이 컴파일에서 제외되었고, OAuth 콜백 deep link URL(`ai-token-monitor://auth/callback?code=...`)이 single-instance 콜백의 args에 도착하지만 deep-link 플러그인으로 전달되지 않아 `onOpenUrl` 리스너가 작동하지 않았습니다.

```rust
// tauri-plugin-single-instance 내부 코드 — 이 블록이 컴파일에서 제외됨
#[cfg(feature = "deep-link")]
if let Some(deep_link) = app.try_state::<tauri_plugin_deep_link::DeepLink<R>>() {
    deep_link.handle_cli_arguments(args.iter());
}
```

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `src-tauri/Cargo.toml` | `tauri-plugin-single-instance`에 `features = ["deep-link"]` 추가 |
| `src/lib/supabase.ts` | `flowType: 'pkce'` 명시적 설정 |
| `src-tauri/Cargo.lock` | 자동 갱신 |

## Action Required
- [ ] **프로덕션 Supabase 대시보드** 확인 필요: **Authentication > URL Configuration > Redirect URLs**에 `ai-token-monitor://auth/callback`이 등록되어 있는지 확인 (`supabase/config.toml`은 로컬 개발용이므로 프로덕션에 미적용)

## Test plan
- [ ] Windows에서 앱 빌드 후 GitHub OAuth 로그인 테스트
- [ ] "Sign In with GitHub" 클릭 → 브라우저 인증 → 앱 복귀 후 로그인 완료 확인
- [ ] macOS에서 기존 OAuth 흐름이 정상 작동하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)