### PR TITLE
fix: 월이 바뀔 때 이전 달 데이터가 사라지는 버그 수정

### DIFF
--- a/src-tauri/src/providers/claude_code.rs
+++ b/src-tauri/src/providers/claude_code.rs
@@ -107,6 +107,18 @@ fn current_month_str() -> String {
     chrono::Local::now().format("%Y-%m").to_string()
 }
 
+fn prev_month_str() -> String {
+    let now = chrono::Local::now();
+    use chrono::Datelike;
+    let year = now.year();
+    let month = now.month();
+    if month == 1 {
+        format!("{}-12", year - 1)
+    } else {
+        format!("{}-{:02}", year, month - 1)
+    }
+}
+
 fn date_to_month(date: &str) -> String {
     date.get(..7).unwrap_or(date).to_string()
 }
@@ -611,14 +623,21 @@ impl ClaudeCodeProvider {
                 let full_start = Instant::now();
 
                 // Check disk cache for historical months to speed up cold start
-                let disk_cache = load_disk_cache(&self.primary_dir);
-                let has_historical = disk_cache.as_ref().map_or(false, |c| !c.months.is_empty());
+                let mut disk_cache = load_disk_cache(&self.primary_dir)
+                    .unwrap_or(DiskCache { version: CACHE_VERSION, months: HashMap::new() });
+                let has_historical = !disk_cache.months.is_empty();
 
                 let current_month = current_month_str();
                 let mut entries = HashMap::new();
 
-                if has_historical {
-                    // Only parse files from current month (skip historical)
+                // Only skip historical files when the disk cache covers up to the previous
+                // month. If the previous month is absent (e.g. the month just rolled over),
+                // a full parse is required so that month's data is not lost.
+                let prev_month = prev_month_str();
+                let only_current = has_historical && disk_cache.months.contains_key(&prev_month);
+
+                if only_current {
+                    // Fast path: disk cache is complete — only parse current-month files
                     for (path, (_, _)) in &current_meta {
                         if let Ok(metadata) = fs::metadata(path) {
                             if let Ok(modified) = metadata.modified() {
@@ -632,14 +651,39 @@ impl ClaudeCodeProvider {
                         entries.extend(Self::parse_single_file(path));
                     }
                 } else {
-                    // Full parse all files
+                    // Full parse: either no cache yet, or the cache is missing some months
                     for path in current_meta.keys() {
                         entries.extend(Self::parse_single_file(path));
                     }
-                    // Save historical months to disk cache for future cold starts
-                    self.save_historical_months(&entries);
-                    // Remove historical entries from memory (disk cache has them)
-                    entries.retain(|_, e| date_to_month(&e.date) >= current_month);
+
+                    // Split off historical entries, persist any months missing from cache
+                    let mut current_entries = HashMap::new();
+                    let mut month_buckets: HashMap<String, Vec<SessionEntry>> = HashMap::new();
+                    for (key, entry) in entries {
+                        let month = date_to_month(&entry.date);
+                        if month >= current_month {
+                            current_entries.insert(key, entry);
+                        } else if !disk_cache.months.contains_key(&month) {
+                            month_buckets.entry(month).or_default().push(entry);
+                        }
+                        // Entries for months already in disk_cache are dropped here;
+                        // build_stats will merge them from disk_cache.
+                    }
+
+                    if !month_buckets.is_empty() {
+                        for (month, month_data) in &month_buckets {
+                            let refs: Vec<&SessionEntry> = month_data.iter().collect();
+                            let (daily_map, model_map, messages, _) = aggregate_entries(&refs);
+                            disk_cache.months.insert(month.clone(), MonthData {
+                                daily: daily_map.into_values().collect(),
+                                model_usage: model_map,
+                                total_messages: messages,
+                            });
+                        }
+                        save_disk_cache(&self.primary_dir, &disk_cache);
+                    }
+
+                    entries = current_entries;
                 }
 
                 eprintln!("[PERF] Full parse completed in {:?}", full_start.elapsed());


### PR DESCRIPTION
## 문제

월이 바뀔 때(예: 3월 → 4월) 이전 달 데이터가 월간 통계에서 사라지는 버그입니다.

**원인** (`claude_code.rs`의 `full_parse`):

1. 최초 콜드 스타트 시 디스크 캐시에 완료된 과거 달(예: 1월, 2월)이 저장됩니다.
2. 3월 내내 3월은 "현재 달"로 JSONL 파일에서 직접 읽힙니다 — **디스크 캐시에는 한 번도 저장되지 않습니다**.
3. 4월 1일이 되면 `current_month = "2026-04"`. `only_current = has_historical` 조건이 `true`가 되어 **mtime이 4월 이전인 파일이 모두 스킵됩니다**.
4. 3월은 디스크 캐시에도 없고, 파싱도 되지 않아 → 데이터가 사라집니다.

## 수정 내용

- `prev_month_str()` 헬퍼 함수 추가.
- 최적화 조건을 다음과 같이 변경:
  ```rust
  // Before
  let only_current = has_historical;

  // After
  let prev_month = prev_month_str();
  let only_current = has_historical && disk_cache.months.contains_key(&prev_month);
  ```
  이전 달이 캐시에 없으면 전체 파싱을 수행합니다.
- "과거 달 저장" 로직을 단일 `if !only_current` 블록으로 통합. 최초 콜드 스타트 케이스와 "캐시는 있지만 일부 달 누락" 케이스 모두 처리합니다. 캐시에 없는 과거 달은 집계 후 디스크에 저장되어 이후 재시작 시 빠르게 로드됩니다.

## 재현 방법

1. 3월 동안 앱을 사용하여 디스크 캐시에 1월, 2월만 저장된 상태로 만듭니다.
2. 4월 1일에 앱을 엽니다.
3. **수정 전**: 월간/30일 차트에서 3월 데이터가 사라짐.
4. **수정 후**: 3월 데이터가 파싱되어 디스크 캐시에 저장되고 정상 표시됨.