### PR TITLE
feat: 리더보드 날짜별 그리드 뷰 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ dist-ssr
 
 # Supabase
 supabase/.temp/
+.tools/

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "ai-token-monitor"
-version = "0.16.3"
+version = "0.17.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect, useMemo } from "react";
 import { useAuth } from "../hooks/useAuth";
-import { useLeaderboardSync } from "../hooks/useLeaderboardSync";
+import { useLeaderboardSync, type LeaderboardPeriod } from "../hooks/useLeaderboardSync";
+import { useLeaderboardGrid } from "../hooks/useLeaderboardGrid";
 import { useTokenStats } from "../hooks/useTokenStats";
 import type { LeaderboardProvider } from "../lib/types";
 import type { User } from "@supabase/supabase-js";
 import { useSettings } from "../contexts/SettingsContext";
 import { LeaderboardRow } from "./LeaderboardRow";
+import { LeaderboardGrid } from "./LeaderboardGrid";
 import { useI18n } from "../i18n/I18nContext";
 import { BadgeOverlay } from "./badge/BadgeOverlay";
 
@@ -200,11 +202,25 @@ function ProviderLeaderboard({
 }) {
   const t = useI18n();
   const { stats } = useTokenStats(provider);
-  const { leaderboard, loading, period, setPeriod, dateRange } = useLeaderboardSync({
+  const [period, setPeriod] = useState<LeaderboardPeriod>("today");
+  const {
+    gridData,
+    loading: gridLoading,
+    refetch: refetchGrid,
+  } = useLeaderboardGrid({
+    provider,
+    // Only poll while the user is looking at the grid; onAfterUpload below
+    // still fires for this hook but becomes a no-op when disabled, which is
+    // fine because the cache will be repopulated on the next grid tab entry.
+    enabled: period === "grid",
+  });
+  const { leaderboard, loading, dateRange } = useLeaderboardSync({
     stats,
     user,
     optedIn: true,
     provider,
+    period,
+    onAfterUpload: refetchGrid,
   });
 
   const [page, setPage] = useState(0);
@@ -239,7 +255,7 @@ function ProviderLeaderboard({
         padding: 2,
         alignSelf: "center",
       }}>
-        {(["today", "week", "month"] as const).map((p) => (
+        {(["today", "week", "month", "grid"] as const).map((p) => (
           <button
             key={p}
             onClick={() => setPeriod(p)}
@@ -255,7 +271,12 @@ function ProviderLeaderboard({
               transition: "all 0.15s ease",
             }}
           >
-            {{ today: t("leaderboard.today"), week: t("leaderboard.thisWeek"), month: t("leaderboard.thisMonth") }[p]}
+            {{
+              today: t("leaderboard.today"),
+              week: t("leaderboard.thisWeek"),
+              month: t("leaderboard.thisMonth"),
+              grid: t("leaderboard.grid"),
+            }[p]}
           </button>
         ))}
       </div>
@@ -263,12 +284,14 @@ function ProviderLeaderboard({
       {/* Period date range */}
       {period !== "today" && (
         <div style={{ textAlign: "center", fontSize: 10, color: "var(--text-tertiary)", marginTop: -6 }}>
-          {dateRange.from.slice(5).replace("-", "/")} ~ {dateRange.to.slice(5).replace("-", "/")}
+          {period === "grid"
+            ? t("leaderboard.gridSubtitle")
+            : `${dateRange.from.slice(5).replace("-", "/")} ~ ${dateRange.to.slice(5).replace("-", "/")}`}
         </div>
       )}
 
-      {/* My rank card */}
-      {myRank > 0 && (
+      {/* My rank card — hidden in grid view (different semantics) */}
+      {period !== "grid" && myRank > 0 && (
         <div style={{ display: "flex", gap: 8, alignItems: "stretch" }}>
           <div
             onClick={goToMyPage}
@@ -325,10 +348,14 @@ function ProviderLeaderboard({
         leaderboard={leaderboard}
         userId={user.id}
         provider={provider}
-        period={period}
+        period={period === "grid" ? "today" : period}
         dateRange={dateRange}
       />
 
+      {period === "grid" ? (
+        <LeaderboardGrid gridData={gridData} loading={gridLoading} userId={user.id} />
+      ) : (
+      <>
       {/* Leaderboard list */}
       <div style={{
         background: "var(--bg-card)",
@@ -371,6 +398,8 @@ function ProviderLeaderboard({
       {/* Pagination */}
       {totalPages > 1 && (
         <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
+      )}
+      </>
       )}
     </div>
   );

--- a/src/components/LeaderboardGrid.tsx
+++ b/src/components/LeaderboardGrid.tsx
@@ -1,0 +1,283 @@
+import { useMemo } from "react";
+import type { CSSProperties } from "react";
+import type { GridCell, GridRow } from "../hooks/useLeaderboardGrid";
+import { useI18n } from "../i18n/I18nContext";
+import { useMiniProfile } from "../contexts/MiniProfileContext";
+import { toLocalDateStr } from "../lib/format";
+
+interface Props {
+  gridData: GridRow[];
+  loading: boolean;
+  userId: string;
+}
+
+type DeltaKind = "up" | "down" | "same" | "new";
+
+interface AnnotatedCell extends GridCell {
+  deltaKind: DeltaKind;
+  deltaValue: number; // absolute value; 0 for same/new
+}
+
+const TOP_N = 10;
+
+const CELL_SIZE = 54;
+const AVATAR_SIZE = 33;
+const DATE_COL_WIDTH = 56;
+
+export function LeaderboardGrid({ gridData, loading, userId }: Props) {
+  const t = useI18n();
+  const { open: openMiniProfile } = useMiniProfile();
+
+  // Compute rank delta for each cell by comparing with the next row (previous day).
+  // gridData is already sorted by date desc.
+  const annotated = useMemo(() => {
+    return gridData.map((row, rowIdx) => {
+      const prevRow = gridData[rowIdx + 1]; // previous day
+      const prevRankById = new Map<string, number>();
+      if (prevRow) {
+        for (const e of prevRow.entries) prevRankById.set(e.user_id, e.rank);
+      }
+
+      const cells: AnnotatedCell[] = row.entries.map((cell) => {
+        if (!prevRow) {
+          // Oldest day in the window — no prior context, treat as "same"
+          return { ...cell, deltaKind: "same", deltaValue: 0 };
+        }
+        const prevRank = prevRankById.get(cell.user_id);
+        if (prevRank === undefined) {
+          return { ...cell, deltaKind: "new", deltaValue: 0 };
+        }
+        const diff = prevRank - cell.rank; // positive = moved up
+        if (diff > 0) return { ...cell, deltaKind: "up", deltaValue: diff };
+        if (diff < 0) return { ...cell, deltaKind: "down", deltaValue: -diff };
+        return { ...cell, deltaKind: "same", deltaValue: 0 };
+      });
+
+      return { date: row.date, entries: cells };
+    });
+  }, [gridData]);
+
+  const hasAnyData = annotated.some((r) => r.entries.length > 0);
+
+  return (
+    <div style={{
+      background: "var(--bg-card)",
+      borderRadius: "var(--radius-lg)",
+      padding: 10,
+      boxShadow: "var(--shadow-card)",
+      overflowX: "auto",
+    }}>
+      {loading && !hasAnyData ? (
+        <div style={{
+          padding: 20,
+          textAlign: "center",
+          color: "var(--text-secondary)",
+          fontSize: 12,
+          fontWeight: 600,
+        }}>
+          {t("leaderboard.loading")}
+        </div>
+      ) : !hasAnyData ? (
+        <div style={{
+          padding: 20,
+          textAlign: "center",
+          color: "var(--text-secondary)",
+          fontSize: 12,
+          fontWeight: 600,
+        }}>
+          {t("leaderboard.gridEmpty")}
+        </div>
+      ) : (
+        <div style={{
+          display: "inline-block",
+          minWidth: "100%",
+        }}>
+          {/* Header row: rank labels */}
+          <div style={{ display: "flex", alignItems: "center", marginBottom: 6 }}>
+            <div style={{ width: DATE_COL_WIDTH, flexShrink: 0 }} />
+            {Array.from({ length: TOP_N }, (_, i) => (
+              <div
+                key={i}
+                style={{
+                  width: CELL_SIZE,
+                  textAlign: "center",
+                  fontSize: 11,
+                  fontWeight: 700,
+                  color: "var(--text-secondary)",
+                  flexShrink: 0,
+                }}
+              >
+                {i + 1}
+              </div>
+            ))}
+          </div>
+
+          {/* Data rows */}
+          {annotated.map((row) => (
+            <div
+              key={row.date}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                marginBottom: 4,
+              }}
+            >
+              <div style={{
+                width: DATE_COL_WIDTH,
+                flexShrink: 0,
+                fontSize: 12,
+                fontWeight: 700,
+                color: "var(--text-secondary)",
+                paddingRight: 6,
+                textAlign: "right",
+              }}>
+                {formatDateLabel(row.date, t)}
+              </div>
+
+              {Array.from({ length: TOP_N }, (_, rankIdx) => {
+                const cell = row.entries.find((e) => e.rank === rankIdx + 1);
+                if (!cell) {
+                  return (
+                    <div
+                      key={rankIdx}
+                      style={{
+                        width: CELL_SIZE,
+                        height: CELL_SIZE + 10,
+                        flexShrink: 0,
+                      }}
+                    />
+                  );
+                }
+                return (
+                  <Cell
+                    key={rankIdx}
+                    cell={cell}
+                    isMe={cell.user_id === userId}
+                    onClick={() => openMiniProfile({
+                      user_id: cell.user_id,
+                      nickname: cell.nickname,
+                      avatar_url: cell.avatar_url,
+                    })}
+                    t={t}
+                  />
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Cell({
+  cell,
+  isMe,
+  onClick,
+  t,
+}: {
+  cell: AnnotatedCell;
+  isMe: boolean;
+  onClick: () => void;
+  t: (key: string) => string;
+}) {
+  return (
+    <div
+      onClick={onClick}
+      title={cell.nickname}
+      style={{
+        width: CELL_SIZE,
+        height: CELL_SIZE + 14,
+        flexShrink: 0,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "flex-start",
+        cursor: "pointer",
+        borderRadius: 8,
+        background: isMe ? "rgba(124, 92, 252, 0.12)" : "transparent",
+        border: isMe ? "1px solid rgba(124, 92, 252, 0.25)" : "1px solid transparent",
+        padding: 3,
+        boxSizing: "border-box",
+      }}
+    >
+      {cell.avatar_url ? (
+        <img
+          src={cell.avatar_url}
+          alt=""
+          style={{
+            width: AVATAR_SIZE,
+            height: AVATAR_SIZE,
+            borderRadius: AVATAR_SIZE / 2,
+            flexShrink: 0,
+          }}
+        />
+      ) : (
+        <div style={{
+          width: AVATAR_SIZE,
+          height: AVATAR_SIZE,
+          borderRadius: AVATAR_SIZE / 2,
+          background: "var(--heat-1)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontSize: 14,
+          fontWeight: 700,
+          color: "var(--accent-purple)",
+          flexShrink: 0,
+        }}>
+          {cell.nickname.charAt(0).toUpperCase()}
+        </div>
+      )}
+      <DeltaBadge cell={cell} t={t} />
+    </div>
+  );
+}
+
+function DeltaBadge({ cell, t }: { cell: AnnotatedCell; t: (key: string) => string }) {
+  const common: CSSProperties = {
+    fontSize: 8,
+    fontWeight: 800,
+    lineHeight: 1,
+    marginTop: 2,
+    letterSpacing: "-0.02em",
+  };
+
+  if (cell.deltaKind === "new") {
+    return (
+      <span style={{ ...common, color: "var(--accent-purple)" }}>
+        {t("leaderboard.new")}
+      </span>
+    );
+  }
+  if (cell.deltaKind === "up") {
+    return (
+      <span style={{ ...common, color: "var(--accent-mint)" }}>
+        ▲{cell.deltaValue}
+      </span>
+    );
+  }
+  if (cell.deltaKind === "down") {
+    return (
+      <span style={{ ...common, color: "var(--accent-pink)" }}>
+        ▼{cell.deltaValue}
+      </span>
+    );
+  }
+  return (
+    <span style={{ ...common, color: "var(--text-secondary)", opacity: 0.5 }}>
+      —
+    </span>
+  );
+}
+
+function formatDateLabel(dateStr: string, t: (key: string) => string): string {
+  const today = toLocalDateStr(new Date());
+  if (dateStr === today) return t("leaderboard.today");
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+  if (dateStr === toLocalDateStr(yesterday)) return t("leaderboard.yesterday");
+  // MM/DD
+  const [, mm, dd] = dateStr.split("-");
+  return `${mm}/${dd}`;
+}

--- a/src/hooks/useLeaderboardGrid.ts
+++ b/src/hooks/useLeaderboardGrid.ts
@@ -1,0 +1,169 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { supabase } from "../lib/supabase";
+import type { LeaderboardProvider } from "../lib/types";
+import { toLocalDateStr } from "../lib/format";
+
+export interface GridCell {
+  rank: number;
+  user_id: string;
+  nickname: string;
+  avatar_url: string | null;
+  total_tokens: number;
+}
+
+export interface GridRow {
+  date: string; // YYYY-MM-DD, local
+  entries: GridCell[];
+}
+
+interface UseLeaderboardGridProps {
+  provider: LeaderboardProvider;
+  enabled: boolean;
+  days?: number;
+  topN?: number;
+}
+
+interface RpcRow {
+  date: string;
+  rank: number;
+  user_id: string;
+  nickname: string;
+  avatar_url: string | null;
+  total_tokens: number;
+}
+
+const CACHE_TTL = 180_000; // 3 minutes — matches useLeaderboardSync
+const POLL_INTERVAL = 180_000;
+
+export function useLeaderboardGrid({
+  provider,
+  enabled,
+  days = 7,
+  topN = 10,
+}: UseLeaderboardGridProps) {
+  const [gridData, setGridData] = useState<GridRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const cacheRef = useRef<{
+    data: GridRow[];
+    fetchedAt: number;
+    provider: LeaderboardProvider;
+    days: number;
+    topN: number;
+  } | null>(null);
+
+  const fetchGrid = useCallback(async (forceRefresh = false) => {
+    if (!supabase || !enabled) return;
+
+    if (
+      !forceRefresh &&
+      cacheRef.current &&
+      cacheRef.current.provider === provider &&
+      cacheRef.current.days === days &&
+      cacheRef.current.topN === topN &&
+      Date.now() - cacheRef.current.fetchedAt < CACHE_TTL
+    ) {
+      setGridData(cacheRef.current.data);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const now = new Date();
+      const to = toLocalDateStr(now);
+      const fromDate = new Date(now);
+      fromDate.setDate(now.getDate() - (days - 1));
+      const from = toLocalDateStr(fromDate);
+
+      const { data, error } = await supabase.rpc("get_leaderboard_date_grid", {
+        p_provider: provider,
+        p_date_from: from,
+        p_date_to: to,
+        p_top_n: topN,
+      });
+
+      if (error) {
+        console.error("[leaderboard-grid] rpc error:", error);
+        return;
+      }
+      if (!data) {
+        console.warn("[leaderboard-grid] rpc returned no data");
+        return;
+      }
+      console.debug("[leaderboard-grid] rpc rows:", (data as RpcRow[]).length, { provider, from, to, topN });
+
+      // Build a full list of `days` dates (desc), even if a date has no rows.
+      // This keeps the grid shape stable so the UI doesn't jump.
+      const dates: string[] = [];
+      for (let i = 0; i < days; i++) {
+        const d = new Date(now);
+        d.setDate(now.getDate() - i);
+        dates.push(toLocalDateStr(d));
+      }
+
+      const byDate = new Map<string, GridCell[]>();
+      for (const row of data as RpcRow[]) {
+        const cell: GridCell = {
+          rank: row.rank,
+          user_id: row.user_id,
+          nickname: row.nickname,
+          avatar_url: row.avatar_url,
+          total_tokens: Number(row.total_tokens),
+        };
+        const existing = byDate.get(row.date);
+        if (existing) existing.push(cell);
+        else byDate.set(row.date, [cell]);
+      }
+
+      const rows: GridRow[] = dates.map((date) => ({
+        date,
+        entries: (byDate.get(date) ?? []).sort((a, b) => a.rank - b.rank),
+      }));
+
+      setGridData(rows);
+      cacheRef.current = { data: rows, fetchedAt: Date.now(), provider, days, topN };
+    } finally {
+      setLoading(false);
+    }
+  }, [provider, enabled, days, topN]);
+
+  // Initial fetch + visibility-aware polling
+  useEffect(() => {
+    if (!enabled) return;
+    fetchGrid();
+
+    let intervalId: ReturnType<typeof setInterval> | undefined;
+
+    const startPolling = () => {
+      if (intervalId) clearInterval(intervalId);
+      intervalId = setInterval(() => fetchGrid(false), POLL_INTERVAL);
+    };
+
+    const handleVisibility = () => {
+      if (document.hidden) {
+        if (intervalId) { clearInterval(intervalId); intervalId = undefined; }
+      } else {
+        fetchGrid(false);
+        startPolling();
+      }
+    };
+
+    startPolling();
+    document.addEventListener("visibilitychange", handleVisibility);
+
+    return () => {
+      if (intervalId) clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
+  }, [enabled, fetchGrid]);
+
+  // Always invalidate the cache before refetching. When the grid is not
+  // currently enabled (user is on the list tab), fetchGrid() early-returns,
+  // but clearing the cache guarantees the next enable→fetch will read fresh
+  // data instead of a stale TTL-warm entry.
+  const refetch = useCallback(() => {
+    cacheRef.current = null;
+    return fetchGrid(true);
+  }, [fetchGrid]);
+
+  return { gridData, loading, refetch };
+}

--- a/src/hooks/useLeaderboardSync.ts
+++ b/src/hooks/useLeaderboardSync.ts
@@ -20,30 +20,44 @@ interface UseLeaderboardSyncProps {
   user: User | null;
   optedIn: boolean;
   provider: LeaderboardProvider;
+  period: LeaderboardPeriod;
+  /**
+   * Called after a successful snapshot upload. Used by the grid view to
+   * refresh its own data, since `fetchLeaderboard` is a no-op in grid mode.
+   */
+  onAfterUpload?: () => void;
 }
 
 const LEADERBOARD_CACHE_TTL = 180_000; // 3 minutes
 const LEADERBOARD_POLL_INTERVAL = 180_000; // 3 minutes
 const stableDeviceIdCache = new Map<string, string>();
 
-export function useLeaderboardSync({ stats, user, optedIn, provider }: UseLeaderboardSyncProps) {
+export type LeaderboardPeriod = "today" | "week" | "month" | "grid";
+
+export function useLeaderboardSync({ stats, user, optedIn, provider, period, onAfterUpload }: UseLeaderboardSyncProps) {
   const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
-  const [period, setPeriod] = useState<"today" | "week" | "month">("today");
   const [loading, setLoading] = useState(false);
   const [deviceId, setDeviceId] = useState<string | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  // Keep a stable reference to onAfterUpload so the upload effect doesn't
+  // re-run (and restart its debounce) every render when the caller passes
+  // a non-memoized callback.
+  const onAfterUploadRef = useRef(onAfterUpload);
+  useEffect(() => { onAfterUploadRef.current = onAfterUpload; }, [onAfterUpload]);
   // Track which past days (before today) have already been synced this session, per provider
   const syncedPastDatesRef = useRef<Set<string>>(new Set());
   const cacheRef = useRef<{
     data: LeaderboardEntry[];
     fetchedAt: number;
-    period: "today" | "week" | "month";
+    period: LeaderboardPeriod;
     provider: LeaderboardProvider;
   } | null>(null);
 
   // Fetch leaderboard data
   const fetchLeaderboard = useCallback(async (forceRefresh = false) => {
     if (!supabase) return;
+    // Grid view uses a separate hook (useLeaderboardGrid); skip list fetch.
+    if (period === "grid") return;
 
     // Return cached data if still fresh and period+provider match
     if (
@@ -137,7 +151,16 @@ export function useLeaderboardSync({ stats, user, optedIn, provider }: UseLeader
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(async () => {
       await uploadSnapshot(stats, provider, deviceId, syncedPastDatesRef.current);
+      // Always invalidate the list cache so the "other" tab reads fresh data
+      // when the user eventually switches to it. fetchLeaderboard(true) is a
+      // no-op in grid mode due to its early return, so without this line a
+      // grid→list switch within the 3-minute TTL would show stale rankings.
+      cacheRef.current = null;
+      // List view: refresh cached leaderboard immediately (no-op in grid mode).
       fetchLeaderboard(true);
+      // Grid view: the caller's refetch also invalidates its cache, so a
+      // list→grid switch within TTL reads fresh data too.
+      onAfterUploadRef.current?.();
     }, 500);
 
     return () => {
@@ -147,6 +170,9 @@ export function useLeaderboardSync({ stats, user, optedIn, provider }: UseLeader
 
   // Auto-refresh with visibility-aware polling
   useEffect(() => {
+    // Grid view is served by useLeaderboardGrid; skip list polling entirely.
+    if (period === "grid") return;
+
     fetchLeaderboard();
 
     let intervalId: ReturnType<typeof setInterval> | undefined;
@@ -172,7 +198,7 @@ export function useLeaderboardSync({ stats, user, optedIn, provider }: UseLeader
       if (intervalId) clearInterval(intervalId);
       document.removeEventListener("visibilitychange", handleVisibility);
     };
-  }, [fetchLeaderboard]);
+  }, [period, fetchLeaderboard]);
 
   const dateRange = useMemo(() => {
     const now = new Date();
@@ -185,11 +211,16 @@ export function useLeaderboardSync({ stats, user, optedIn, provider }: UseLeader
       monday.setDate(now.getDate() - mondayOffset);
       return { from: toLocalDateStr(monday), to: today };
     }
+    if (period === "grid") {
+      const weekAgo = new Date(now);
+      weekAgo.setDate(now.getDate() - 6);
+      return { from: toLocalDateStr(weekAgo), to: today };
+    }
     const firstOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
     return { from: toLocalDateStr(firstOfMonth), to: today };
   }, [period]);
 
-  return { leaderboard, loading, period, setPeriod, dateRange, refetch: () => fetchLeaderboard(true) };
+  return { leaderboard, loading, dateRange, refetch: () => fetchLeaderboard(true) };
 }
 
 async function uploadSnapshot(

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -86,6 +86,11 @@
   "leaderboard.today": "Heute",
   "leaderboard.thisWeek": "Diese Woche",
   "leaderboard.thisMonth": "Dieser Monat",
+  "leaderboard.grid": "Raster",
+  "leaderboard.gridSubtitle": "Letzte 7 Tage · TOP 10",
+  "leaderboard.gridEmpty": "Noch nicht genug Verlauf",
+  "leaderboard.yesterday": "Gestern",
+  "leaderboard.new": "NEW",
   "leaderboard.you": "(Sie)",
   "leaderboard.msgs": "Nachr.",
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -86,6 +86,11 @@
   "leaderboard.today": "Today",
   "leaderboard.thisWeek": "This Week",
   "leaderboard.thisMonth": "This Month",
+  "leaderboard.grid": "Grid",
+  "leaderboard.gridSubtitle": "Last 7 days · TOP 10",
+  "leaderboard.gridEmpty": "Not enough history yet",
+  "leaderboard.yesterday": "Yesterday",
+  "leaderboard.new": "NEW",
   "leaderboard.you": "(you)",
   "leaderboard.msgs": "msgs",
 

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -86,6 +86,11 @@
   "leaderboard.today": "Hoy",
   "leaderboard.thisWeek": "Esta semana",
   "leaderboard.thisMonth": "Este mes",
+  "leaderboard.grid": "Cuadrícula",
+  "leaderboard.gridSubtitle": "Últimos 7 días · TOP 10",
+  "leaderboard.gridEmpty": "Historial insuficiente",
+  "leaderboard.yesterday": "Ayer",
+  "leaderboard.new": "NEW",
   "leaderboard.you": "(tú)",
   "leaderboard.msgs": "msgs",
 

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -86,6 +86,11 @@
   "leaderboard.today": "Aujourd'hui",
   "leaderboard.thisWeek": "Cette semaine",
   "leaderboard.thisMonth": "Ce mois",
+  "leaderboard.grid": "Grille",
+  "leaderboard.gridSubtitle": "7 derniers jours · TOP 10",
+  "leaderboard.gridEmpty": "Pas encore assez d'historique",
+  "leaderboard.yesterday": "Hier",
+  "leaderboard.new": "NEW",
   "leaderboard.you": "(vous)",
   "leaderboard.msgs": "msgs",
 

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -86,6 +86,11 @@
   "leaderboard.today": "今日",
   "leaderboard.thisWeek": "今週",
   "leaderboard.thisMonth": "今月",
+  "leaderboard.grid": "グリッド",
+  "leaderboard.gridSubtitle": "過去7日間 · TOP 10",
+  "leaderboard.gridEmpty": "まだ記録が足りません",
+  "leaderboard.yesterday": "昨日",
+  "leaderboard.new": "NEW",
   "leaderboard.you": "(あなた)",
   "leaderboard.msgs": "メッセージ",
 

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -86,6 +86,11 @@
   "leaderboard.today": "오늘",
   "leaderboard.thisWeek": "이번 주",
   "leaderboard.thisMonth": "이번 달",
+  "leaderboard.grid": "그리드",
+  "leaderboard.gridSubtitle": "최근 7일 · TOP 10",
+  "leaderboard.gridEmpty": "아직 기록이 부족해요",
+  "leaderboard.yesterday": "어제",
+  "leaderboard.new": "NEW",
   "leaderboard.you": "(나)",
   "leaderboard.msgs": "메시지",
 

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -86,6 +86,11 @@
   "leaderboard.today": "今日",
   "leaderboard.thisWeek": "本周",
   "leaderboard.thisMonth": "本月",
+  "leaderboard.grid": "网格",
+  "leaderboard.gridSubtitle": "最近 7 天 · TOP 10",
+  "leaderboard.gridEmpty": "暂无足够数据",
+  "leaderboard.yesterday": "昨天",
+  "leaderboard.new": "NEW",
   "leaderboard.you": "(你)",
   "leaderboard.msgs": "条消息",
 

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -86,6 +86,11 @@
   "leaderboard.today": "今日",
   "leaderboard.thisWeek": "本週",
   "leaderboard.thisMonth": "本月",
+  "leaderboard.grid": "網格",
+  "leaderboard.gridSubtitle": "最近 7 天 · TOP 10",
+  "leaderboard.gridEmpty": "尚無足夠資料",
+  "leaderboard.yesterday": "昨天",
+  "leaderboard.new": "NEW",
   "leaderboard.you": "(你)",
   "leaderboard.msgs": "則訊息",
 

--- a/supabase/migrations/20260410_leaderboard_date_grid.sql
+++ b/supabase/migrations/20260410_leaderboard_date_grid.sql
@@ -1,0 +1,62 @@
+-- Per-date leaderboard grid: returns top N users for each date in a range.
+-- Used by the "Grid" view in the frontend leaderboard to display rank evolution.
+--
+-- Filter: exclude profiles with leaderboard_hidden = true (admin manual hide).
+-- Mirrors get_leaderboard_entries().
+
+create or replace function get_leaderboard_date_grid(
+  p_provider text,
+  p_date_from date,
+  p_date_to date,
+  p_top_n integer default 10
+) returns table (
+  date date,
+  rank integer,
+  user_id uuid,
+  nickname text,
+  avatar_url text,
+  total_tokens bigint
+)
+language sql
+security definer
+set search_path = public
+as $$
+  with per_date as (
+    select
+      s.date,
+      s.user_id,
+      sum(s.total_tokens)::bigint as total_tokens
+    from daily_snapshots s
+    join profiles p on p.id = s.user_id
+    where s.provider = p_provider
+      and s.date >= p_date_from
+      and s.date <= p_date_to
+      and p.leaderboard_hidden = false
+    group by s.date, s.user_id
+  ),
+  ranked as (
+    select
+      d.date,
+      d.user_id,
+      d.total_tokens,
+      row_number() over (
+        partition by d.date
+        order by d.total_tokens desc, d.user_id
+      )::integer as rank
+    from per_date d
+  )
+  select
+    r.date,
+    r.rank,
+    r.user_id,
+    p.nickname,
+    p.avatar_url,
+    r.total_tokens
+  from ranked r
+  join profiles p on p.id = r.user_id
+  where r.rank <= p_top_n
+  order by r.date desc, r.rank asc;
+$$;
+
+revoke all on function get_leaderboard_date_grid(text, date, date, integer) from public;
+grant execute on function get_leaderboard_date_grid(text, date, date, integer) to authenticated;

--- a/supabase/migrations/20260411000000_remove_leaderboard_outlier_filter.sql
+++ b/supabase/migrations/20260411000000_remove_leaderboard_outlier_filter.sql
@@ -1,0 +1,50 @@
+-- Remove the per-user outlier HAVING filter from get_leaderboard_entries().
+--
+-- Rationale: the tokens/messages > 3000 threshold introduced in
+-- 20260330_leaderboard_hidden.sql turned out to be ineffective in practice.
+-- Claude cache hits naturally inflate the ratio for normal heavy users, so
+-- the filter would either hide legitimate top users or (as actually
+-- happened on our remote) silently not take effect at all. Abuse cases are
+-- now handled exclusively via the manual `profiles.leaderboard_hidden`
+-- admin-hide switch, which this function still respects.
+--
+-- This is a forward migration so it reaches every environment that already
+-- applied 20260330. The new date-grid RPC (20260410_leaderboard_date_grid)
+-- was authored without the outlier filter from the start, so no further
+-- grid-side change is required.
+
+create or replace function get_leaderboard_entries(
+  p_provider text,
+  p_date_from date,
+  p_date_to date
+) returns table (
+  user_id uuid,
+  nickname text,
+  avatar_url text,
+  total_tokens bigint,
+  cost_usd numeric(10,4),
+  messages integer,
+  sessions integer
+)
+language sql
+security definer
+set search_path = public
+as $$
+  select
+    s.user_id,
+    p.nickname,
+    p.avatar_url,
+    sum(s.total_tokens)::bigint as total_tokens,
+    sum(s.cost_usd)::numeric(10,4) as cost_usd,
+    sum(s.messages)::integer as messages,
+    sum(s.sessions)::integer as sessions
+  from daily_snapshots s
+  join profiles p on p.id = s.user_id
+  where s.provider = p_provider
+    and s.date >= p_date_from
+    and s.date <= p_date_to
+    and p.leaderboard_hidden = false
+  group by s.user_id, p.nickname, p.avatar_url
+  order by sum(s.total_tokens) desc, s.user_id
+  limit 200;
+$$;


### PR DESCRIPTION
## Summary

- 기존 today/week/month 리스트 옆에 **Grid 탭** 추가 — 최근 7일 × TOP 10 의 날짜별 순위 흐름을 한눈에 보여주고 일별 등락(▲N/▼N/NEW/—)을 표시
- 신규 RPC `get_leaderboard_date_grid()` + 훅 `useLeaderboardGrid` + 컴포넌트 `LeaderboardGrid` 추가. 3분 TTL 캐시 + visibility-aware 폴링 + 업로드 직후 양방향 캐시 무효화
- 별도 fix 커밋으로 `get_leaderboard_entries()` 의 outlier HAVING 필터(tokens/messages > 3000)를 forward migration 으로 제거. 기존 마이그레이션 파일을 수정하지 않고 신규 `20260411000000_remove_leaderboard_outlier_filter.sql` 로 배포해 기존 환경에도 반영되도록 함

## 변경 파일

**신규**
- `supabase/migrations/20260410_leaderboard_date_grid.sql`
- `supabase/migrations/20260411000000_remove_leaderboard_outlier_filter.sql`
- `src/hooks/useLeaderboardGrid.ts`
- `src/components/LeaderboardGrid.tsx`

**수정**
- `src/hooks/useLeaderboardSync.ts` — period 타입 확장, grid 모드 early return, 업로드 후 캐시 무효화 + onAfterUpload 콜백
- `src/components/Leaderboard.tsx` — period 토글 배열에 grid 추가, 조건부 렌더, useLeaderboardGrid 연결
- i18n 로케일 8개 — `leaderboard.grid` / `gridSubtitle` / `gridEmpty` / `yesterday` / `new`

## Test plan

- [x] `npx tsc --noEmit` 통과
- [x] 원격 Supabase 에 두 마이그레이션 적용 완료 및 RPC 반환 검증 (`list_today=48`, grid 7일×10명)
- [x] Codex 리뷰 2회 (초기 + fix 반영 후 재리뷰)
- [ ] 디버그 앱 Grid 탭: 7×10 테이블 렌더 확인
- [ ] today/week/month 리스트 탭 회귀 확인 (내 순위 카드, 배지 공유, 페이지네이션)
- [ ] 본인 셀 강조 / ▲N·▼N·NEW·— 뱃지 4케이스 모두 표시
- [ ] provider 탭(Claude/Codex/OpenCode) 전환 시 그리드 재로드
- [ ] 업로드 직후 list↔grid 전환 시 stale 데이터 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)