### PR TITLE
feat: switch usage alerts to OAuth API for accurate utilization tracking

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "ai-token-monitor"
-version = "0.9.2"
+version = "0.9.5"
 dependencies = [
  "chrono",
  "cocoa",
@@ -27,6 +27,8 @@ dependencies = [
  "glob",
  "notify",
  "objc",
+ "reqwest 0.12.28",
+ "security-framework",
  "serde",
  "serde_json",
  "tauri",
@@ -34,10 +36,12 @@ dependencies = [
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
+ "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
+ "whoami",
  "windows",
 ]
 
@@ -509,6 +513,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -1483,8 +1493,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1494,9 +1506,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1818,6 +1832,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2313,10 +2328,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "mac-notification-sys"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+dependencies = [
+ "cc",
+ "objc2",
+ "objc2-foundation",
+ "time",
+]
 
 [[package]]
 name = "malloc_buf"
@@ -2517,6 +2550,20 @@ dependencies = [
  "notify-types",
  "walkdir",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-rust"
+version = "4.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21af20a1b50be5ac5861f74af1a863da53a11c38684d9818d82f1c42f7fdc6c2"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
 ]
 
 [[package]]
@@ -3259,6 +3306,15 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
@@ -3273,6 +3329,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3322,6 +3433,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3342,6 +3463,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3357,6 +3488,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3460,6 +3600,44 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
 
 [[package]]
 name = "reqwest"
@@ -3608,6 +3786,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3654,6 +3833,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3893,6 +4078,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -4311,7 +4508,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4489,6 +4686,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4551,7 +4767,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.13.2",
  "rustls",
  "semver",
  "serde",
@@ -4666,6 +4882,18 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
 ]
 
 [[package]]
@@ -4805,6 +5033,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -5282,6 +5525,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5468,6 +5717,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5533,6 +5792,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5573,6 +5841,17 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+ "web-sys",
+]
 
 [[package]]
 name = "winapi"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,9 @@ tauri-plugin-dialog = "2.6.0"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-deep-link = "2"
+tauri-plugin-notification = "2"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+whoami = "1"
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(feature, values("cargo-clippy"))'] }
@@ -34,6 +37,7 @@ unexpected_cfgs = { level = "allow", check-cfg = ['cfg(feature, values("cargo-cl
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.26"
 objc = "0.2"
+security-framework = "3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.61", features = [

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,6 +12,7 @@
     "dialog:allow-open",
     "updater:default",
     "process:allow-restart",
-    "deep-link:default"
+    "deep-link:default",
+    "notification:default"
   ]
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -343,6 +343,11 @@ pub fn capture_window(_app: tauri::AppHandle) -> Result<(), String> {
 }
 
 #[tauri::command]
+pub fn get_oauth_usage() -> Option<crate::oauth_usage::OAuthUsage> {
+    crate::oauth_usage::get_cached_usage()
+}
+
+#[tauri::command]
 pub fn get_pricing_table() -> pricing::PricingTable {
     pricing::get_pricing_table()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,10 +1,13 @@
 mod commands;
+mod oauth_usage;
 mod providers;
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
+use std::sync::Mutex;
 use std::thread;
+use std::time::Instant;
 
 /// When true, the window will not auto-hide on focus loss (e.g. during dialog).
 static DIALOG_OPEN: AtomicBool = AtomicBool::new(false);
@@ -13,6 +16,99 @@ use tauri::tray::TrayIconBuilder;
 use tauri::{Emitter, Manager};
 
 use providers::types::UserPreferences;
+
+struct AlertState {
+    window_id: String,
+    fired_thresholds: Vec<u32>,
+    last_notification_at: Option<Instant>,
+}
+
+static ALERT_STATE: Mutex<Option<AlertState>> = Mutex::new(None);
+
+/// Check OAuth usage thresholds and fire OS notifications for newly crossed thresholds.
+fn check_and_fire_alerts(app_handle: &tauri::AppHandle) {
+    let prefs = commands::get_preferences();
+    if !prefs.usage_alerts_enabled {
+        return;
+    }
+
+    let usage = match oauth_usage::get_cached_usage() {
+        Some(u) => u,
+        None => return,
+    };
+
+    // Use five_hour utilization for threshold alerts
+    let utilization = match &usage.five_hour {
+        Some(w) => w.utilization,
+        None => return,
+    };
+
+    // Use resets_at as window_id (stable identifier from API)
+    let window_id = usage.five_hour.as_ref().map(|w| w.resets_at.clone()).unwrap_or_default();
+
+    let thresholds: Vec<u32> = [50, 80, 90]
+        .iter()
+        .filter(|&&t| utilization >= t as f64)
+        .copied()
+        .collect();
+
+    let mut state_guard = match ALERT_STATE.lock() {
+        Ok(g) => g,
+        Err(_) => return,
+    };
+
+    let state = state_guard.get_or_insert_with(|| AlertState {
+        window_id: window_id.clone(),
+        fired_thresholds: Vec::new(),
+        last_notification_at: None,
+    });
+
+    // Reset if window changed
+    if state.window_id != window_id {
+        state.window_id = window_id;
+        state.fired_thresholds.clear();
+    }
+
+    let new_thresholds: Vec<u32> = thresholds
+        .iter()
+        .filter(|t| !state.fired_thresholds.contains(t))
+        .copied()
+        .collect();
+
+    if new_thresholds.is_empty() {
+        return;
+    }
+
+    // Cooldown: at least 60 seconds between notifications
+    if let Some(last) = state.last_notification_at {
+        if last.elapsed().as_secs() < 60 {
+            return;
+        }
+    }
+
+    // Record thresholds only after cooldown check passes
+    for t in &new_thresholds {
+        if !state.fired_thresholds.contains(t) {
+            state.fired_thresholds.push(*t);
+        }
+    }
+
+    let highest = new_thresholds.iter().copied().max().unwrap_or(50);
+    let title = "AI Token Monitor";
+    let body = match highest {
+        90 => format!("Session usage at {:.0}% — may be throttled soon", utilization),
+        80 => format!("Session usage at {:.0}%", utilization),
+        _ => format!("Session usage at {:.0}%", utilization),
+    };
+
+    use tauri_plugin_notification::NotificationExt;
+    let _ = app_handle.notification().builder()
+        .title(title)
+        .body(&body)
+        .show();
+
+    state.last_notification_at = Some(Instant::now());
+}
 
 fn get_config_dirs_from_prefs() -> Vec<PathBuf> {
     let prefs_path = dirs::home_dir()
@@ -289,7 +385,8 @@ pub fn run() {
             quit_app,
             commands::capture_window,
             commands::copy_png_to_clipboard,
-            commands::get_pricing_table
+            commands::get_pricing_table,
+            commands::get_oauth_usage
         ])
         .setup(|app| {
             // Build tray icon
@@ -408,6 +505,26 @@ pub fn run() {
 
             // Start file watcher
             start_file_watcher(app.handle().clone());
+
+            // Start OAuth usage polling (5-minute interval)
+            {
+                let handle = app.handle().clone();
+                thread::spawn(move || {
+                    let rt = tauri::async_runtime::handle();
+                    loop {
+                        // Always fetch to keep cache fresh for UI
+                        if let Some(_) = rt.block_on(oauth_usage::fetch_and_cache_usage()) {
+                            let _ = handle.emit("usage-updated", ());
+                            // Only fire OS notifications if alerts are enabled
+                            let prefs = commands::get_preferences();
+                            if prefs.usage_alerts_enabled {
+                                check_and_fire_alerts(&handle);
+                            }
+                        }
+                        thread::sleep(std::time::Duration::from_secs(300));
+                    }
+                });
+            }
 
             Ok(())
         })

--- a/src-tauri/src/oauth_usage.rs
+++ b/src-tauri/src/oauth_usage.rs
@@ -1,0 +1,256 @@
+use std::sync::Mutex;
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageWindow {
+    pub utilization: f64,
+    pub resets_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtraUsage {
+    pub is_enabled: bool,
+    pub monthly_limit: f64,
+    pub used_credits: f64,
+    pub utilization: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OAuthUsage {
+    pub five_hour: Option<UsageWindow>,
+    pub seven_day: Option<UsageWindow>,
+    pub seven_day_sonnet: Option<UsageWindow>,
+    pub seven_day_opus: Option<UsageWindow>,
+    pub extra_usage: Option<ExtraUsage>,
+    pub fetched_at: String,
+    pub is_stale: bool,
+}
+
+struct CacheEntry {
+    usage: OAuthUsage,
+    fetched_at: Instant,
+}
+
+static OAUTH_CACHE: Mutex<Option<CacheEntry>> = Mutex::new(None);
+
+/// Return cached OAuth usage data without fetching.
+pub fn get_cached_usage() -> Option<OAuthUsage> {
+    let cache = OAUTH_CACHE.lock().ok()?;
+    cache.as_ref().map(|entry| {
+        let mut usage = entry.usage.clone();
+        // Mark as stale if older than 10 minutes
+        if entry.fetched_at.elapsed().as_secs() > 600 {
+            usage.is_stale = true;
+        }
+        usage
+    })
+}
+
+/// Fetch usage from OAuth API and update cache. Returns the usage data.
+pub async fn fetch_and_cache_usage() -> Option<OAuthUsage> {
+    let token = read_oauth_token()?;
+
+    match fetch_usage_from_api(&token).await {
+        Ok(mut usage) => {
+            usage.is_stale = false;
+            usage.fetched_at = chrono::Local::now().to_rfc3339();
+            if let Ok(mut cache) = OAUTH_CACHE.lock() {
+                *cache = Some(CacheEntry {
+                    usage: usage.clone(),
+                    fetched_at: Instant::now(),
+                });
+            }
+            Some(usage)
+        }
+        Err(e) => {
+            eprintln!("[OAUTH] fetch failed: {}", e);
+            // Return stale cache on error
+            get_cached_usage().map(|mut u| {
+                u.is_stale = true;
+                u
+            })
+        }
+    }
+}
+
+/// Read OAuth access token from macOS Keychain.
+fn read_oauth_token() -> Option<String> {
+    #[cfg(target_os = "macos")]
+    {
+        read_oauth_token_macos()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        read_oauth_token_file()
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn read_oauth_token_macos() -> Option<String> {
+    // Try Keychain first, then fall back to .credentials.json file
+    read_oauth_token_keychain().or_else(read_oauth_token_file)
+}
+
+#[cfg(target_os = "macos")]
+fn read_oauth_token_keychain() -> Option<String> {
+    use security_framework::passwords::get_generic_password;
+
+    let account = whoami::username();
+
+    // Claude Code v2.1.52+ uses "Claude Code-credentials-{hash}" service name.
+    // Try the new hashed format first, then fall back to the old format.
+    let service_names = find_keychain_service_names();
+
+    for service in &service_names {
+        if let Ok(password) = get_generic_password(service, &account) {
+            if let Some(token) = extract_token_from_keychain_data(&password) {
+                return Some(token);
+            }
+        }
+    }
+    None
+}
+
+/// Find Keychain service names matching "Claude Code-credentials*"
+#[cfg(target_os = "macos")]
+fn find_keychain_service_names() -> Vec<String> {
+    use std::process::Command;
+
+    let mut names = Vec::new();
+
+    // Use `security find-generic-password` to discover entries.
+    // First try prefix-based discovery via `security dump-keychain` grep.
+    if let Ok(output) = Command::new("security")
+        .args(["dump-keychain"])
+        .output()
+    {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout.lines() {
+            // Look for: "svce"<blob>="Claude Code-credentials..."
+            if let Some(start) = line.find("\"Claude Code-credentials") {
+                let rest = &line[start + 1..]; // skip opening quote
+                if let Some(end) = rest.find('"') {
+                    let service = &rest[..end];
+                    if !names.contains(&service.to_string()) {
+                        names.push(service.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    // Always include the legacy name as fallback
+    let legacy = "Claude Code-credentials".to_string();
+    if !names.contains(&legacy) {
+        names.push(legacy);
+    }
+
+    names
+}
+
+#[cfg(target_os = "macos")]
+fn extract_token_from_keychain_data(data: &[u8]) -> Option<String> {
+    let json_str = String::from_utf8_lossy(data);
+    // Claude Code may prepend a non-JSON byte
+    let json_str = json_str.trim_start_matches(|c: char| !c.is_ascii() || c == '\x07');
+    let value: serde_json::Value = serde_json::from_str(json_str).ok()?;
+    value
+        .get("claudeAiOauth")?
+        .get("accessToken")?
+        .as_str()
+        .map(|s| s.to_string())
+}
+
+fn read_oauth_token_file() -> Option<String> {
+    // Read from ~/.claude/.credentials.json (Windows, Linux, and macOS fallback)
+    let config_dir = std::env::var("CLAUDE_CONFIG_DIR")
+        .ok()
+        .map(std::path::PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|h| h.join(".claude")))?;
+    let path = config_dir.join(".credentials.json");
+    let content = std::fs::read_to_string(&path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&content).ok()?;
+    value
+        .get("claudeAiOauth")?
+        .get("accessToken")?
+        .as_str()
+        .map(|s| s.to_string())
+}
+
+/// Raw API response structure
+#[derive(Debug, Deserialize)]
+struct ApiResponse {
+    five_hour: Option<ApiUsageWindow>,
+    seven_day: Option<ApiUsageWindow>,
+    seven_day_sonnet: Option<ApiUsageWindow>,
+    seven_day_opus: Option<ApiUsageWindow>,
+    extra_usage: Option<ApiExtraUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiUsageWindow {
+    utilization: f64,
+    resets_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiExtraUsage {
+    is_enabled: bool,
+    monthly_limit: f64,
+    used_credits: f64,
+    utilization: f64,
+}
+
+async fn fetch_usage_from_api(token: &str) -> Result<OAuthUsage, String> {
+    let client = reqwest::Client::new();
+    let response = client
+        .get("https://api.anthropic.com/api/oauth/usage")
+        .header("Authorization", format!("Bearer {}", token))
+        .header("anthropic-beta", "oauth-2025-04-20")
+        .header("Content-Type", "application/json")
+        .send()
+        .await
+        .map_err(|e| format!("HTTP request failed: {}", e))?;
+
+    let status = response.status();
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        return Err("Rate limited (429)".to_string());
+    }
+    if !status.is_success() {
+        return Err(format!("HTTP {}", status));
+    }
+
+    let api: ApiResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("JSON parse failed: {}", e))?;
+
+    Ok(OAuthUsage {
+        five_hour: api.five_hour.map(|w| UsageWindow {
+            utilization: w.utilization,
+            resets_at: w.resets_at,
+        }),
+        seven_day: api.seven_day.map(|w| UsageWindow {
+            utilization: w.utilization,
+            resets_at: w.resets_at,
+        }),
+        seven_day_sonnet: api.seven_day_sonnet.map(|w| UsageWindow {
+            utilization: w.utilization,
+            resets_at: w.resets_at,
+        }),
+        seven_day_opus: api.seven_day_opus.map(|w| UsageWindow {
+            utilization: w.utilization,
+            resets_at: w.resets_at,
+        }),
+        extra_usage: api.extra_usage.map(|e| ExtraUsage {
+            is_enabled: e.is_enabled,
+            monthly_limit: e.monthly_limit,
+            used_credits: e.used_credits,
+            utilization: e.utilization,
+        }),
+        fetched_at: String::new(),
+        is_stale: false,
+    })
+}

--- a/src-tauri/src/providers/claude_code.rs
+++ b/src-tauri/src/providers/claude_code.rs
@@ -350,6 +350,7 @@ impl ClaudeCodeProvider {
 #[derive(Clone)]
 struct SessionEntry {
     date: String,
+    timestamp: String,
     model: String,
     session_id: String,
     message_id: String,
@@ -407,7 +408,7 @@ fn parse_session_line(line: &str) -> Option<SessionEntry> {
     let cache_creation_input_tokens = usage.get("cache_creation_input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
 
     Some(SessionEntry {
-        date, model, session_id, message_id, request_id,
+        date, timestamp: timestamp.to_string(), model, session_id, message_id, request_id,
         input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens,
     })
 }

--- a/src-tauri/src/providers/types.rs
+++ b/src-tauri/src/providers/types.rs
@@ -52,6 +52,8 @@ pub struct UserPreferences {
     pub include_codex: bool,
     #[serde(default)]
     pub monthly_salary: Option<f64>,
+    #[serde(default = "default_true")]
+    pub usage_alerts_enabled: bool,
 }
 
 fn default_theme() -> String {
@@ -87,6 +89,7 @@ impl Default for UserPreferences {
             include_claude: true,
             include_codex: false,
             monthly_salary: None,
+            usage_alerts_enabled: true,
         }
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { ActivityGraph } from "./components/ActivityGraph";
 import { SupportBanner } from "./components/SupportBanner";
 import { SourceSelector } from "./components/SourceSelector";
 import { SalaryComparator } from "./components/SalaryComparator";
+import { UsageAlertBar } from "./components/UsageAlertBar";
 import { useUpdater } from "./hooks/useUpdater";
 
 function AppContent() {
@@ -112,6 +113,7 @@ function AppContent() {
       {/* Keep mounted tabs alive to avoid remount/recalculation on switch */}
       <div style={{ display: activeTab === "overview" ? "contents" : "none" }}>
         <TodaySummary today={today} weekAvg={weekAvg} />
+        <UsageAlertBar />
         <SalaryComparator stats={stats} />
         <DailyChart daily={stats.daily} days={7} />
         <PeriodTotals daily={stats.daily} />

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useAuth } from "../hooks/useAuth";
 import { useLeaderboardSync } from "../hooks/useLeaderboardSync";
 import { useTokenStats } from "../hooks/useTokenStats";
@@ -187,6 +187,8 @@ function LeaderboardContent({ user }: { user: User }) {
   );
 }
 
+const PAGE_SIZE = 20;
+
 function ProviderLeaderboard({
   provider,
   user,
@@ -203,7 +205,26 @@ function ProviderLeaderboard({
     provider,
   });
 
+  const [page, setPage] = useState(0);
+  const totalPages = Math.max(1, Math.ceil(leaderboard.length / PAGE_SIZE));
   const myRank = leaderboard.findIndex((e) => e.user_id === user.id) + 1;
+
+  // Reset to page 0 when period or provider changes
+  useEffect(() => { setPage(0); }, [period, provider]);
+
+  // Clamp page if data shrinks
+  useEffect(() => {
+    if (page >= totalPages) setPage(Math.max(0, totalPages - 1));
+  }, [totalPages, page]);
+
+  const pageEntries = useMemo(
+    () => leaderboard.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE),
+    [leaderboard, page],
+  );
+
+  const goToMyPage = () => {
+    if (myRank > 0) setPage(Math.floor((myRank - 1) / PAGE_SIZE));
+  };
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
@@ -238,16 +259,20 @@ function ProviderLeaderboard({
 
       {/* My rank card */}
       {myRank > 0 && (
-        <div style={{
-          background: "linear-gradient(135deg, rgba(124,92,252,0.08), rgba(255,143,164,0.08))",
-          borderRadius: "var(--radius-lg)",
-          padding: "12px 16px",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          gap: 6,
-          border: "1px solid rgba(124, 92, 252, 0.1)",
-        }}>
+        <div
+          onClick={goToMyPage}
+          style={{
+            background: "linear-gradient(135deg, rgba(124,92,252,0.08), rgba(255,143,164,0.08))",
+            borderRadius: "var(--radius-lg)",
+            padding: "12px 16px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 6,
+            border: "1px solid rgba(124, 92, 252, 0.1)",
+            cursor: "pointer",
+          }}
+        >
           <span style={{ fontSize: 11, color: "var(--text-secondary)", fontWeight: 600 }}>
             {t("leaderboard.yourRank")}
           </span>
@@ -288,16 +313,101 @@ function ProviderLeaderboard({
             {t("leaderboard.noData")}
           </div>
         ) : (
-          leaderboard.map((entry, i) => (
+          pageEntries.map((entry, i) => (
             <LeaderboardRow
               key={entry.user_id}
               entry={entry}
-              rank={i + 1}
+              rank={page * PAGE_SIZE + i + 1}
               isMe={entry.user_id === user.id}
             />
           ))
         )}
       </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
+      )}
+    </div>
+  );
+}
+
+function Pagination({
+  page,
+  totalPages,
+  onPageChange,
+}: {
+  page: number;
+  totalPages: number;
+  onPageChange: (p: number) => void;
+}) {
+  const pages = useMemo(() => {
+    const items: (number | "...")[] = [];
+    if (totalPages <= 7) {
+      for (let i = 0; i < totalPages; i++) items.push(i);
+    } else {
+      items.push(0);
+      if (page > 2) items.push("...");
+      for (let i = Math.max(1, page - 1); i <= Math.min(totalPages - 2, page + 1); i++) {
+        items.push(i);
+      }
+      if (page < totalPages - 3) items.push("...");
+      items.push(totalPages - 1);
+    }
+    return items;
+  }, [page, totalPages]);
+
+  const btnBase: React.CSSProperties = {
+    fontSize: 11,
+    fontWeight: 600,
+    border: "none",
+    borderRadius: 4,
+    cursor: "pointer",
+    background: "transparent",
+    color: "var(--text-secondary)",
+    padding: "4px 8px",
+    minWidth: 28,
+    transition: "all 0.15s ease",
+  };
+
+  return (
+    <div style={{
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 2,
+    }}>
+      <button
+        onClick={() => onPageChange(Math.max(0, page - 1))}
+        disabled={page === 0}
+        style={{ ...btnBase, opacity: page === 0 ? 0.3 : 1, cursor: page === 0 ? "default" : "pointer" }}
+      >
+        ‹
+      </button>
+      {pages.map((p, i) =>
+        p === "..." ? (
+          <span key={`dots-${i}`} style={{ ...btnBase, cursor: "default" }}>…</span>
+        ) : (
+          <button
+            key={p}
+            onClick={() => onPageChange(p)}
+            style={{
+              ...btnBase,
+              background: p === page ? "var(--accent-purple)" : "transparent",
+              color: p === page ? "#fff" : "var(--text-secondary)",
+            }}
+          >
+            {p + 1}
+          </button>
+        ),
+      )}
+      <button
+        onClick={() => onPageChange(Math.min(totalPages - 1, page + 1))}
+        disabled={page === totalPages - 1}
+        style={{ ...btnBase, opacity: page === totalPages - 1 ? 0.3 : 1, cursor: page === totalPages - 1 ? "default" : "pointer" }}
+      >
+        ›
+      </button>
     </div>
   );
 }

--- a/src/components/UsageAlertBar.tsx
+++ b/src/components/UsageAlertBar.tsx
@@ -1,0 +1,144 @@
+import { useOAuthUsage } from "../hooks/useOAuthUsage";
+import { useI18n } from "../i18n/I18nContext";
+
+function getBarColor(percent: number): string {
+  if (percent >= 90) return "#ef4444";
+  if (percent >= 80) return "#f97316";
+  if (percent >= 50) return "#eab308";
+  return "#22c55e";
+}
+
+function formatResetTime(resetsAt: string, t: (key: string, params?: Record<string, string>) => string): string {
+  const reset = new Date(resetsAt);
+  const now = new Date();
+  const diffMs = reset.getTime() - now.getTime();
+  if (diffMs <= 0) return t("usageAlert.resetsNow");
+  const totalMin = Math.floor(diffMs / 60000);
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  if (h > 0) return t("usageAlert.resetsIn", { time: `${h}h ${m}m` });
+  return t("usageAlert.resetsIn", { time: `${m}m` });
+}
+
+function UsageRow({
+  label,
+  utilization,
+  subtitle,
+}: {
+  label: string;
+  utilization: number;
+  subtitle: string;
+}) {
+  const pct = Math.min(utilization, 100);
+  const color = getBarColor(utilization);
+
+  return (
+    <div style={{ marginBottom: 8 }}>
+      <div style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        marginBottom: 3,
+      }}>
+        <span style={{ fontSize: 10, fontWeight: 600, color: "var(--text-primary)" }}>
+          {label}
+        </span>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <span style={{ fontSize: 10, color: "var(--text-muted)" }}>
+            {subtitle}
+          </span>
+          <span style={{ fontSize: 11, fontWeight: 700, color }}>
+            {utilization.toFixed(1)}%
+          </span>
+        </div>
+      </div>
+      <div style={{
+        width: "100%",
+        height: 5,
+        borderRadius: 3,
+        background: "var(--heat-0)",
+        overflow: "hidden",
+      }}>
+        <div style={{
+          width: `${pct}%`,
+          height: "100%",
+          borderRadius: 3,
+          background: color,
+          transition: "width 0.3s ease, background 0.3s ease",
+        }} />
+      </div>
+    </div>
+  );
+}
+
+export function UsageAlertBar() {
+  const { usage } = useOAuthUsage();
+  const t = useI18n();
+
+  if (!usage) return null;
+
+  const { five_hour, seven_day, extra_usage, is_stale } = usage;
+
+  // Don't render if no data at all
+  if (!five_hour && !seven_day && !extra_usage) return null;
+
+  return (
+    <div style={{
+      background: "var(--bg-card)",
+      borderRadius: "var(--radius-lg)",
+      padding: "12px 16px",
+    }}>
+      {/* Header */}
+      <div style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        marginBottom: 8,
+      }}>
+        <span style={{
+          fontSize: 11,
+          fontWeight: 700,
+          color: "var(--text-primary)",
+        }}>
+          {t("usageAlert.title")}
+        </span>
+        {is_stale && (
+          <span style={{
+            fontSize: 9,
+            fontWeight: 600,
+            color: "var(--text-muted)",
+          }}>
+            {t("usageAlert.stale")}
+          </span>
+        )}
+      </div>
+
+      {/* Session (5h) */}
+      {five_hour && (
+        <UsageRow
+          label={t("usageAlert.session")}
+          utilization={five_hour.utilization}
+          subtitle={formatResetTime(five_hour.resets_at, t)}
+        />
+      )}
+
+      {/* Weekly (7d) */}
+      {seven_day && (
+        <UsageRow
+          label={t("usageAlert.weekly")}
+          utilization={seven_day.utilization}
+          subtitle={formatResetTime(seven_day.resets_at, t)}
+        />
+      )}
+
+      {/* Extra usage */}
+      {extra_usage && extra_usage.is_enabled && (
+        <UsageRow
+          label={t("usageAlert.extraUsage")}
+          utilization={extra_usage.utilization}
+          subtitle={`$${extra_usage.used_credits.toFixed(0)} / $${extra_usage.monthly_limit.toFixed(0)}`}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -20,6 +20,7 @@ const defaultPrefs: UserPreferences = {
   color_mode: "system",
   language: "en",
   config_dirs: ["~/.claude"],
+  usage_alerts_enabled: true,
 };
 
 const SettingsContext = createContext<SettingsContextType>({

--- a/src/hooks/useOAuthUsage.ts
+++ b/src/hooks/useOAuthUsage.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState, useCallback, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type { OAuthUsage } from "../lib/types";
+
+export function useOAuthUsage() {
+  const [usage, setUsage] = useState<OAuthUsage | null>(null);
+  const [loading, setLoading] = useState(true);
+  const requestIdRef = useRef(0);
+
+  const fetchUsage = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+    try {
+      const data = await invoke<OAuthUsage | null>("get_oauth_usage");
+      if (requestId !== requestIdRef.current) return;
+      setUsage(data);
+    } catch {
+      // Ignore errors silently
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchUsage();
+
+    // Listen for backend polling updates
+    const unlisten = listen("usage-updated", () => {
+      fetchUsage();
+    }).catch(() => null);
+
+    return () => {
+      unlisten.then((fn) => fn?.());
+    };
+  }, [fetchUsage]);
+
+  return { usage, loading };
+}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -187,5 +187,15 @@
   "update.downloading": "Herunterladen... {{progress}}%",
   "update.restart": "Update bereit",
   "update.restartBtn": "Neustarten",
-  "update.error": "Update fehlgeschlagen"
+  "update.error": "Update fehlgeschlagen",
+
+  "settings.usageAlerts": "Nutzungswarnungen",
+
+  "usageAlert.title": "Nutzung",
+  "usageAlert.session": "Sitzung (5h)",
+  "usageAlert.weekly": "Wöchentlich",
+  "usageAlert.extraUsage": "Zusätzliche Nutzung",
+  "usageAlert.stale": "Aktualisierung...",
+  "usageAlert.resetsIn": "Zurücksetzen in {{time}}",
+  "usageAlert.resetsNow": "Wird zurückgesetzt..."
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -187,5 +187,15 @@
   "update.downloading": "Downloading... {{progress}}%",
   "update.restart": "Ready to update",
   "update.restartBtn": "Restart",
-  "update.error": "Update failed"
+  "update.error": "Update failed",
+
+  "settings.usageAlerts": "Usage Alerts",
+
+  "usageAlert.title": "Usage",
+  "usageAlert.session": "Session (5h)",
+  "usageAlert.weekly": "Weekly",
+  "usageAlert.extraUsage": "Extra Usage",
+  "usageAlert.stale": "Updating...",
+  "usageAlert.resetsIn": "Resets in {{time}}",
+  "usageAlert.resetsNow": "Resetting..."
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -187,5 +187,15 @@
   "update.downloading": "Descargando... {{progress}}%",
   "update.restart": "Listo para actualizar",
   "update.restartBtn": "Reiniciar",
-  "update.error": "Error de actualización"
+  "update.error": "Error de actualización",
+
+  "settings.usageAlerts": "Alertas de uso",
+
+  "usageAlert.title": "Uso",
+  "usageAlert.session": "Sesión (5h)",
+  "usageAlert.weekly": "Semanal",
+  "usageAlert.extraUsage": "Uso adicional",
+  "usageAlert.stale": "Actualizando...",
+  "usageAlert.resetsIn": "Se reinicia en {{time}}",
+  "usageAlert.resetsNow": "Reiniciando..."
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -187,5 +187,15 @@
   "update.downloading": "Téléchargement... {{progress}}%",
   "update.restart": "Prêt à mettre à jour",
   "update.restartBtn": "Redémarrer",
-  "update.error": "Échec de la mise à jour"
+  "update.error": "Échec de la mise à jour",
+
+  "settings.usageAlerts": "Alertes d'utilisation",
+
+  "usageAlert.title": "Utilisation",
+  "usageAlert.session": "Session (5h)",
+  "usageAlert.weekly": "Hebdomadaire",
+  "usageAlert.extraUsage": "Utilisation supplémentaire",
+  "usageAlert.stale": "Mise à jour...",
+  "usageAlert.resetsIn": "Réinitialisation dans {{time}}",
+  "usageAlert.resetsNow": "Réinitialisation..."
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -187,5 +187,15 @@
   "update.downloading": "ダウンロード中... {{progress}}%",
   "update.restart": "更新の準備完了",
   "update.restartBtn": "再起動",
-  "update.error": "更新に失敗しました"
+  "update.error": "更新に失敗しました",
+
+  "settings.usageAlerts": "使用量アラート",
+
+  "usageAlert.title": "使用量",
+  "usageAlert.session": "セッション (5時間)",
+  "usageAlert.weekly": "週間",
+  "usageAlert.extraUsage": "追加使用量",
+  "usageAlert.stale": "更新中...",
+  "usageAlert.resetsIn": "{{time}}後にリセット",
+  "usageAlert.resetsNow": "リセット中..."
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -187,5 +187,15 @@
   "update.downloading": "다운로드 중... {{progress}}%",
   "update.restart": "업데이트 준비 완료",
   "update.restartBtn": "재시작",
-  "update.error": "업데이트 실패"
+  "update.error": "업데이트 실패",
+
+  "settings.usageAlerts": "사용량 알림",
+
+  "usageAlert.title": "사용량",
+  "usageAlert.session": "세션 (5시간)",
+  "usageAlert.weekly": "주간",
+  "usageAlert.extraUsage": "추가 사용량",
+  "usageAlert.stale": "업데이트 중...",
+  "usageAlert.resetsIn": "{{time}} 후 리셋",
+  "usageAlert.resetsNow": "리셋 중..."
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -187,5 +187,15 @@
   "update.downloading": "下载中... {{progress}}%",
   "update.restart": "更新已就绪",
   "update.restartBtn": "重启",
-  "update.error": "更新失败"
+  "update.error": "更新失败",
+
+  "settings.usageAlerts": "用量提醒",
+
+  "usageAlert.title": "用量",
+  "usageAlert.session": "会话 (5小时)",
+  "usageAlert.weekly": "每周",
+  "usageAlert.extraUsage": "额外用量",
+  "usageAlert.stale": "更新中...",
+  "usageAlert.resetsIn": "{{time}}后重置",
+  "usageAlert.resetsNow": "重置中..."
 }

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -187,5 +187,15 @@
   "update.downloading": "下載中... {{progress}}%",
   "update.restart": "更新已就緒",
   "update.restartBtn": "重啟",
-  "update.error": "更新失敗"
+  "update.error": "更新失敗",
+
+  "settings.usageAlerts": "用量提醒",
+
+  "usageAlert.title": "用量",
+  "usageAlert.session": "工作階段 (5小時)",
+  "usageAlert.weekly": "每週",
+  "usageAlert.extraUsage": "額外用量",
+  "usageAlert.stale": "更新中...",
+  "usageAlert.resetsIn": "{{time}}後重置",
+  "usageAlert.resetsNow": "重置中..."
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,4 +40,27 @@ export interface UserPreferences {
   language: "en" | "ko" | "ja" | "zh-CN" | "zh-TW" | "fr" | "es" | "de";
   config_dirs: string[];
   monthly_salary?: number;
+  usage_alerts_enabled: boolean;
+}
+
+export interface UsageWindow {
+  utilization: number;
+  resets_at: string;
+}
+
+export interface ExtraUsage {
+  is_enabled: boolean;
+  monthly_limit: number;
+  used_credits: number;
+  utilization: number;
+}
+
+export interface OAuthUsage {
+  five_hour: UsageWindow | null;
+  seven_day: UsageWindow | null;
+  seven_day_sonnet: UsageWindow | null;
+  seven_day_opus: UsageWindow | null;
+  extra_usage: ExtraUsage | null;
+  fetched_at: string;
+  is_stale: boolean;
 }


### PR DESCRIPTION
## Summary
- JSONL 기반 토큰 합산 방식에서 OAuth `/api/oauth/usage` API 직접 호출로 전환 (기존 방식은 Anthropic 실제 사용률 대비 ~10배 오차 발생)
- 5분 간격 백그라운드 폴링으로 정확한 실시간 사용률 표시 (세션 5h, 주간 7d, 추가 사용량)
- 50%/80%/90% 임계값 초과 시 OS 네이티브 알림 발송
- macOS Keychain (v2.1.52+ 해시 서비스명 prefix 검색 지원) + Windows/Linux 파일 기반 credential 읽기
- `claude_plan` 설정 제거 (OAuth가 실제 사용률을 직접 제공)

## Changes
| File | Change |
|------|--------|
| `src-tauri/src/oauth_usage.rs` | **New** — OAuth 모듈 (Keychain/파일 토큰 읽기, API 호출, 캐시) |
| `src-tauri/src/lib.rs` | 5분 폴링 스레드, OAuth 기반 check_and_fire_alerts |
| `src-tauri/src/commands.rs` | `get_window_usage` → `get_oauth_usage` |
| `src/components/UsageAlertBar.tsx` | **New** — 다중 프로그레스바 (세션/주간/추가사용량) |
| `src/hooks/useOAuthUsage.ts` | **New** — `usage-updated` 이벤트 기반 훅 |
| `src/lib/types.ts` | `OAuthUsage`/`UsageWindow`/`ExtraUsage` 타입 |
| `src/i18n/locales/*.json` (8개) | `claudePlan*` 키 제거, OAuth 관련 키 추가 |

## Test plan
- [x] macOS에서 OAuth 데이터가 UsageAlertBar에 정상 표시 확인
- [ ] Windows에서 `.credentials.json` 기반 토큰 읽기 동작 확인
- [ ] 5분 후 자동 갱신 (usage-updated 이벤트) 확인
- [ ] Settings에서 Usage Alerts 토글 on/off 동작 확인
- [ ] Keychain 없는 환경에서 프로그레스바가 숨겨지는지 확인
- [ ] 임계값 초과 시 OS 알림 발송 확인

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)