### PR TITLE
fix: forward deep-link OAuth callback to frontend on Windows

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "ai-token-monitor"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,14 @@ use std::time::Instant;
 
 /// When true, the window will not auto-hide on focus loss (e.g. during dialog).
 static DIALOG_OPEN: AtomicBool = AtomicBool::new(false);
+
+/// Stores a deep-link URL that arrived before the frontend was ready (cold start).
+/// The frontend can retrieve it via the `get_pending_deep_link` command.
+static PENDING_DEEP_LINK: Mutex<Option<String>> = Mutex::new(None);
+
+/// Set to true when the single-instance callback has already emitted the deep-link URL,
+/// so the setup block doesn't store a duplicate into PENDING_DEEP_LINK.
+static DEEP_LINK_EMITTED: AtomicBool = AtomicBool::new(false);
 use notify::{Event, EventKind, RecursiveMode, Watcher};
 use tauri::tray::TrayIconBuilder;
 use tauri::{Emitter, Manager};
@@ -358,6 +366,11 @@ fn show_window(window: tauri::WebviewWindow) {
 }
 
 #[tauri::command]
+fn get_pending_deep_link() -> Option<String> {
+    PENDING_DEEP_LINK.lock().ok().and_then(|mut guard| guard.take())
+}
+
+#[tauri::command]
 fn quit_app(app: tauri::AppHandle) {
     eprintln!("[CMD] quit_app called");
     app.exit(0);
@@ -367,11 +380,14 @@ fn quit_app(app: tauri::AppHandle) {
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
-            // OAuth deep-link 콜백이면 윈도우를 표시하지 않음 —
-            // 프론트엔드에서 세션 교환 완료 후 직접 show_window를 호출한다.
-            let is_oauth_callback = args.iter().any(|a| a.contains("auth/callback"));
-            if is_oauth_callback {
-                eprintln!("[SINGLE-INSTANCE] OAuth callback detected, skipping window show");
+            // Windows에서 deep link는 새 프로세스의 CLI arg로 전달되며,
+            // single-instance 플러그인이 이를 가로챈다.
+            // deep-link 플러그인의 onOpenUrl에 도달하지 않을 수 있으므로
+            // 여기서 직접 프론트엔드에 emit한다.
+            if let Some(url) = args.iter().find(|a| a.contains("auth/callback")) {
+                eprintln!("[SINGLE-INSTANCE] OAuth callback detected, emitting to frontend: {}", url);
+                DEEP_LINK_EMITTED.store(true, Ordering::SeqCst);
+                let _ = app.emit("deep-link-auth", url.clone());
                 return;
             }
 
@@ -398,6 +414,7 @@ pub fn run() {
             set_dialog_open,
             hide_window,
             show_window,
+            get_pending_deep_link,
             quit_app,
             commands::capture_window,
             commands::copy_png_to_clipboard,
@@ -471,6 +488,21 @@ pub fn run() {
                     }
                 })
                 .build(app)?;
+
+            // Cold start (Windows only): check if the app was launched with a deep-link URL as arg.
+            // macOS delivers deep links via Apple Events, not process args.
+            #[cfg(target_os = "windows")]
+            {
+                if !DEEP_LINK_EMITTED.load(Ordering::SeqCst) {
+                    let args: Vec<String> = std::env::args().collect();
+                    if let Some(url) = args.iter().find(|a| a.contains("auth/callback")) {
+                        eprintln!("[SETUP] Deep-link URL found in launch args: {}", url);
+                        if let Ok(mut guard) = PENDING_DEEP_LINK.lock() {
+                            *guard = Some(url.clone());
+                        }
+                    }
+                }
+            }
 
             // Hide from dock on macOS
             #[cfg(target_os = "macos")]

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -4,6 +4,7 @@ import { supabase } from "../lib/supabase";
 import { onOpenUrl } from "@tauri-apps/plugin-deep-link";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import type { User } from "@supabase/supabase-js";
 
 const DEEP_LINK_CALLBACK = "ai-token-monitor://auth/callback";
@@ -64,42 +65,85 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => subscription.unsubscribe();
   }, []);
 
+  // Shared handler: extract code from deep-link URL and exchange for session.
+  // Uses a Set to prevent duplicate processing of the same auth code.
+  const processedCodes = useRef(new Set<string>());
+  const handleDeepLinkUrl = useCallback(async (url: string) => {
+    if (!supabase || !url.startsWith(DEEP_LINK_CALLBACK)) return;
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      console.warn("[OAuth] Malformed deep-link URL, ignoring:", url);
+      return;
+    }
+    const code = parsed.searchParams.get("code");
+    if (!code) {
+      console.warn("[OAuth] Deep-link received but no code param:", url);
+      return;
+    }
+    if (processedCodes.current.has(code)) {
+      console.log("[OAuth] Code already processed, skipping:", code);
+      return;
+    }
+    processedCodes.current.add(code);
+    try {
+      await supabase.auth.exchangeCodeForSession(code);
+      await invoke("show_window");
+    } catch (err) {
+      console.error("[OAuth] Session exchange failed:", err);
+      processedCodes.current.delete(code);
+    } finally {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      setLoading(false);
+    }
+  }, []);
+
   // Production: listen for deep link OAuth callback (macOS + Windows)
   useEffect(() => {
     if (!isProduction() || !supabase) return;
 
     let cancelled = false;
-    let unlisten: (() => void) | undefined;
+    let unlistenDeepLink: (() => void) | undefined;
+    let unlistenEvent: (() => void) | undefined;
 
+    // Path 1: deep-link plugin (works on macOS, may not fire on Windows)
     onOpenUrl(async (urls: string[]) => {
       for (const url of urls) {
-        if (!url.startsWith(DEEP_LINK_CALLBACK)) continue;
-        const code = new URL(url).searchParams.get("code");
-        if (!code) {
-          console.warn("[OAuth] Deep-link received but no code param:", url);
-          continue;
-        }
-        try {
-          await supabase.auth.exchangeCodeForSession(code);
-          // OAuth 성공 — single-instance 콜백에서 스킵한 윈도우 표시를 여기서 수행
-          await invoke("show_window");
-        } catch (err) {
-          console.error("[OAuth] Session exchange failed:", err);
-        } finally {
-          if (timeoutRef.current) clearTimeout(timeoutRef.current);
-          setLoading(false);
-        }
+        await handleDeepLinkUrl(url);
       }
     }).then((fn) => {
       if (cancelled) fn();
-      else unlisten = fn;
+      else unlistenDeepLink = fn;
     });
+
+    // Path 2: Rust single-instance emit (Windows fallback when Path 1 does not fire)
+    listen<string>("deep-link-auth", async (event) => {
+      console.log("[OAuth] Received deep-link-auth event:", event.payload);
+      await handleDeepLinkUrl(event.payload);
+    }).then((fn) => {
+      if (cancelled) fn();
+      else unlistenEvent = fn;
+    });
+
+    // Path 3: cold start (Windows) — check for URL stored before frontend mounted.
+    // Delayed slightly to let Path 1/2 listeners register first.
+    const pendingTimer = setTimeout(() => {
+      invoke<string | null>("get_pending_deep_link").then(async (url) => {
+        if (url) {
+          console.log("[OAuth] Pending deep-link found:", url);
+          await handleDeepLinkUrl(url);
+        }
+      });
+    }, 100);
 
     return () => {
       cancelled = true;
-      unlisten?.();
+      clearTimeout(pendingTimer);
+      unlistenDeepLink?.();
+      unlistenEvent?.();
     };
-  }, []);
+  }, [handleDeepLinkUrl]);
 
   // Cleanup auth timeout on unmount
   useEffect(() => {
@@ -165,6 +209,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (!supabase) return;
     setLoading(true);
     await supabase.auth.signOut();
+    processedCodes.current.clear();
     setUser(null);
     setProfile(null);
     setLoading(false);


### PR DESCRIPTION
## Summary
- Windows 설치본에서 GitHub OAuth 로그인 실패 문제 수정 (#67)
- Single-instance 플러그인이 deep-link URL을 소비한 후 프론트엔드에 전달하지 않던 문제
- 3가지 경로로 deep-link URL을 프론트엔드에 전달: `onOpenUrl` (macOS), emit event (Windows), pending URL query (Windows cold start)
- 동일 auth code 중복 처리 방지 (processedCodes Set)
- Malformed URL 방어 (try/catch)

## Test plan
- [ ] macOS: 기존 OAuth 로그인 플로우 정상 동작 확인
- [ ] Windows 설치본: GitHub OAuth 로그인 → 브라우저 인증 → 앱 복귀 → 로그인 상태 반영
- [ ] Windows 콜드 스타트: 앱 미실행 상태에서 deep-link → 앱 실행 → 로그인 완료

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)