### PR TITLE
perf: keep chat tab mounted to eliminate refetch on tab switch

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { useCombinedStats } from "./hooks/useCombinedStats";
 import { useToday } from "./hooks/useToday";
 import { useUnreadChat } from "./hooks/useUnreadChat";
@@ -35,8 +35,13 @@ function AppContent() {
   const { user } = useAuth();
   const updater = useUpdater();
   const [activeTab, setActiveTab] = useState<TabType>("overview");
+  const [chatActivated, setChatActivated] = useState(false);
   const todayStr = useToday();
   const { unreadCount } = useUnreadChat(activeTab === "chat", user?.id ?? null);
+
+  useEffect(() => {
+    if (activeTab === "chat") setChatActivated(true);
+  }, [activeTab]);
 
   const { today, weekAvg } = useMemo(() => {
     if (!stats) return { today: null, weekAvg: 0 };
@@ -137,12 +142,15 @@ function AppContent() {
         <Leaderboard />
       )}
 
-      {/* Chat lazy-loads (realtime subscription), keep conditional */}
-      {activeTab === "chat" && (
-        <div style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }}>
-          <ChatRoom />
-        </div>
-      )}
+      {/* Chat: always mounted but hidden via CSS; defers fetch until first visit */}
+      <div style={{
+        flex: 1,
+        minHeight: 0,
+        display: activeTab === "chat" ? "flex" : "none",
+        flexDirection: "column" as const,
+      }}>
+        <ChatRoom activated={chatActivated} visible={activeTab === "chat"} />
+      </div>
 
       <SupportBanner />
     </PopoverShell>

--- a/src/components/ChatRoom.tsx
+++ b/src/components/ChatRoom.tsx
@@ -7,7 +7,7 @@ import { ChatMessageRow, DateSeparator, formatDateSeparator, TranslateIcon } fro
 import { useI18n, LANGUAGE_NAMES } from "../i18n/I18nContext";
 import type { ChatMessage } from "../hooks/useChat";
 
-export function ChatRoom() {
+export function ChatRoom({ activated = true, visible = true }: { activated?: boolean; visible?: boolean }) {
   const { user, loading: authLoading, signIn, available } = useAuth();
   const { prefs } = useSettings();
   const t = useI18n();
@@ -36,7 +36,7 @@ export function ChatRoom() {
     return <ChatCTA onSignIn={signIn} loading={authLoading} hasUser={!!user} />;
   }
 
-  return <ChatContent userId={user.id} />;
+  return <ChatContent userId={user.id} activated={activated} visible={visible} />;
 }
 
 function ChatCTA({
@@ -122,13 +122,13 @@ function ChatCTA({
   );
 }
 
-function ChatContent({ userId }: { userId: string }) {
+function ChatContent({ userId, activated, visible }: { userId: string; activated: boolean; visible: boolean }) {
   const t = useI18n();
   const { prefs } = useSettings();
   const {
     messages, reactions, loading, sending, hasMore,
     sendMessage, deleteMessage, loadMore, toggleReaction,
-  } = useChat(userId);
+  } = useChat(userId, activated);
   const langName = LANGUAGE_NAMES[prefs.language] ?? prefs.language;
   const { translations, translating, translate, translateReply: invokeTranslateReply } = useTranslate(langName);
   const hasAiKey = !!(prefs.ai_keys?.gemini || prefs.ai_keys?.openai || prefs.ai_keys?.anthropic);
@@ -149,12 +149,12 @@ function ChatContent({ userId }: { userId: string }) {
     prevMessagesLenRef.current = messages.length;
   }, [messages.length]);
 
-  // Initial scroll to bottom
+  // Scroll to bottom on initial load or when tab becomes visible again
   useEffect(() => {
-    if (!loading && scrollRef.current) {
+    if (!loading && visible && scrollRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
-  }, [loading]);
+  }, [loading, visible]);
 
   const handleScroll = useCallback(() => {
     const el = scrollRef.current;

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -28,10 +28,10 @@ const COOLDOWN_MS = 2000;
 
 const emptyReactions = (): ReactionMap => ({ like: [], heart: [], dislike: [] });
 
-export function useChat(userId: string | null) {
+export function useChat(userId: string | null, enabled: boolean = true) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [reactions, setReactions] = useState<Map<string, ReactionMap>>(new Map());
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(enabled);
   const [sending, setSending] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const reactionsRef = useRef(reactions);
@@ -156,7 +156,7 @@ export function useChat(userId: string | null) {
 
   // Initial fetch
   useEffect(() => {
-    if (!supabase || !userId) return;
+    if (!supabase || !userId || !enabled) return;
 
     let cancelled = false;
     (async () => {
@@ -182,11 +182,11 @@ export function useChat(userId: string | null) {
     })();
 
     return () => { cancelled = true; };
-  }, [userId, parseRow, cacheProfile, enrichReplies, fetchReactions]);
+  }, [userId, enabled, parseRow, cacheProfile, enrichReplies, fetchReactions]);
 
   // Realtime subscription for messages + reactions
   useEffect(() => {
-    if (!supabase || !userId) return;
+    if (!supabase || !userId || !enabled) return;
 
     const channel = supabase
       .channel("chat_realtime")
@@ -274,7 +274,7 @@ export function useChat(userId: string | null) {
       channel.unsubscribe();
       channelRef.current = null;
     };
-  }, [userId, fetchProfile, enrichReplies]);
+  }, [userId, enabled, fetchProfile, enrichReplies]);
 
   // Toggle reaction (uses ref to avoid stale closure)
   const toggleReaction = useCallback(async (messageId: string, type: ReactionType) => {


### PR DESCRIPTION
## Summary
- 채팅 탭 전환 시 매번 발생하던 3회 Supabase 쿼리 (메시지 50건 + 리액션 + 답장 원문) 제거
- Overview/Analytics와 동일한 CSS `display: none/flex` 패턴으로 컴포넌트를 항상 마운트
- `enabled` 가드로 첫 방문 전까지 fetch/구독 지연 (불필요한 리소스 방지)
- 탭 복귀 시 스크롤 위치 하단 복원

## Test plan
- [ ] 채팅 탭 최초 진입 → 메시지 정상 로드
- [ ] 다른 탭 전환 후 채팅 복귀 → refetch 없이 즉시 표시, 스크롤 하단 위치
- [ ] 채팅 비활성 중 새 메시지 수신 → 탭 복귀 시 새 메시지 존재 확인
- [ ] 채팅 탭 미방문 상태에서 다른 탭만 사용 → 불필요한 Supabase 쿼리 없음 (DevTools Network)

🤖 Generated with [Claude Code](https://claude.com/claude-code)