### PR TITLE
fix: 앱 실행 중 업데이트 알림이 표시되지 않는 문제 수정

### DIFF
--- a/src/hooks/useUpdater.ts
+++ b/src/hooks/useUpdater.ts
@@ -26,6 +26,7 @@ export function useUpdater(): UpdaterState {
     let cancelled = false;
 
     async function checkForUpdate() {
+      if (updateAvailable) return;
       try {
         const update = await check();
         if (cancelled) return;
@@ -35,17 +36,19 @@ export function useUpdater(): UpdaterState {
           setUpdateAvailable(true);
         }
       } catch (e) {
-        // Silently ignore update check failures (e.g. no network, no latest.json)
         console.warn("[updater] check failed:", e);
       }
     }
 
     checkForUpdate();
 
+    const interval = setInterval(checkForUpdate, 30 * 60 * 1000);
+
     return () => {
       cancelled = true;
+      clearInterval(interval);
     };
-  }, []);
+  }, [updateAvailable]);
 
   const download = useCallback(async () => {
     const update = updateRef.current;


### PR DESCRIPTION
## Summary
- 업데이트 체크가 앱 시작 시 1회만 실행되어, 앱을 켜놓은 상태에서 새 버전이 릴리스되어도 알림이 표시되지 않는 문제 수정
- 30분 간격으로 주기적 업데이트 체크 추가
- 이미 업데이트가 감지된 경우 불필요한 추가 체크 스킵

## Test plan
- [ ] 앱 실행 후 업데이트 체크 로그 확인
- [ ] 30분 후 재체크 동작 확인
- [ ] 업데이트 감지 후 추가 체크가 중단되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)