### PR TITLE
feat: add real-time community chat for leaderboard participants

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { ModelBreakdown } from "./components/ModelBreakdown";
 import { PeriodTotals } from "./components/PeriodTotals";
 import { CacheEfficiency } from "./components/CacheEfficiency";
 import { Leaderboard } from "./components/Leaderboard";
+import { ChatRoom } from "./components/ChatRoom";
 import { ActivityGraph } from "./components/ActivityGraph";
 import { SupportBanner } from "./components/SupportBanner";
 import { SourceSelector } from "./components/SourceSelector";
@@ -131,6 +132,11 @@ function AppContent() {
       {/* Leaderboard lazy-loads (network requests), keep conditional */}
       {activeTab === "leaderboard" && (
         <Leaderboard />
+      )}
+
+      {/* Chat lazy-loads (realtime subscription), keep conditional */}
+      {activeTab === "chat" && (
+        <ChatRoom />
       )}
 
       <SupportBanner />

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -1,0 +1,201 @@
+import { useState } from "react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import type { ChatMessage as ChatMessageData } from "../hooks/useChat";
+import { useI18n } from "../i18n/I18nContext";
+
+interface Props {
+  message: ChatMessageData;
+  isMe: boolean;
+  showAvatar: boolean;  // false when same user sends consecutive messages
+  showNickname: boolean;
+  onDelete?: (id: string) => void;
+}
+
+function formatTime(dateStr: string): string {
+  const d = new Date(dateStr);
+  const h = d.getHours();
+  const m = d.getMinutes().toString().padStart(2, "0");
+  const ampm = h < 12 ? "AM" : "PM";
+  const h12 = h === 0 ? 12 : h > 12 ? h - 12 : h;
+  return `${ampm} ${h12}:${m}`;
+}
+
+export function formatDateSeparator(dateStr: string, locale: string): string {
+  const d = new Date(dateStr);
+  if (locale.startsWith("ko")) {
+    return `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일`;
+  }
+  if (locale.startsWith("ja")) {
+    return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`;
+  }
+  if (locale.startsWith("zh")) {
+    return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`;
+  }
+  return d.toLocaleDateString(locale, { year: "numeric", month: "long", day: "numeric" });
+}
+
+export function ChatMessageRow({ message, isMe, showAvatar, showNickname, onDelete }: Props) {
+  const [hovered, setHovered] = useState(false);
+  const t = useI18n();
+
+  if (isMe) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+          alignItems: "flex-end",
+          gap: 4,
+          marginTop: showNickname ? 12 : 3,
+          paddingRight: 8,
+          paddingLeft: 40,
+        }}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      >
+        {/* Delete button + time on left */}
+        <div style={{ display: "flex", alignItems: "flex-end", gap: 4, flexShrink: 0 }}>
+          {hovered && onDelete && (
+            <button
+              onClick={() => onDelete(message.id)}
+              title={t("chat.delete")}
+              style={{
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                padding: 2,
+                color: "var(--text-muted)",
+                fontSize: 10,
+                opacity: 0.6,
+                lineHeight: 1,
+              }}
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="3 6 5 6 21 6"/>
+                <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
+              </svg>
+            </button>
+          )}
+          <span style={{ fontSize: 9, color: "var(--text-muted)", fontWeight: 500, whiteSpace: "nowrap" }}>
+            {formatTime(message.created_at)}
+          </span>
+        </div>
+
+        {/* Bubble */}
+        <div style={{
+          background: "linear-gradient(135deg, var(--accent-purple), var(--accent-pink, #c084fc))",
+          color: "#fff",
+          padding: "8px 12px",
+          borderRadius: "12px 12px 2px 12px",
+          fontSize: 12,
+          fontWeight: 500,
+          lineHeight: 1.5,
+          maxWidth: "75%",
+          wordBreak: "break-word",
+          whiteSpace: "pre-wrap",
+        }}>
+          {message.content}
+        </div>
+      </div>
+    );
+  }
+
+  // Other user's message (left-aligned)
+  return (
+    <div style={{ marginTop: showNickname ? 12 : 3, paddingLeft: 8, paddingRight: 40 }}>
+      <div style={{ display: "flex", alignItems: "flex-start", gap: 8 }}>
+        {/* Avatar column (fixed width for alignment) */}
+        <div style={{ width: 32, flexShrink: 0 }}>
+          {showAvatar ? (
+            message.avatar_url ? (
+              <img
+                src={message.avatar_url}
+                alt=""
+                style={{ width: 32, height: 32, borderRadius: 10, cursor: "pointer" }}
+                onClick={() => openUrl(`https://github.com/${message.nickname}`)}
+              />
+            ) : (
+              <div
+                onClick={() => openUrl(`https://github.com/${message.nickname}`)}
+                style={{
+                  width: 32,
+                  height: 32,
+                  borderRadius: 10,
+                  background: "var(--heat-1)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: 13,
+                  fontWeight: 700,
+                  color: "var(--accent-purple)",
+                  cursor: "pointer",
+                }}
+              >
+                {message.nickname.charAt(0).toUpperCase()}
+              </div>
+            )
+          ) : null}
+        </div>
+
+        {/* Content column */}
+        <div style={{ flex: 1, minWidth: 0 }}>
+          {showNickname && (
+            <div
+              onClick={() => openUrl(`https://github.com/${message.nickname}`)}
+              style={{
+                fontSize: 11,
+                fontWeight: 700,
+                color: "var(--text-secondary)",
+                marginBottom: 4,
+                cursor: "pointer",
+              }}
+            >
+              {message.nickname}
+            </div>
+          )}
+
+          <div style={{ display: "flex", alignItems: "flex-end", gap: 4 }}>
+            {/* Bubble */}
+            <div style={{
+              background: "var(--bg-card)",
+              color: "var(--text-primary)",
+              padding: "8px 12px",
+              borderRadius: showNickname ? "2px 12px 12px 12px" : "12px 12px 12px 12px",
+              fontSize: 12,
+              fontWeight: 500,
+              lineHeight: 1.5,
+              maxWidth: "75%",
+              wordBreak: "break-word",
+              whiteSpace: "pre-wrap",
+              boxShadow: "0 1px 2px rgba(0,0,0,0.05)",
+            }}>
+              {message.content}
+            </div>
+
+            {/* Time */}
+            <span style={{ fontSize: 9, color: "var(--text-muted)", fontWeight: 500, whiteSpace: "nowrap", flexShrink: 0 }}>
+              {formatTime(message.created_at)}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function DateSeparator({ label }: { label: string }) {
+  return (
+    <div style={{
+      display: "flex",
+      alignItems: "center",
+      gap: 8,
+      margin: "16px 12px 8px",
+    }}>
+      <div style={{ flex: 1, height: 1, background: "var(--heat-0)" }} />
+      <span style={{ fontSize: 10, fontWeight: 600, color: "var(--text-muted)", whiteSpace: "nowrap" }}>
+        {label}
+      </span>
+      <div style={{ flex: 1, height: 1, background: "var(--heat-0)" }} />
+    </div>
+  );
+}

--- a/src/components/ChatRoom.tsx
+++ b/src/components/ChatRoom.tsx
@@ -1,0 +1,385 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import { useAuth } from "../hooks/useAuth";
+import { useSettings } from "../contexts/SettingsContext";
+import { useChat } from "../hooks/useChat";
+import { ChatMessageRow, DateSeparator, formatDateSeparator } from "./ChatMessage";
+import { useI18n } from "../i18n/I18nContext";
+import type { ChatMessage } from "../hooks/useChat";
+
+export function ChatRoom() {
+  const { user, loading: authLoading, signIn, available } = useAuth();
+  const { prefs } = useSettings();
+  const t = useI18n();
+
+  if (!available) {
+    return (
+      <div style={{
+        background: "var(--bg-card)",
+        borderRadius: "var(--radius-lg)",
+        padding: 24,
+        boxShadow: "var(--shadow-card)",
+        textAlign: "center",
+      }}>
+        <div style={{ fontSize: 32, marginBottom: 8 }}>💬</div>
+        <div style={{ fontSize: 14, fontWeight: 700, color: "var(--text-primary)", marginBottom: 4 }}>
+          {t("leaderboard.comingSoon")}
+        </div>
+        <div style={{ fontSize: 11, color: "var(--text-secondary)", fontWeight: 600 }}>
+          {t("leaderboard.notConfigured")}
+        </div>
+      </div>
+    );
+  }
+
+  if (!user || !prefs.leaderboard_opted_in) {
+    return <ChatCTA onSignIn={signIn} loading={authLoading} hasUser={!!user} />;
+  }
+
+  return <ChatContent userId={user.id} />;
+}
+
+function ChatCTA({
+  onSignIn,
+  loading,
+  hasUser,
+}: {
+  onSignIn: () => void;
+  loading: boolean;
+  hasUser: boolean;
+}) {
+  const { updatePrefs } = useSettings();
+  const t = useI18n();
+
+  return (
+    <div style={{
+      background: "var(--bg-card)",
+      borderRadius: "var(--radius-lg)",
+      padding: 24,
+      boxShadow: "var(--shadow-card)",
+      textAlign: "center",
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      gap: 12,
+    }}>
+      <div style={{ fontSize: 40 }}>💬</div>
+      <div style={{ fontSize: 16, fontWeight: 800, color: "var(--text-primary)" }}>
+        {t("chat.join")}
+      </div>
+      <div style={{
+        fontSize: 12,
+        color: "var(--text-secondary)",
+        fontWeight: 600,
+        maxWidth: 260,
+        lineHeight: 1.5,
+      }}>
+        {t("chat.description")}
+      </div>
+
+      {hasUser ? (
+        <button
+          onClick={() => updatePrefs({ leaderboard_opted_in: true })}
+          style={{
+            padding: "10px 24px",
+            fontSize: 13,
+            fontWeight: 700,
+            border: "none",
+            borderRadius: "var(--radius-sm)",
+            cursor: "pointer",
+            background: "linear-gradient(135deg, var(--accent-purple), var(--accent-pink, #c084fc))",
+            color: "#fff",
+          }}
+        >
+          {t("leaderboard.enable")}
+        </button>
+      ) : (
+        <button
+          onClick={onSignIn}
+          disabled={loading}
+          style={{
+            padding: "10px 24px",
+            fontSize: 13,
+            fontWeight: 700,
+            border: "none",
+            borderRadius: "var(--radius-sm)",
+            cursor: loading ? "wait" : "pointer",
+            background: "#24292e",
+            color: "#fff",
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            opacity: loading ? 0.7 : 1,
+          }}
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
+          </svg>
+          {t("leaderboard.signIn")}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function ChatContent({ userId }: { userId: string }) {
+  const t = useI18n();
+  const { prefs } = useSettings();
+  const { messages, loading, sending, hasMore, sendMessage, deleteMessage, loadMore } = useChat(userId);
+  const [input, setInput] = useState("");
+  const [rateLimited, setRateLimited] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const isAtBottomRef = useRef(true);
+  const prevMessagesLenRef = useRef(0);
+
+  // Auto-scroll to bottom on new messages (only if user is at bottom)
+  useEffect(() => {
+    if (messages.length > prevMessagesLenRef.current && isAtBottomRef.current) {
+      scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+    }
+    prevMessagesLenRef.current = messages.length;
+  }, [messages.length]);
+
+  // Initial scroll to bottom
+  useEffect(() => {
+    if (!loading && scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [loading]);
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    isAtBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+  }, []);
+
+  const handleSend = useCallback(async () => {
+    if (!input.trim() || sending) return;
+
+    const result = await sendMessage(input);
+    if (result.error === "rate_limited") {
+      setRateLimited(true);
+      setTimeout(() => setRateLimited(false), 3000);
+      return;
+    }
+    if (!result.error) {
+      setInput("");
+      // Scroll to bottom after sending
+      setTimeout(() => {
+        scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+      }, 100);
+    }
+  }, [input, sending, sendMessage]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  }, [handleSend]);
+
+  // Group messages for KakaoTalk-style rendering
+  const grouped = groupMessages(messages, prefs.language ?? "en");
+
+  return (
+    <div style={{
+      display: "flex",
+      flexDirection: "column",
+      background: "var(--heat-0)",
+      borderRadius: "var(--radius-lg)",
+      overflow: "hidden",
+      height: 420,
+      boxShadow: "var(--shadow-card)",
+    }}>
+      {/* Messages area */}
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        style={{
+          flex: 1,
+          overflowY: "auto",
+          paddingTop: 8,
+          paddingBottom: 8,
+        }}
+      >
+        {/* Load more button */}
+        {hasMore && !loading && (
+          <div style={{ textAlign: "center", padding: "8px 0" }}>
+            <button
+              onClick={loadMore}
+              style={{
+                background: "none",
+                border: "none",
+                color: "var(--text-secondary)",
+                fontSize: 11,
+                fontWeight: 600,
+                cursor: "pointer",
+                padding: "4px 12px",
+              }}
+            >
+              {t("chat.loadMore")}
+            </button>
+          </div>
+        )}
+
+        {loading ? (
+          <div style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            height: "100%",
+            color: "var(--text-secondary)",
+            fontSize: 12,
+            fontWeight: 600,
+          }}>
+            {t("chat.loading")}
+          </div>
+        ) : messages.length === 0 ? (
+          <div style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            height: "100%",
+            color: "var(--text-secondary)",
+            fontSize: 12,
+            fontWeight: 600,
+            gap: 8,
+          }}>
+            <div style={{ fontSize: 32 }}>💬</div>
+            {t("chat.empty")}
+          </div>
+        ) : (
+          grouped.map((item) => {
+            if (item.type === "date") {
+              return <DateSeparator key={`date-${item.label}`} label={item.label} />;
+            }
+            return (
+              <ChatMessageRow
+                key={item.message.id}
+                message={item.message}
+                isMe={item.message.user_id === userId}
+                showAvatar={item.showAvatar}
+                showNickname={item.showNickname}
+                onDelete={item.message.user_id === userId ? deleteMessage : undefined}
+              />
+            );
+          })
+        )}
+      </div>
+
+      {/* Input bar */}
+      <div style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        padding: "8px 10px",
+        borderTop: "1px solid var(--heat-1, rgba(0,0,0,0.06))",
+        background: "var(--bg-card)",
+      }}>
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value.slice(0, 500))}
+          onKeyDown={handleKeyDown}
+          placeholder={t("chat.placeholder")}
+          disabled={sending}
+          style={{
+            flex: 1,
+            padding: "8px 14px",
+            fontSize: 12,
+            fontWeight: 500,
+            border: "1px solid var(--heat-1, rgba(0,0,0,0.08))",
+            borderRadius: 18,
+            background: "var(--heat-0)",
+            color: "var(--text-primary)",
+            outline: "none",
+          }}
+        />
+
+        {/* Character count (show when > 450) */}
+        {input.length > 450 && (
+          <span style={{
+            fontSize: 9,
+            fontWeight: 600,
+            color: input.length >= 500 ? "var(--accent-pink, #ef4444)" : "var(--text-muted)",
+            flexShrink: 0,
+          }}>
+            {input.length}/500
+          </span>
+        )}
+
+        {/* Send button */}
+        <button
+          onClick={handleSend}
+          disabled={!input.trim() || sending}
+          style={{
+            width: 32,
+            height: 32,
+            borderRadius: 16,
+            border: "none",
+            cursor: input.trim() && !sending ? "pointer" : "default",
+            background: input.trim()
+              ? "linear-gradient(135deg, var(--accent-purple), var(--accent-pink, #c084fc))"
+              : "var(--heat-1)",
+            color: input.trim() ? "#fff" : "var(--text-muted)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: 0,
+            transition: "all 0.15s ease",
+          }}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"/>
+          </svg>
+        </button>
+      </div>
+
+      {/* Rate limit warning */}
+      {rateLimited && (
+        <div style={{
+          textAlign: "center",
+          padding: "4px 0",
+          fontSize: 10,
+          fontWeight: 600,
+          color: "var(--accent-pink, #ef4444)",
+          background: "var(--bg-card)",
+        }}>
+          {t("chat.rateLimited")}
+        </div>
+      )}
+    </div>
+  );
+}
+
+type GroupedItem =
+  | { type: "date"; label: string }
+  | { type: "message"; message: ChatMessage; showAvatar: boolean; showNickname: boolean };
+
+function groupMessages(messages: ChatMessage[], locale: string): GroupedItem[] {
+  const items: GroupedItem[] = [];
+  let lastDate = "";
+  let lastUserId = "";
+
+  for (const msg of messages) {
+    const msgDate = new Date(msg.created_at).toLocaleDateString();
+
+    if (msgDate !== lastDate) {
+      items.push({ type: "date", label: formatDateSeparator(msg.created_at, locale) });
+      lastDate = msgDate;
+      lastUserId = "";
+    }
+
+    const isSameUser = msg.user_id === lastUserId;
+    items.push({
+      type: "message",
+      message: msg,
+      showAvatar: !isSameUser,
+      showNickname: !isSameUser,
+    });
+
+    lastUserId = msg.user_id;
+  }
+
+  return items;
+}

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,6 +1,6 @@
 import { useI18n } from "../i18n/I18nContext";
 
-export type TabType = "overview" | "analytics" | "leaderboard";
+export type TabType = "overview" | "analytics" | "leaderboard" | "chat";
 
 interface Props {
   activeTab: TabType;
@@ -33,6 +33,12 @@ export function TabBar({ activeTab, onChange }: Props) {
         active={activeTab === "leaderboard"}
         onClick={() => onChange("leaderboard")}
         icon="🏆"
+      />
+      <TabButton
+        label={t("tab.chat")}
+        active={activeTab === "chat"}
+        onClick={() => onChange("chat")}
+        icon="💬"
       />
     </div>
   );

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1,0 +1,218 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+import { supabase } from "../lib/supabase";
+import type { RealtimeChannel } from "@supabase/supabase-js";
+
+export interface ChatMessage {
+  id: string;
+  user_id: string;
+  content: string;
+  created_at: string;
+  nickname: string;
+  avatar_url: string | null;
+}
+
+interface ProfileCache {
+  nickname: string;
+  avatar_url: string | null;
+}
+
+const PAGE_SIZE = 50;
+const COOLDOWN_MS = 2000;
+
+export function useChat(userId: string | null) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [sending, setSending] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const profileCache = useRef<Map<string, ProfileCache>>(new Map());
+  const channelRef = useRef<RealtimeChannel | null>(null);
+  const lastSendRef = useRef(0);
+  const loadingMoreRef = useRef(false);
+
+  // Cache profile from a message
+  const cacheProfile = useCallback((msg: ChatMessage) => {
+    if (!profileCache.current.has(msg.user_id)) {
+      profileCache.current.set(msg.user_id, {
+        nickname: msg.nickname,
+        avatar_url: msg.avatar_url,
+      });
+    }
+  }, []);
+
+  // Fetch profile for a user_id
+  const fetchProfile = useCallback(async (uid: string): Promise<ProfileCache> => {
+    const cached = profileCache.current.get(uid);
+    if (cached) return cached;
+
+    if (!supabase) return { nickname: "Unknown", avatar_url: null };
+
+    const { data } = await supabase
+      .from("profiles")
+      .select("nickname, avatar_url")
+      .eq("id", uid)
+      .single();
+
+    const profile: ProfileCache = {
+      nickname: data?.nickname ?? "Unknown",
+      avatar_url: data?.avatar_url ?? null,
+    };
+    profileCache.current.set(uid, profile);
+    return profile;
+  }, []);
+
+  // Parse raw DB row into ChatMessage
+  const parseRow = useCallback((row: {
+    id: string;
+    user_id: string;
+    content: string;
+    created_at: string;
+    profiles?: { nickname: string; avatar_url: string | null } | { nickname: string; avatar_url: string | null }[];
+  }): ChatMessage => {
+    const profile = Array.isArray(row.profiles) ? row.profiles[0] : row.profiles;
+    return {
+      id: row.id,
+      user_id: row.user_id,
+      content: row.content,
+      created_at: row.created_at,
+      nickname: profile?.nickname ?? "Unknown",
+      avatar_url: profile?.avatar_url ?? null,
+    };
+  }, []);
+
+  // Initial fetch
+  useEffect(() => {
+    if (!supabase || !userId) return;
+
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      const { data } = await supabase
+        .from("chat_messages")
+        .select("id, user_id, content, created_at, profiles(nickname, avatar_url)")
+        .order("created_at", { ascending: false })
+        .limit(PAGE_SIZE);
+
+      if (cancelled) return;
+
+      if (data) {
+        const msgs = (data as typeof data).map(parseRow).reverse();
+        msgs.forEach(cacheProfile);
+        setMessages(msgs);
+        setHasMore(data.length === PAGE_SIZE);
+      }
+      setLoading(false);
+    })();
+
+    return () => { cancelled = true; };
+  }, [userId, parseRow, cacheProfile]);
+
+  // Realtime subscription
+  useEffect(() => {
+    if (!supabase || !userId) return;
+
+    const channel = supabase
+      .channel("chat_messages_realtime")
+      .on("postgres_changes", {
+        event: "INSERT",
+        schema: "public",
+        table: "chat_messages",
+      }, async (payload) => {
+        const row = payload.new as { id: string; user_id: string; content: string; created_at: string };
+        const profile = await fetchProfile(row.user_id);
+        const msg: ChatMessage = {
+          ...row,
+          nickname: profile.nickname,
+          avatar_url: profile.avatar_url,
+        };
+        setMessages((prev) => {
+          // Avoid duplicates
+          if (prev.some((m) => m.id === msg.id)) return prev;
+          return [...prev, msg];
+        });
+      })
+      .on("postgres_changes", {
+        event: "DELETE",
+        schema: "public",
+        table: "chat_messages",
+      }, (payload) => {
+        const deletedId = (payload.old as { id: string }).id;
+        setMessages((prev) => prev.filter((m) => m.id !== deletedId));
+      })
+      .subscribe();
+
+    channelRef.current = channel;
+
+    return () => {
+      channel.unsubscribe();
+      channelRef.current = null;
+    };
+  }, [userId, fetchProfile]);
+
+  // Send message
+  const sendMessage = useCallback(async (content: string): Promise<{ error?: string }> => {
+    if (!supabase || !userId) return { error: "Not authenticated" };
+
+    const trimmed = content.trim();
+    if (!trimmed || trimmed.length > 500) return { error: "Invalid message" };
+
+    // Client-side cooldown
+    const now = Date.now();
+    if (now - lastSendRef.current < COOLDOWN_MS) {
+      return { error: "rate_limited" };
+    }
+
+    setSending(true);
+
+    const { error } = await supabase.from("chat_messages").insert({
+      user_id: userId,
+      content: trimmed,
+    });
+
+    setSending(false);
+
+    if (error) {
+      // DB trigger raises 'Rate limit exceeded' — PostgREST wraps it in details/hint/message
+      const errStr = `${error.message} ${error.details ?? ""} ${error.hint ?? ""}`;
+      if (error.code === "P0001" || errStr.includes("Rate limit")) return { error: "rate_limited" };
+      return { error: error.message };
+    }
+
+    lastSendRef.current = now;
+    return {};
+  }, [userId]);
+
+  // Delete message (optimistic: Realtime DELETE event removes from UI)
+  const deleteMessage = useCallback(async (messageId: string): Promise<{ error?: string }> => {
+    if (!supabase) return { error: "Not available" };
+    const { error } = await supabase.from("chat_messages").delete().eq("id", messageId);
+    if (error) return { error: error.message };
+    return {};
+  }, []);
+
+  // Load more (older messages) with in-flight guard
+  const loadMore = useCallback(async () => {
+    if (!supabase || !hasMore || messages.length === 0 || loadingMoreRef.current) return;
+
+    loadingMoreRef.current = true;
+    try {
+      const oldest = messages[0];
+      const { data } = await supabase
+        .from("chat_messages")
+        .select("id, user_id, content, created_at, profiles(nickname, avatar_url)")
+        .lt("created_at", oldest.created_at)
+        .order("created_at", { ascending: false })
+        .limit(PAGE_SIZE);
+
+      if (data) {
+        const older = (data as typeof data).map(parseRow).reverse();
+        older.forEach(cacheProfile);
+        setMessages((prev) => [...older, ...prev]);
+        setHasMore(data.length === PAGE_SIZE);
+      }
+    } finally {
+      loadingMoreRef.current = false;
+    }
+  }, [hasMore, messages, parseRow, cacheProfile]);
+
+  return { messages, loading, sending, hasMore, sendMessage, deleteMessage, loadMore };
+}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -8,6 +8,7 @@
   "tab.overview": "Übersicht",
   "tab.analytics": "Analyse",
   "tab.leaderboard": "Rangliste",
+  "tab.chat": "Chat",
 
   "sources.title": "Quellen",
   "sources.claude": "Claude",
@@ -197,5 +198,16 @@
   "usageAlert.extraUsage": "Zusätzliche Nutzung",
   "usageAlert.stale": "Aktualisierung...",
   "usageAlert.resetsIn": "Zurücksetzen in {{time}}",
-  "usageAlert.resetsNow": "Wird zurückgesetzt..."
+  "usageAlert.resetsNow": "Wird zurückgesetzt...",
+
+  "chat.join": "Chat beitreten",
+  "chat.description": "Chatten Sie mit anderen Entwicklern in der Rangliste. Melden Sie sich an und aktivieren Sie die Rangliste, um teilzunehmen.",
+  "chat.placeholder": "Nachricht eingeben...",
+  "chat.send": "Senden",
+  "chat.loading": "Nachrichten werden geladen...",
+  "chat.empty": "Noch keine Nachrichten. Starten Sie das Gespräch!",
+  "chat.loadMore": "Ältere Nachrichten laden",
+  "chat.rateLimited": "Zu schnell! Versuchen Sie es gleich nochmal.",
+  "chat.delete": "Löschen",
+  "chat.maxLength": "Maximal 500 Zeichen"
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -8,6 +8,7 @@
   "tab.overview": "Overview",
   "tab.analytics": "Analytics",
   "tab.leaderboard": "Leaderboard",
+  "tab.chat": "Chat",
 
   "sources.title": "Sources",
   "sources.claude": "Claude",
@@ -197,5 +198,16 @@
   "usageAlert.extraUsage": "Extra Usage",
   "usageAlert.stale": "Updating...",
   "usageAlert.resetsIn": "Resets in {{time}}",
-  "usageAlert.resetsNow": "Resetting..."
+  "usageAlert.resetsNow": "Resetting...",
+
+  "chat.join": "Join the Chat",
+  "chat.description": "Chat with other developers on the leaderboard. Sign in and enable the leaderboard to participate.",
+  "chat.placeholder": "Type a message...",
+  "chat.send": "Send",
+  "chat.loading": "Loading messages...",
+  "chat.empty": "No messages yet. Start the conversation!",
+  "chat.loadMore": "Load older messages",
+  "chat.rateLimited": "Slow down! Try again in a moment.",
+  "chat.delete": "Delete",
+  "chat.maxLength": "Max 500 characters"
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -8,6 +8,7 @@
   "tab.overview": "Resumen",
   "tab.analytics": "Análisis",
   "tab.leaderboard": "Clasificación",
+  "tab.chat": "Chat",
 
   "sources.title": "Fuentes",
   "sources.claude": "Claude",
@@ -197,5 +198,16 @@
   "usageAlert.extraUsage": "Uso adicional",
   "usageAlert.stale": "Actualizando...",
   "usageAlert.resetsIn": "Se reinicia en {{time}}",
-  "usageAlert.resetsNow": "Reiniciando..."
+  "usageAlert.resetsNow": "Reiniciando...",
+
+  "chat.join": "Unirse al chat",
+  "chat.description": "Chatea con otros desarrolladores de la clasificación. Inicia sesión y activa la clasificación para participar.",
+  "chat.placeholder": "Escribe un mensaje...",
+  "chat.send": "Enviar",
+  "chat.loading": "Cargando mensajes...",
+  "chat.empty": "Aún no hay mensajes. ¡Inicia la conversación!",
+  "chat.loadMore": "Cargar mensajes anteriores",
+  "chat.rateLimited": "¡Demasiado rápido! Inténtalo de nuevo en un momento.",
+  "chat.delete": "Eliminar",
+  "chat.maxLength": "Máximo 500 caracteres"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -8,6 +8,7 @@
   "tab.overview": "Aperçu",
   "tab.analytics": "Analyse",
   "tab.leaderboard": "Classement",
+  "tab.chat": "Chat",
 
   "sources.title": "Sources",
   "sources.claude": "Claude",
@@ -197,5 +198,16 @@
   "usageAlert.extraUsage": "Utilisation supplémentaire",
   "usageAlert.stale": "Mise à jour...",
   "usageAlert.resetsIn": "Réinitialisation dans {{time}}",
-  "usageAlert.resetsNow": "Réinitialisation..."
+  "usageAlert.resetsNow": "Réinitialisation...",
+
+  "chat.join": "Rejoindre le chat",
+  "chat.description": "Discutez avec les autres développeurs du classement. Connectez-vous et activez le classement pour participer.",
+  "chat.placeholder": "Tapez un message...",
+  "chat.send": "Envoyer",
+  "chat.loading": "Chargement des messages...",
+  "chat.empty": "Aucun message pour l'instant. Lancez la conversation !",
+  "chat.loadMore": "Charger les anciens messages",
+  "chat.rateLimited": "Trop rapide ! Réessayez dans un instant.",
+  "chat.delete": "Supprimer",
+  "chat.maxLength": "500 caractères maximum"
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -8,6 +8,7 @@
   "tab.overview": "概要",
   "tab.analytics": "分析",
   "tab.leaderboard": "リーダーボード",
+  "tab.chat": "チャット",
 
   "sources.title": "ソース",
   "sources.claude": "Claude",
@@ -197,5 +198,16 @@
   "usageAlert.extraUsage": "追加使用量",
   "usageAlert.stale": "更新中...",
   "usageAlert.resetsIn": "{{time}}後にリセット",
-  "usageAlert.resetsNow": "リセット中..."
+  "usageAlert.resetsNow": "リセット中...",
+
+  "chat.join": "チャットに参加",
+  "chat.description": "リーダーボードの他の開発者とチャットしましょう。ログインしてリーダーボードを有効にすると参加できます。",
+  "chat.placeholder": "メッセージを入力...",
+  "chat.send": "送信",
+  "chat.loading": "メッセージを読み込み中...",
+  "chat.empty": "まだメッセージはありません。最初の会話を始めましょう！",
+  "chat.loadMore": "過去のメッセージを読み込む",
+  "chat.rateLimited": "少し待ってからもう一度お試しください。",
+  "chat.delete": "削除",
+  "chat.maxLength": "最大500文字"
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -8,6 +8,7 @@
   "tab.overview": "개요",
   "tab.analytics": "분석",
   "tab.leaderboard": "리더보드",
+  "tab.chat": "채팅",
 
   "sources.title": "소스",
   "sources.claude": "Claude",
@@ -197,5 +198,16 @@
   "usageAlert.extraUsage": "추가 사용량",
   "usageAlert.stale": "업데이트 중...",
   "usageAlert.resetsIn": "{{time}} 후 리셋",
-  "usageAlert.resetsNow": "리셋 중..."
+  "usageAlert.resetsNow": "리셋 중...",
+
+  "chat.join": "채팅 참여하기",
+  "chat.description": "리더보드에 참여 중인 다른 개발자들과 대화하세요. 로그인 후 리더보드를 활성화하면 참여할 수 있습니다.",
+  "chat.placeholder": "메시지를 입력하세요...",
+  "chat.send": "전송",
+  "chat.loading": "메시지 로딩 중...",
+  "chat.empty": "아직 메시지가 없습니다. 첫 대화를 시작해보세요!",
+  "chat.loadMore": "이전 메시지 불러오기",
+  "chat.rateLimited": "너무 빨라요! 잠시 후 다시 시도하세요.",
+  "chat.delete": "삭제",
+  "chat.maxLength": "최대 500자"
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -8,6 +8,7 @@
   "tab.overview": "概览",
   "tab.analytics": "分析",
   "tab.leaderboard": "排行榜",
+  "tab.chat": "聊天",
 
   "sources.title": "来源",
   "sources.claude": "Claude",
@@ -197,5 +198,16 @@
   "usageAlert.extraUsage": "额外用量",
   "usageAlert.stale": "更新中...",
   "usageAlert.resetsIn": "{{time}}后重置",
-  "usageAlert.resetsNow": "重置中..."
+  "usageAlert.resetsNow": "重置中...",
+
+  "chat.join": "加入聊天",
+  "chat.description": "与排行榜上的其他开发者聊天。登录并启用排行榜即可参与。",
+  "chat.placeholder": "输入消息...",
+  "chat.send": "发送",
+  "chat.loading": "加载消息中...",
+  "chat.empty": "还没有消息。开始第一段对话吧！",
+  "chat.loadMore": "加载更早的消息",
+  "chat.rateLimited": "发送太快了！请稍后再试。",
+  "chat.delete": "删除",
+  "chat.maxLength": "最多500个字符"
 }

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -8,6 +8,7 @@
   "tab.overview": "總覽",
   "tab.analytics": "分析",
   "tab.leaderboard": "排行榜",
+  "tab.chat": "聊天",
 
   "sources.title": "來源",
   "sources.claude": "Claude",
@@ -197,5 +198,16 @@
   "usageAlert.extraUsage": "額外用量",
   "usageAlert.stale": "更新中...",
   "usageAlert.resetsIn": "{{time}}後重置",
-  "usageAlert.resetsNow": "重置中..."
+  "usageAlert.resetsNow": "重置中...",
+
+  "chat.join": "加入聊天",
+  "chat.description": "與排行榜上的其他開發者聊天。登入並啟用排行榜即可參與。",
+  "chat.placeholder": "輸入訊息...",
+  "chat.send": "傳送",
+  "chat.loading": "載入訊息中...",
+  "chat.empty": "還沒有訊息。開始第一段對話吧！",
+  "chat.loadMore": "載入更早的訊息",
+  "chat.rateLimited": "傳送太快了！請稍後再試。",
+  "chat.delete": "刪除",
+  "chat.maxLength": "最多500個字元"
 }

--- a/supabase/migrations/20260326_chat_messages.sql
+++ b/supabase/migrations/20260326_chat_messages.sql
@@ -1,0 +1,51 @@
+-- Chat messages table for leaderboard community chat
+create table chat_messages (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references profiles(id) not null,
+  content text not null,
+  created_at timestamptz default now(),
+  constraint chat_messages_content_length check (char_length(content) between 1 and 500)
+);
+
+create index idx_chat_messages_created_at on chat_messages(created_at desc);
+alter table chat_messages enable row level security;
+
+-- RLS: Only leaderboard participants (users with at least one snapshot) can read
+create policy "chat_read" on chat_messages for select using (
+  auth.uid() is not null
+  and exists (select 1 from daily_snapshots where user_id = auth.uid() limit 1)
+);
+
+-- RLS: Only leaderboard participants can insert their own messages
+create policy "chat_insert" on chat_messages for insert with check (
+  auth.uid() = user_id
+  and exists (select 1 from daily_snapshots where user_id = auth.uid() limit 1)
+);
+
+-- RLS: Users can delete their own messages
+create policy "chat_delete" on chat_messages for delete using (auth.uid() = user_id);
+
+-- Rate limiting: max 5 messages per 30 seconds per user
+-- SECURITY DEFINER is intentional: count must bypass RLS to see all user's messages
+create or replace function check_chat_rate_limit() returns trigger as $$
+begin
+  if (select count(*) from chat_messages
+      where user_id = new.user_id and created_at > now() - interval '30 seconds') >= 5 then
+    raise exception 'Rate limit exceeded';
+  end if;
+  return new;
+end;
+$$ language plpgsql security definer;
+
+create trigger chat_rate_limit before insert on chat_messages
+  for each row execute function check_chat_rate_limit();
+
+-- Cleanup function for messages older than 7 days (schedule via pg_cron)
+create or replace function cleanup_old_chat_messages() returns void as $$
+begin
+  delete from chat_messages where created_at < now() - interval '7 days';
+end;
+$$ language plpgsql security definer;
+
+-- Enable Supabase Realtime for chat_messages
+alter publication supabase_realtime add table chat_messages;


### PR DESCRIPTION
## Summary
- KakaoTalk-style real-time chat room for leaderboard participants (4th tab)
- Supabase Realtime for live message delivery, RLS for access control
- DB-level rate limiting (5msg/30s), 500 char limit, 7-day retention
- i18n support for all 8 locales

## New Files
- `supabase/migrations/20260326_chat_messages.sql` — DB schema, RLS, rate limit trigger
- `src/hooks/useChat.ts` — Real-time chat hook (fetch, subscribe, send, delete)
- `src/components/ChatRoom.tsx` — Chat UI container with auth gate
- `src/components/ChatMessage.tsx` — KakaoTalk-style message bubbles

## Modified Files
- `TabBar.tsx` — Added chat tab
- `App.tsx` — Added ChatRoom rendering
- `8 locale files` — Added chat i18n keys

## Test plan
- [ ] Verify chat tab appears and CTA shows for non-authenticated users
- [ ] Sign in and send a message — verify it appears in real-time
- [ ] Test with a second account to verify real-time message delivery
- [ ] Test rate limiting (rapid sends)
- [ ] Test message deletion (own messages only)
- [ ] Test "load older messages" pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)