### PR TITLE
fix: Windows release 빌드 ERR_CONNECTION_REFUSED 수정

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -11,7 +11,10 @@ const DEEP_LINK_CALLBACK = "ai-token-monitor://auth/callback";
 const AUTH_TIMEOUT_MS = 120_000;
 
 function isProduction(): boolean {
-  return window.location.protocol !== "http:";
+  // Tauri v2: macOS/Linux → "tauri:", Windows → "http:" with host "tauri.localhost"
+  const { protocol, hostname } = window.location;
+  if (protocol !== "http:") return true;
+  return hostname === "tauri.localhost";
 }
 
 interface AuthContextType {


### PR DESCRIPTION
## Summary
- Tauri v2는 Windows에서 프론트엔드를 `http://tauri.localhost`로 서빙하지만, `isProduction()` 함수가 `protocol !== "http:"`로만 판별하여 Windows release 빌드를 dev 환경으로 오인
- dev 모드 OAuth 플로우로 진입 → `http://localhost:1420`으로 폴백 → 서버 없음 → ERR_CONNECTION_REFUSED
- `hostname === "tauri.localhost"` 체크를 추가하여 Windows release 빌드를 올바르게 감지

| 환경 | protocol | hostname | 수정 전 | 수정 후 |
|------|----------|----------|--------|--------|
| macOS Dev | `http:` | `localhost` | false | false |
| macOS Release | `tauri:` | `localhost` | true | true |
| Windows Dev | `http:` | `localhost` | false | false |
| Windows Release | `http:` | `tauri.localhost` | **false (BUG)** | **true (FIX)** |

## Test plan
- [ ] `npm run build` 성공 확인
- [ ] macOS dev 모드에서 OAuth 로그인 정상 동작 확인
- [ ] Windows release 빌드에서 OAuth 로그인 → 리더보드 접근 테스트

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)