### PR TITLE
fix: OAuth usage 개선 및 주간 리셋 시간 가독성 향상

### DIFF
--- a/src/components/UsageAlertBar.tsx
+++ b/src/components/UsageAlertBar.tsx
@@ -17,10 +17,14 @@ function formatResetTime(resetsAt: string, t: (key: string, params?: Record<stri
   const diffMs = reset.getTime() - now.getTime();
   if (diffMs <= 0) return t("usageAlert.resetsNow");
   const totalMin = Math.floor(diffMs / 60000);
-  const h = Math.floor(totalMin / 60);
+  const d = Math.floor(totalMin / 1440);
+  const h = Math.floor((totalMin % 1440) / 60);
   const m = totalMin % 60;
-  if (h > 0) return t("usageAlert.resetsIn", { time: `${h}h ${m}m` });
-  return t("usageAlert.resetsIn", { time: `${m}m` });
+  const parts: string[] = [];
+  if (d > 0) parts.push(`${d}d`);
+  if (h > 0) parts.push(`${h}h`);
+  if (m > 0 || parts.length === 0) parts.push(`${m}m`);
+  return t("usageAlert.resetsIn", { time: parts.join(" ") });
 }
 
 const SEGMENT_COUNT = 10;


### PR DESCRIPTION
## Summary
- Handle OAuth usage API 429 rate limit with retry logic and improve additional usage display
- Add automatic reconnection when chat real-time connection drops
- Improve weekly reset time readability: `165h 8m` → `6d 21h 8m` format

## 요약
- OAuth usage API 429 rate limit 대응 및 추가 사용량 표시 개선
- 채팅 실시간 연결 끊김 시 자동 재연결 로직 추가
- 주간 리셋 시간 표시를 `165h 8m` → `6d 21h 8m` 형태로 변경하여 가독성 개선

## Test plan
- [ ] Verify weekly reset time displays correctly in d/h/m format
- [ ] Verify session reset time (under 5h) still shows in h/m format
- [ ] Verify OAuth API 429 error retry works properly
- [ ] Verify auto-reconnection after chat connection drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)