### PR TITLE
feat: add multi-device leaderboard aggregation

### DIFF
--- a/src-tauri/src/providers/types.rs
+++ b/src-tauri/src/providers/types.rs
@@ -62,6 +62,8 @@ pub struct UserPreferences {
     pub ai_keys: Option<AiKeys>,
     #[serde(default)]
     pub ai_model: Option<String>,
+    #[serde(default)]
+    pub device_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -112,6 +114,7 @@ impl Default for UserPreferences {
             usage_tracking_migrated: false,
             ai_keys: None,
             ai_model: None,
+            device_id: None,
         }
     }
 }

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -197,12 +197,15 @@ function ProviderLeaderboard({
   user: User;
 }) {
   const t = useI18n();
+  const { prefs, updatePrefs } = useSettings();
   const { stats } = useTokenStats(provider);
   const { leaderboard, loading, period, setPeriod } = useLeaderboardSync({
     stats,
     user,
     optedIn: true,
     provider,
+    prefs,
+    updatePrefs,
   });
 
   const [page, setPage] = useState(0);

--- a/src/hooks/useLeaderboardSync.ts
+++ b/src/hooks/useLeaderboardSync.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { supabase } from "../lib/supabase";
-import type { AllStats, LeaderboardProvider } from "../lib/types";
+import type { AllStats, LeaderboardProvider, UserPreferences } from "../lib/types";
 import { getTotalTokens, toLocalDateStr } from "../lib/format";
 import type { User } from "@supabase/supabase-js";
 
@@ -42,13 +42,26 @@ interface UseLeaderboardSyncProps {
   user: User | null;
   optedIn: boolean;
   provider: LeaderboardProvider;
+  prefs: UserPreferences;
+  updatePrefs: (patch: Partial<UserPreferences>) => void;
 }
 
 const LEADERBOARD_CACHE_TTL = 180_000; // 3 minutes
 const LEADERBOARD_POLL_INTERVAL = 180_000; // 3 minutes
 
-export function useLeaderboardSync({ stats, user, optedIn, provider }: UseLeaderboardSyncProps) {
+export function useLeaderboardSync({ stats, user, optedIn, provider, prefs, updatePrefs }: UseLeaderboardSyncProps) {
   const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
+  const deviceIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (prefs.device_id) {
+      deviceIdRef.current = prefs.device_id;
+    } else {
+      const id = crypto.randomUUID().slice(0, 16);
+      deviceIdRef.current = id;
+      updatePrefs({ device_id: id });
+    }
+  }, [prefs.device_id, updatePrefs]);
   const [period, setPeriod] = useState<"today" | "week">("today");
   const [loading, setLoading] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -83,20 +96,29 @@ export function useLeaderboardSync({ stats, user, optedIn, provider }: UseLeader
       const today = toLocalDateStr(new Date());
 
       if (period === "today") {
-        const query = supabase
+        const { data } = await supabase
           .from("daily_snapshots")
           .select("user_id, total_tokens, cost_usd, messages, sessions, profiles(nickname, avatar_url)")
           .eq("date", today)
           .eq("provider", provider)
-          .order("total_tokens", { ascending: false })
-          .limit(100);
-
-        const { data } = await query;
+          .limit(500);
 
         if (data) {
-          const entries = (data as SnapshotRow[]).map(toLeaderboardEntry);
-          setLeaderboard(entries);
-          cacheRef.current = { data: entries, fetchedAt: Date.now(), period, provider };
+          const userMap = new Map<string, LeaderboardEntry>();
+          for (const row of (data as SnapshotRow[])) {
+            const existing = userMap.get(row.user_id);
+            if (existing) {
+              existing.total_tokens += row.total_tokens;
+              existing.cost_usd += Number(row.cost_usd);
+              existing.messages += row.messages;
+              existing.sessions += row.sessions;
+            } else {
+              userMap.set(row.user_id, toLeaderboardEntry(row));
+            }
+          }
+          const sorted = Array.from(userMap.values()).sort((a, b) => b.total_tokens - a.total_tokens);
+          setLeaderboard(sorted);
+          cacheRef.current = { data: sorted, fetchedAt: Date.now(), period, provider };
         }
       } else {
         // Weekly: aggregate snapshots from monday to today
@@ -144,7 +166,7 @@ export function useLeaderboardSync({ stats, user, optedIn, provider }: UseLeader
 
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(async () => {
-      await uploadSnapshot(user.id, stats, provider, syncedPastDatesRef.current);
+      await uploadSnapshot(user.id, stats, provider, syncedPastDatesRef.current, deviceIdRef.current ?? "default");
       fetchLeaderboard(true);
     }, 500);
 
@@ -190,6 +212,7 @@ async function uploadSnapshot(
   stats: AllStats,
   provider: LeaderboardProvider,
   syncedPastDates: Set<string>,
+  deviceId: string,
 ) {
   if (!supabase) return;
 
@@ -227,6 +250,7 @@ async function uploadSnapshot(
       .delete()
       .eq("user_id", userId)
       .eq("provider", provider)
+      .eq("device_id", deviceId)
       .in("date", toClean);
 
     if (!delError) {
@@ -251,6 +275,7 @@ async function uploadSnapshot(
     user_id: userId,
     date: d.date,
     provider,
+    device_id: deviceId,
     total_tokens: getTotalTokens(d.tokens),
     cost_usd: d.cost_usd,
     messages: d.messages,
@@ -258,7 +283,7 @@ async function uploadSnapshot(
   }));
 
   const { error } = await supabase.from("daily_snapshots").upsert(rows, {
-    onConflict: "user_id,date,provider",
+    onConflict: "user_id,date,provider,device_id",
   });
 
   // Mark past days as synced so they won't be re-uploaded until next session

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -48,6 +48,7 @@ export interface UserPreferences {
     anthropic?: string;
   };
   ai_model?: string;
+  device_id?: string;
 }
 
 export interface UsageWindow {

--- a/supabase/migrations/20260330_add_device_id.sql
+++ b/supabase/migrations/20260330_add_device_id.sql
@@ -1,0 +1,11 @@
+-- Add device_id column for multi-device leaderboard aggregation.
+-- Existing rows default to 'default' for backward compatibility.
+
+ALTER TABLE daily_snapshots
+ADD COLUMN IF NOT EXISTS device_id text NOT NULL DEFAULT 'default';
+
+-- Keep old (user_id, date, provider) constraint for backward compatibility
+-- with older clients. Add new 4-column constraint for multi-device upsert.
+ALTER TABLE daily_snapshots
+ADD CONSTRAINT daily_snapshots_user_id_date_provider_device_key
+UNIQUE (user_id, date, provider, device_id);


### PR DESCRIPTION
## Summary

- Adds `device_id` column to `daily_snapshots` so each device gets its own row
- Leaderboard aggregates across devices client-side (SUM tokens, cost, messages, sessions)
- Users running the app on multiple machines see their combined usage on the leaderboard

## Changes

| File | Change |
|------|--------|
| `supabase/migrations/20260330_add_device_id.sql` | Add `device_id` column (default `'default'`) + 4-column unique constraint |
| `src/lib/types.ts` | Add `device_id?: string` to `UserPreferences` |
| `src-tauri/src/providers/types.rs` | Add `device_id: Option<String>` to Rust `UserPreferences` |
| `src/hooks/useLeaderboardSync.ts` | Generate device_id, include in upsert, scope delete to device, aggregate "today" query |
| `src/components/Leaderboard.tsx` | Pass `prefs`/`updatePrefs` to `useLeaderboardSync` |

## Backward Compatibility

- Old 3-column constraint `(user_id, date, provider)` is **kept** — older clients continue working
- New 4-column constraint `(user_id, date, provider, device_id)` added for multi-device upsert
- Existing rows get `device_id = 'default'` via column default

## How it works

1. On first launch, a random 16-char UUID is generated and stored in `UserPreferences`
2. Each upload includes `device_id` → separate row per device
3. Leaderboard "today" query now aggregates across all device rows per user (same pattern as existing weekly aggregation)
4. Stale-row cleanup is scoped to the current device only

## Test plan

- [ ] Verify `daily_snapshots` rows include `device_id` after opt-in
- [ ] Manually insert a second device row for same user → leaderboard shows summed values
- [ ] Old clients (without `device_id`) still upsert normally on 3-column constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)