### PR TITLE
feat: make OAuth usage tracking opt-in

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7,10 +7,11 @@ use crate::providers::pricing;
 use crate::providers::traits::TokenProvider;
 use crate::providers::types::{AllStats, UserPreferences};
 
+use tauri::Emitter;
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use tauri::Manager;
 
-fn prefs_path() -> PathBuf {
+pub(crate) fn prefs_path() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_default()
         .join(".claude")
@@ -350,4 +351,17 @@ pub fn get_oauth_usage() -> Option<crate::oauth_usage::OAuthUsage> {
 #[tauri::command]
 pub fn get_pricing_table() -> pricing::PricingTable {
     pricing::get_pricing_table()
+}
+
+#[tauri::command]
+pub async fn enable_usage_tracking(app: tauri::AppHandle) -> Result<(), String> {
+    let mut prefs = get_preferences();
+    prefs.usage_tracking_enabled = true;
+    set_preferences(app.clone(), prefs)?;
+
+    // Immediately fetch so user sees data right away
+    if let Some(_) = crate::oauth_usage::fetch_and_cache_usage().await {
+        let _ = app.emit("usage-updated", ());
+    }
+    Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -401,7 +401,8 @@ pub fn run() {
             commands::capture_window,
             commands::copy_png_to_clipboard,
             commands::get_pricing_table,
-            commands::get_oauth_usage
+            commands::get_oauth_usage,
+            commands::enable_usage_tracking
         ])
         .setup(|app| {
             // Build tray icon
@@ -521,22 +522,39 @@ pub fn run() {
             // Start file watcher
             start_file_watcher(app.handle().clone());
 
-            // Start OAuth usage polling (5-minute interval)
+            // Migrate existing users: auto-enable usage tracking if prefs file exists
+            {
+                let prefs_file = commands::prefs_path();
+                if prefs_file.exists() {
+                    let mut prefs = commands::get_preferences();
+                    if !prefs.usage_tracking_migrated {
+                        prefs.usage_tracking_enabled = true;
+                        prefs.usage_tracking_migrated = true;
+                        if let Ok(json) = serde_json::to_string_pretty(&prefs) {
+                            let _ = std::fs::write(&prefs_file, json);
+                        }
+                    }
+                }
+            }
+
+            // Start OAuth usage polling (5-minute interval, only when tracking enabled)
             {
                 let handle = app.handle().clone();
                 thread::spawn(move || {
                     let rt = tauri::async_runtime::handle();
                     loop {
-                        // Always fetch to keep cache fresh for UI
-                        if let Some(_) = rt.block_on(oauth_usage::fetch_and_cache_usage()) {
-                            let _ = handle.emit("usage-updated", ());
-                            // Only fire OS notifications if alerts are enabled
-                            let prefs = commands::get_preferences();
-                            if prefs.usage_alerts_enabled {
-                                check_and_fire_alerts(&handle);
+                        let prefs = commands::get_preferences();
+                        if prefs.usage_tracking_enabled {
+                            if let Some(_) = rt.block_on(oauth_usage::fetch_and_cache_usage()) {
+                                let _ = handle.emit("usage-updated", ());
+                                if prefs.usage_alerts_enabled {
+                                    check_and_fire_alerts(&handle);
+                                }
                             }
+                            thread::sleep(std::time::Duration::from_secs(300));
+                        } else {
+                            thread::sleep(std::time::Duration::from_secs(5));
                         }
-                        thread::sleep(std::time::Duration::from_secs(300));
                     }
                 });
             }

--- a/src-tauri/src/providers/types.rs
+++ b/src-tauri/src/providers/types.rs
@@ -54,6 +54,10 @@ pub struct UserPreferences {
     pub monthly_salary: Option<f64>,
     #[serde(default = "default_true")]
     pub usage_alerts_enabled: bool,
+    #[serde(default)]
+    pub usage_tracking_enabled: bool,
+    #[serde(default)]
+    pub usage_tracking_migrated: bool,
 }
 
 fn default_theme() -> String {
@@ -90,6 +94,8 @@ impl Default for UserPreferences {
             include_codex: false,
             monthly_salary: None,
             usage_alerts_enabled: true,
+            usage_tracking_enabled: false,
+            usage_tracking_migrated: false,
         }
     }
 }

--- a/src/components/SettingsOverlay.tsx
+++ b/src/components/SettingsOverlay.tsx
@@ -97,6 +97,13 @@ export function SettingsOverlay({ visible, onClose }: Props) {
           />
         </SettingRow>
 
+        <SettingRow label={t("settings.usageTracking")}>
+          <ToggleSwitch
+            checked={prefs.usage_tracking_enabled}
+            onChange={(v) => updatePrefs({ usage_tracking_enabled: v })}
+          />
+        </SettingRow>
+
         {/* Salary section */}
         <SettingRow
           label={t("settings.monthlySalary")}

--- a/src/components/UsageAlertBar.tsx
+++ b/src/components/UsageAlertBar.tsx
@@ -1,4 +1,7 @@
+import { useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { useOAuthUsage } from "../hooks/useOAuthUsage";
+import { useSettings } from "../contexts/SettingsContext";
 import { useI18n } from "../i18n/I18nContext";
 
 function getBarColor(percent: number): string {
@@ -72,8 +75,66 @@ function UsageRow({
 }
 
 export function UsageAlertBar() {
+  const { prefs, refreshPrefs } = useSettings();
   const { usage } = useOAuthUsage();
   const t = useI18n();
+  const [enabling, setEnabling] = useState(false);
+
+  if (!prefs.usage_tracking_enabled) {
+    return (
+      <div style={{
+        background: "var(--bg-card)",
+        borderRadius: "var(--radius-lg)",
+        padding: "12px 16px",
+      }}>
+        <div style={{
+          fontSize: 11,
+          fontWeight: 700,
+          color: "var(--text-primary)",
+          marginBottom: 4,
+        }}>
+          {t("usageTracking.title")}
+        </div>
+        <div style={{
+          fontSize: 10,
+          color: "var(--text-secondary)",
+          marginBottom: 10,
+          lineHeight: 1.4,
+        }}>
+          {t("usageTracking.description")}
+        </div>
+        <button
+          onClick={async () => {
+            setEnabling(true);
+            try {
+              await invoke("enable_usage_tracking");
+              await refreshPrefs();
+            } catch {
+              // silently ignore
+            } finally {
+              setEnabling(false);
+            }
+          }}
+          disabled={enabling}
+          style={{
+            width: "100%",
+            padding: "6px 0",
+            fontSize: 11,
+            fontWeight: 600,
+            color: "var(--text-primary)",
+            background: "var(--bg-hover)",
+            border: "1px solid var(--border-secondary)",
+            borderRadius: "var(--radius-md)",
+            cursor: enabling ? "default" : "pointer",
+            opacity: enabling ? 0.6 : 1,
+            transition: "opacity 0.2s ease",
+          }}
+        >
+          {enabling ? t("usageTracking.enabling") : t("usageTracking.enable")}
+        </button>
+      </div>
+    );
+  }
 
   if (!usage) return null;
 

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -7,6 +7,7 @@ import type { UserPreferences } from "../lib/types";
 interface SettingsContextType {
   prefs: UserPreferences;
   updatePrefs: (partial: Partial<UserPreferences>) => void;
+  refreshPrefs: () => Promise<void>;
   ready: boolean;
 }
 
@@ -21,11 +22,13 @@ const defaultPrefs: UserPreferences = {
   language: "en",
   config_dirs: ["~/.claude"],
   usage_alerts_enabled: true,
+  usage_tracking_enabled: false,
 };
 
 const SettingsContext = createContext<SettingsContextType>({
   prefs: defaultPrefs,
   updatePrefs: () => {},
+  refreshPrefs: async () => {},
   ready: false,
 });
 
@@ -97,8 +100,18 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     setPrefs((prev) => ({ ...prev, ...partial }));
   }, [ready]);
 
+  const refreshPrefs = useCallback(async () => {
+    try {
+      const p = await invoke<UserPreferences>("get_preferences");
+      skipNextPersist.current = true;
+      setPrefs(p);
+    } catch {
+      // ignore
+    }
+  }, []);
+
   return (
-    <SettingsContext.Provider value={{ prefs, updatePrefs, ready }}>
+    <SettingsContext.Provider value={{ prefs, updatePrefs, refreshPrefs, ready }}>
       {children}
     </SettingsContext.Provider>
   );

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -191,6 +191,7 @@
   "update.error": "Update fehlgeschlagen",
 
   "settings.usageAlerts": "Nutzungswarnungen",
+  "settings.usageTracking": "Nutzungsverfolgung",
 
   "usageAlert.title": "Nutzung",
   "usageAlert.session": "Sitzung (5h)",
@@ -199,6 +200,11 @@
   "usageAlert.stale": "Aktualisierung...",
   "usageAlert.resetsIn": "Zurücksetzen in {{time}}",
   "usageAlert.resetsNow": "Wird zurückgesetzt...",
+
+  "usageTracking.title": "Claude Nutzungsverfolgung",
+  "usageTracking.description": "Überwachen Sie Ihre Claude Code Sitzungs- und Wochenlimits in Echtzeit. Dies erfordert Zugriff auf Ihre Claude Code Anmeldedaten.",
+  "usageTracking.enable": "Aktivieren",
+  "usageTracking.enabling": "Wird aktiviert...",
 
   "chat.join": "Chat beitreten",
   "chat.description": "Chatten Sie mit anderen Entwicklern in der Rangliste. Melden Sie sich an und aktivieren Sie die Rangliste, um teilzunehmen.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -191,6 +191,7 @@
   "update.error": "Update failed",
 
   "settings.usageAlerts": "Usage Alerts",
+  "settings.usageTracking": "Usage Tracking",
 
   "usageAlert.title": "Usage",
   "usageAlert.session": "Session (5h)",
@@ -199,6 +200,11 @@
   "usageAlert.stale": "Updating...",
   "usageAlert.resetsIn": "Resets in {{time}}",
   "usageAlert.resetsNow": "Resetting...",
+
+  "usageTracking.title": "Claude Usage Tracking",
+  "usageTracking.description": "Monitor your Claude Code session and weekly usage limits in real-time. This requires access to your Claude Code login credentials.",
+  "usageTracking.enable": "Enable",
+  "usageTracking.enabling": "Enabling...",
 
   "chat.join": "Join the Chat",
   "chat.description": "Chat with other developers on the leaderboard. Sign in and enable the leaderboard to participate.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -191,6 +191,7 @@
   "update.error": "Error de actualización",
 
   "settings.usageAlerts": "Alertas de uso",
+  "settings.usageTracking": "Seguimiento de uso",
 
   "usageAlert.title": "Uso",
   "usageAlert.session": "Sesión (5h)",
@@ -199,6 +200,11 @@
   "usageAlert.stale": "Actualizando...",
   "usageAlert.resetsIn": "Se reinicia en {{time}}",
   "usageAlert.resetsNow": "Reiniciando...",
+
+  "usageTracking.title": "Seguimiento de uso de Claude",
+  "usageTracking.description": "Monitorea tus límites de sesión y semanales de Claude Code en tiempo real. Requiere acceso a tus credenciales de inicio de sesión de Claude Code.",
+  "usageTracking.enable": "Activar",
+  "usageTracking.enabling": "Activando...",
 
   "chat.join": "Unirse al chat",
   "chat.description": "Chatea con otros desarrolladores de la clasificación. Inicia sesión y activa la clasificación para participar.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -191,6 +191,7 @@
   "update.error": "Échec de la mise à jour",
 
   "settings.usageAlerts": "Alertes d'utilisation",
+  "settings.usageTracking": "Suivi d'utilisation",
 
   "usageAlert.title": "Utilisation",
   "usageAlert.session": "Session (5h)",
@@ -199,6 +200,11 @@
   "usageAlert.stale": "Mise à jour...",
   "usageAlert.resetsIn": "Réinitialisation dans {{time}}",
   "usageAlert.resetsNow": "Réinitialisation...",
+
+  "usageTracking.title": "Suivi d'utilisation Claude",
+  "usageTracking.description": "Surveillez vos limites de session et hebdomadaires de Claude Code en temps réel. Nécessite l'accès à vos identifiants de connexion Claude Code.",
+  "usageTracking.enable": "Activer",
+  "usageTracking.enabling": "Activation...",
 
   "chat.join": "Rejoindre le chat",
   "chat.description": "Discutez avec les autres développeurs du classement. Connectez-vous et activez le classement pour participer.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -191,6 +191,7 @@
   "update.error": "更新に失敗しました",
 
   "settings.usageAlerts": "使用量アラート",
+  "settings.usageTracking": "使用量トラッキング",
 
   "usageAlert.title": "使用量",
   "usageAlert.session": "セッション (5時間)",
@@ -199,6 +200,11 @@
   "usageAlert.stale": "更新中...",
   "usageAlert.resetsIn": "{{time}}後にリセット",
   "usageAlert.resetsNow": "リセット中...",
+
+  "usageTracking.title": "Claude 使用量トラッキング",
+  "usageTracking.description": "Claude Codeのセッションおよび週間使用制限をリアルタイムで監視します。Claude Codeのログイン認証情報へのアクセスが必要です。",
+  "usageTracking.enable": "有効にする",
+  "usageTracking.enabling": "有効化中...",
 
   "chat.join": "チャットに参加",
   "chat.description": "リーダーボードの他の開発者とチャットしましょう。ログインしてリーダーボードを有効にすると参加できます。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -191,6 +191,7 @@
   "update.error": "업데이트 실패",
 
   "settings.usageAlerts": "사용량 알림",
+  "settings.usageTracking": "사용량 추적",
 
   "usageAlert.title": "사용량",
   "usageAlert.session": "세션 (5시간)",
@@ -199,6 +200,11 @@
   "usageAlert.stale": "업데이트 중...",
   "usageAlert.resetsIn": "{{time}} 후 리셋",
   "usageAlert.resetsNow": "리셋 중...",
+
+  "usageTracking.title": "Claude 사용량 추적",
+  "usageTracking.description": "Claude Code 세션 및 주간 사용 한도를 실시간으로 모니터링합니다. Claude Code 로그인 자격 증명에 대한 접근이 필요합니다.",
+  "usageTracking.enable": "활성화",
+  "usageTracking.enabling": "활성화 중...",
 
   "chat.join": "채팅 참여하기",
   "chat.description": "리더보드에 참여 중인 다른 개발자들과 대화하세요. 로그인 후 리더보드를 활성화하면 참여할 수 있습니다.",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -191,6 +191,7 @@
   "update.error": "更新失败",
 
   "settings.usageAlerts": "用量提醒",
+  "settings.usageTracking": "用量追踪",
 
   "usageAlert.title": "用量",
   "usageAlert.session": "会话 (5小时)",
@@ -199,6 +200,11 @@
   "usageAlert.stale": "更新中...",
   "usageAlert.resetsIn": "{{time}}后重置",
   "usageAlert.resetsNow": "重置中...",
+
+  "usageTracking.title": "Claude 用量追踪",
+  "usageTracking.description": "实时监控 Claude Code 会话和每周使用限额。需要访问 Claude Code 登录凭据。",
+  "usageTracking.enable": "启用",
+  "usageTracking.enabling": "启用中...",
 
   "chat.join": "加入聊天",
   "chat.description": "与排行榜上的其他开发者聊天。登录并启用排行榜即可参与。",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -191,6 +191,7 @@
   "update.error": "更新失敗",
 
   "settings.usageAlerts": "用量提醒",
+  "settings.usageTracking": "用量追蹤",
 
   "usageAlert.title": "用量",
   "usageAlert.session": "工作階段 (5小時)",
@@ -199,6 +200,11 @@
   "usageAlert.stale": "更新中...",
   "usageAlert.resetsIn": "{{time}}後重置",
   "usageAlert.resetsNow": "重置中...",
+
+  "usageTracking.title": "Claude 用量追蹤",
+  "usageTracking.description": "即時監控 Claude Code 工作階段和每週使用限額。需要存取 Claude Code 登入憑證。",
+  "usageTracking.enable": "啟用",
+  "usageTracking.enabling": "啟用中...",
 
   "chat.join": "加入聊天",
   "chat.description": "與排行榜上的其他開發者聊天。登入並啟用排行榜即可參與。",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -41,6 +41,7 @@ export interface UserPreferences {
   config_dirs: string[];
   monthly_salary?: number;
   usage_alerts_enabled: boolean;
+  usage_tracking_enabled: boolean;
 }
 
 export interface UsageWindow {


### PR DESCRIPTION
## Summary
- Make OAuth usage tracking opt-in to resolve repeated macOS Keychain permission prompts
- New users: see an explanation card with an "Enable" button in the usage area → Keychain access only on click
- Existing users: auto-migrated to preserve current behavior
- Users can disable tracking anytime via the "Usage Tracking" toggle in Settings

## 요약
- OAuth 사용량 추적을 opt-in 방식으로 변경하여 macOS Keychain 반복 프롬프트 문제 해결
- 신규 사용자: 사용량 영역에 설명 카드 + "활성화" 버튼 표시 → 클릭 시 Keychain 접근
- 기존 사용자: 자동 마이그레이션으로 기존 동작 유지
- 설정에서 "사용량 추적" 토글로 언제든 비활성화 가능

## Changes
- Add `usage_tracking_enabled` (default: false) and `usage_tracking_migrated` preferences
- Conditionally run OAuth polling loop only when `usage_tracking_enabled` is true
- Add `enable_usage_tracking` Tauri command (persists setting + immediate fetch)
- Add opt-in card UI in `UsageAlertBar` with platform-neutral description
- Add usage tracking toggle in `SettingsOverlay`
- Add `refreshPrefs()` to `SettingsContext` to prevent double-write on enable
- Add i18n strings for all 8 supported locales

## Test plan
- [ ] Fresh install: launch app → opt-in card shown → click "Enable" → Keychain prompt → usage data displayed
- [ ] Existing user: update app → auto-migration → usage data shown as before
- [ ] Settings → "Usage Tracking" toggle OFF → usage bars disappear, opt-in card shown
- [ ] After disabling, restart app → opt-in card persists (no forced re-enable)
- [ ] Windows: platform-neutral description without Keychain-specific wording

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)