### PR TITLE
fix: macOS production OAuth and chat room blank screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-token-monitor",
-  "version": "0.9.2",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-token-monitor",
-      "version": "0.9.2",
+      "version": "0.11.1",
       "dependencies": {
         "@supabase/supabase-js": "^2.99.3",
         "@tauri-apps/api": "^2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "ai-token-monitor"
-version = "0.10.0"
+version = "0.11.1"
 dependencies = [
  "chrono",
  "cocoa",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -473,7 +473,6 @@ pub fn run() {
                 app.set_activation_policy(tauri::ActivationPolicy::Accessory);
             }
 
-            // Log all window events
             let main_window = app.get_webview_window("main").unwrap();
             let win_clone = main_window.clone();
             main_window.on_window_event(move |event| {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://avatars.githubusercontent.com; connect-src 'self' https://giunmtxxvapcgrpxjopq.supabase.co https://api.github.com https://github.com https://objects.githubusercontent.com"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://avatars.githubusercontent.com; connect-src 'self' https://giunmtxxvapcgrpxjopq.supabase.co wss://giunmtxxvapcgrpxjopq.supabase.co https://api.github.com https://github.com https://objects.githubusercontent.com"
     },
     "macOSPrivateApi": true
   },

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -9,9 +9,8 @@ import type { User } from "@supabase/supabase-js";
 const DEEP_LINK_CALLBACK = "ai-token-monitor://auth/callback";
 const AUTH_TIMEOUT_MS = 120_000;
 
-function isWindowsProduction(): boolean {
-  if (window.location.protocol === "http:") return false;
-  return /windows/i.test(navigator.userAgent);
+function isProduction(): boolean {
+  return window.location.protocol !== "http:";
 }
 
 interface AuthContextType {
@@ -65,9 +64,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => subscription.unsubscribe();
   }, []);
 
-  // Windows production: listen for deep link OAuth callback
+  // Production: listen for deep link OAuth callback (macOS + Windows)
   useEffect(() => {
-    if (!isWindowsProduction() || !supabase) return;
+    if (!isProduction() || !supabase) return;
 
     let cancelled = false;
     let unlisten: (() => void) | undefined;
@@ -132,8 +131,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
     setLoading(true);
 
-    if (!isWindowsProduction()) {
-      // macOS production + dev mode: existing implicit flow
+    if (!isProduction()) {
+      // Dev mode: implicit flow via localhost
       await supabase.auth.signInWithOAuth({
         provider: "github",
         options: { redirectTo: window.location.origin },
@@ -141,7 +140,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       return;
     }
 
-    // Windows production: PKCE + deep link
+    // Production (macOS + Windows): PKCE + deep link
     const { data, error } = await supabase.auth.signInWithOAuth({
       provider: "github",
       options: {


### PR DESCRIPTION
## Summary
- macOS 프로덕션 빌드에서 GitHub OAuth 로그인 시 무한 로딩되는 버그 수정
- 프로덕션 빌드에서 채팅 화면 진입 시 검정화면으로 바뀌는 버그 수정

## Changes

### `src/contexts/AuthContext.tsx`
- `isWindowsProduction()` → `isProduction()`으로 변경
- macOS 프로덕션에서도 PKCE + deep link 방식으로 OAuth 처리
- 기존: macOS 프로덕션에서 implicit flow 사용 → `tauri://localhost`로 리다이렉트 실패 → 무한 로딩
- 수정: 프로덕션 환경(macOS + Windows) 모두 `skipBrowserRedirect: true` + `openUrl` 사용

### `src-tauri/tauri.conf.json`
- CSP `connect-src`에 `wss://giunmtxxvapcgrpxjopq.supabase.co` 추가
- Supabase Realtime WebSocket 연결이 CSP에 의해 차단되어 채팅 화면 크래시 발생

## Root Cause
1. **OAuth**: `isWindowsProduction()`이 macOS에서 `false` 반환 → implicit flow의 `redirectTo: window.location.origin`이 프로덕션에서 `tauri://localhost`가 되어 브라우저에서 콜백 불가
2. **채팅**: Supabase Realtime은 `wss://` WebSocket을 사용하지만 CSP에 `wss://` 미허용 → 연결 차단 → 컴포넌트 크래시 → 검정화면

## Test plan
- [x] 로컬 프로덕션 빌드(`tauri build --debug`)에서 GitHub OAuth 로그인 정상 동작 확인
- [x] 로컬 프로덕션 빌드에서 채팅 화면 정상 표시 확인
- [ ] dev 모드(`tauri dev`)에서 기존 implicit flow 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)