### PR TITLE
refactor: remove unused save_historical_months method

### DIFF
--- a/src-tauri/src/providers/claude_code.rs
+++ b/src-tauri/src/providers/claude_code.rs
@@ -341,33 +341,6 @@ impl ClaudeCodeProvider {
             .map_err(|e| format!("Failed to parse stats-cache.json: {}", e))
     }
 
-    /// Save completed historical months to disk cache for faster cold starts.
-    fn save_historical_months(&self, entries: &HashMap<String, SessionEntry>) {
-        let current_month = current_month_str();
-
-        let mut month_entries: HashMap<String, Vec<&SessionEntry>> = HashMap::new();
-        for entry in entries.values() {
-            let month = date_to_month(&entry.date);
-            if month < current_month {
-                month_entries.entry(month).or_default().push(entry);
-            }
-        }
-
-        if month_entries.is_empty() {
-            return;
-        }
-
-        let mut new_cache = DiskCache { version: CACHE_VERSION, months: HashMap::new() };
-        for (month, month_data) in &month_entries {
-            let (daily_map, model_map, messages, _) = aggregate_entries(month_data);
-            new_cache.months.insert(month.clone(), MonthData {
-                daily: daily_map.into_values().collect(),
-                model_usage: model_map,
-                total_messages: messages,
-            });
-        }
-        save_disk_cache(&self.primary_dir, &new_cache);
-    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
## Summary
- PR #80에서 캐시 저장 로직이 `full_parse` 블록 내부로 통합되면서 더 이상 호출되지 않는 `save_historical_months()` 메서드를 제거합니다.
- 27줄 삭제, 추가 없음

## Test plan
- [x] `cargo check` 빌드 성공 확인
- [x] `save_historical_months` 참조가 코드베이스 어디에도 없음을 grep으로 확인
- [x] 기존 `save_disk_cache` 호출은 `full_parse` 블록(line 656)에서 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)