### PR TITLE
fix: MiniProfile 활동 히트맵 60일 히스토리 동기화

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "ai-token-monitor"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { ModelBreakdown } from "./components/ModelBreakdown";
 import { PeriodTotals } from "./components/PeriodTotals";
 import { CacheEfficiency } from "./components/CacheEfficiency";
 import { Leaderboard } from "./components/Leaderboard";
+import { LeaderboardUploader } from "./components/LeaderboardUploader";
 import { ChatRoom } from "./components/ChatRoom";
 import { ActivityGraph } from "./components/ActivityGraph";
 import { SupportBanner } from "./components/SupportBanner";
@@ -177,6 +178,9 @@ function AppContent() {
 
       <SupportBanner />
       <MiniProfile localDaily={stats.daily} currentUserId={user?.id ?? null} />
+      {/* Headless: keeps all enabled providers' snapshot history in sync
+          regardless of whether the Leaderboard tab is open. */}
+      <LeaderboardUploader />
     </PopoverShell>
   );
 }

--- a/src/components/ChatRoom.tsx
+++ b/src/components/ChatRoom.tsx
@@ -385,6 +385,9 @@ function ChatContent({ userId, activated, visible }: { userId: string; activated
 
   const handleReply = useCallback((message: ChatMessage) => {
     setReplyingTo(message);
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+    });
   }, []);
 
   const handleTranslate = useCallback((message: ChatMessage) => {

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useMemo } from "react";
 import { useAuth } from "../hooks/useAuth";
 import { useLeaderboardSync, type LeaderboardPeriod } from "../hooks/useLeaderboardSync";
 import { useLeaderboardGrid } from "../hooks/useLeaderboardGrid";
-import { useTokenStats } from "../hooks/useTokenStats";
 import type { LeaderboardProvider } from "../lib/types";
 import type { User } from "@supabase/supabase-js";
 import { useSettings } from "../contexts/SettingsContext";
@@ -201,26 +200,19 @@ function ProviderLeaderboard({
   user: User;
 }) {
   const t = useI18n();
-  const { stats } = useTokenStats(provider);
   const [period, setPeriod] = useState<LeaderboardPeriod>("today");
   const {
     gridData,
     loading: gridLoading,
-    refetch: refetchGrid,
   } = useLeaderboardGrid({
     provider,
-    // Only poll while the user is looking at the grid; onAfterUpload below
-    // still fires for this hook but becomes a no-op when disabled, which is
-    // fine because the cache will be repopulated on the next grid tab entry.
+    // Only poll while the user is looking at the grid; the grid hook itself
+    // listens for snapshot upload events and refreshes on its own.
     enabled: period === "grid",
   });
   const { leaderboard, loading, dateRange } = useLeaderboardSync({
-    stats,
-    user,
-    optedIn: true,
     provider,
     period,
-    onAfterUpload: refetchGrid,
   });
 
   const [page, setPage] = useState(0);

--- a/src/components/LeaderboardUploader.tsx
+++ b/src/components/LeaderboardUploader.tsx
@@ -1,0 +1,52 @@
+import { useTokenStats } from "../hooks/useTokenStats";
+import { useSnapshotUploader } from "../hooks/useSnapshotUploader";
+import { useAuth } from "../hooks/useAuth";
+import { useSettings } from "../contexts/SettingsContext";
+
+/**
+ * Headless component that keeps each enabled provider's 60-day snapshot
+ * history in sync with Supabase, regardless of which tab the user is
+ * currently viewing.
+ *
+ * This exists because the per-provider upload used to live inside
+ * `useLeaderboardSync`, which only mounts when the user opens the
+ * Leaderboard tab *and* selects a particular provider. As a result most
+ * users only ever uploaded a handful of days, and the MiniProfile "활동
+ * (8주)" heatmap showed up empty for anyone who wasn't an active leaderboard
+ * visitor. Moving the uploader to the App level fixes that without forcing
+ * the Leaderboard UI to mount.
+ *
+ * Renders nothing.
+ */
+export function LeaderboardUploader() {
+  const { user } = useAuth();
+  const { prefs } = useSettings();
+  const optedIn = !!prefs.leaderboard_opted_in;
+
+  // Stats hooks are always called (rules of hooks) but uploads are gated by
+  // `optedIn` and each provider's include flag inside `useSnapshotUploader`.
+  const { stats: claudeStats } = useTokenStats("claude");
+  const { stats: codexStats } = useTokenStats("codex");
+  const { stats: opencodeStats } = useTokenStats("opencode");
+
+  useSnapshotUploader({
+    stats: prefs.include_claude ? claudeStats : null,
+    user,
+    optedIn,
+    provider: "claude",
+  });
+  useSnapshotUploader({
+    stats: prefs.include_codex ? codexStats : null,
+    user,
+    optedIn,
+    provider: "codex",
+  });
+  useSnapshotUploader({
+    stats: prefs.include_opencode ? opencodeStats : null,
+    user,
+    optedIn,
+    provider: "opencode",
+  });
+
+  return null;
+}

--- a/src/hooks/useLeaderboardGrid.ts
+++ b/src/hooks/useLeaderboardGrid.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { supabase } from "../lib/supabase";
 import type { LeaderboardProvider } from "../lib/types";
 import { toLocalDateStr } from "../lib/format";
+import { SNAPSHOT_UPLOADED_EVENT, type SnapshotUploadedDetail } from "./useSnapshotUploader";
 
 export interface GridCell {
   rank: number;
@@ -164,6 +165,20 @@ export function useLeaderboardGrid({
     cacheRef.current = null;
     return fetchGrid(true);
   }, [fetchGrid]);
+
+  // Refresh when a snapshot upload for this provider completes. The upload
+  // itself runs at the App level via `useSnapshotUploader`; this listener
+  // keeps the grid view in sync when the user is looking at it.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<SnapshotUploadedDetail>).detail;
+      if (detail?.provider !== provider) return;
+      cacheRef.current = null;
+      if (enabled) fetchGrid(true);
+    };
+    window.addEventListener(SNAPSHOT_UPLOADED_EVENT, handler);
+    return () => window.removeEventListener(SNAPSHOT_UPLOADED_EVENT, handler);
+  }, [provider, enabled, fetchGrid]);
 
   return { gridData, loading, refetch };
 }

--- a/src/hooks/useLeaderboardSync.ts
+++ b/src/hooks/useLeaderboardSync.ts
@@ -1,9 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import { supabase } from "../lib/supabase";
-import type { AllStats, LeaderboardProvider } from "../lib/types";
-import { getTotalTokens, toLocalDateStr } from "../lib/format";
-import type { User } from "@supabase/supabase-js";
+import type { LeaderboardProvider } from "../lib/types";
+import { toLocalDateStr } from "../lib/format";
+import { SNAPSHOT_UPLOADED_EVENT, type SnapshotUploadedDetail } from "./useSnapshotUploader";
 
 export interface LeaderboardEntry {
   user_id: string;
@@ -16,36 +15,18 @@ export interface LeaderboardEntry {
 }
 
 interface UseLeaderboardSyncProps {
-  stats: AllStats | null;
-  user: User | null;
-  optedIn: boolean;
   provider: LeaderboardProvider;
   period: LeaderboardPeriod;
-  /**
-   * Called after a successful snapshot upload. Used by the grid view to
-   * refresh its own data, since `fetchLeaderboard` is a no-op in grid mode.
-   */
-  onAfterUpload?: () => void;
 }
 
 const LEADERBOARD_CACHE_TTL = 180_000; // 3 minutes
 const LEADERBOARD_POLL_INTERVAL = 180_000; // 3 minutes
-const stableDeviceIdCache = new Map<string, string>();
 
 export type LeaderboardPeriod = "today" | "week" | "month" | "grid";
 
-export function useLeaderboardSync({ stats, user, optedIn, provider, period, onAfterUpload }: UseLeaderboardSyncProps) {
+export function useLeaderboardSync({ provider, period }: UseLeaderboardSyncProps) {
   const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
   const [loading, setLoading] = useState(false);
-  const [deviceId, setDeviceId] = useState<string | null>(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  // Keep a stable reference to onAfterUpload so the upload effect doesn't
-  // re-run (and restart its debounce) every render when the caller passes
-  // a non-memoized callback.
-  const onAfterUploadRef = useRef(onAfterUpload);
-  useEffect(() => { onAfterUploadRef.current = onAfterUpload; }, [onAfterUpload]);
-  // Track which past days (before today) have already been synced this session, per provider
-  const syncedPastDatesRef = useRef<Set<string>>(new Set());
   const cacheRef = useRef<{
     data: LeaderboardEntry[];
     fetchedAt: number;
@@ -111,62 +92,20 @@ export function useLeaderboardSync({ stats, user, optedIn, provider, period, onA
     }
   }, [period, provider]);
 
+  // Refresh when a snapshot upload for this provider completes. The upload
+  // itself runs at the App level via `useSnapshotUploader`, so this view
+  // just needs to invalidate its cache so the user's own row reflects the
+  // new numbers immediately instead of waiting for the 3-minute poll.
   useEffect(() => {
-    let cancelled = false;
-
-    if (!user) {
-      setDeviceId(null);
-      return () => {
-        cancelled = true;
-      };
-    }
-
-    const cached = stableDeviceIdCache.get(user.id);
-    if (cached) {
-      setDeviceId(cached);
-      return () => {
-        cancelled = true;
-      };
-    }
-
-    invoke<string>("get_stable_device_id", { userId: user.id })
-      .then((derivedId) => {
-        if (cancelled) return;
-        stableDeviceIdCache.set(user.id, derivedId);
-        setDeviceId(derivedId);
-      })
-      .catch(() => {
-        if (!cancelled) setDeviceId(null);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [user?.id]);
-
-  // Upload snapshot (debounced), then immediately refresh leaderboard
-  useEffect(() => {
-    if (!supabase || !user || !optedIn || !stats || !deviceId) return;
-
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(async () => {
-      await uploadSnapshot(stats, provider, deviceId, syncedPastDatesRef.current);
-      // Always invalidate the list cache so the "other" tab reads fresh data
-      // when the user eventually switches to it. fetchLeaderboard(true) is a
-      // no-op in grid mode due to its early return, so without this line a
-      // grid→list switch within the 3-minute TTL would show stale rankings.
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<SnapshotUploadedDetail>).detail;
+      if (detail?.provider !== provider) return;
       cacheRef.current = null;
-      // List view: refresh cached leaderboard immediately (no-op in grid mode).
       fetchLeaderboard(true);
-      // Grid view: the caller's refetch also invalidates its cache, so a
-      // list→grid switch within TTL reads fresh data too.
-      onAfterUploadRef.current?.();
-    }, 500);
-
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [stats, user, optedIn, provider, deviceId, fetchLeaderboard]);
+    window.addEventListener(SNAPSHOT_UPLOADED_EVENT, handler);
+    return () => window.removeEventListener(SNAPSHOT_UPLOADED_EVENT, handler);
+  }, [provider, fetchLeaderboard]);
 
   // Auto-refresh with visibility-aware polling
   useEffect(() => {
@@ -221,76 +160,4 @@ export function useLeaderboardSync({ stats, user, optedIn, provider, period, onA
   }, [period]);
 
   return { leaderboard, loading, dateRange, refetch: () => fetchLeaderboard(true) };
-}
-
-async function uploadSnapshot(
-  stats: AllStats,
-  provider: LeaderboardProvider,
-  deviceId: string,
-  syncedPastDates: Set<string>,
-) {
-  if (!supabase) return;
-
-  const now = new Date();
-  const today = toLocalDateStr(now);
-  const dow = now.getDay();
-  const mondayOffset = dow === 0 ? 6 : dow - 1;
-  const monday = new Date(now);
-  monday.setDate(now.getDate() - mondayOffset);
-  const weekStart = toLocalDateStr(monday);
-  const firstOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
-  const monthStart = toLocalDateStr(firstOfMonth);
-  const syncStart = monthStart < weekStart ? monthStart : weekStart;
-
-  // Build full list of dates in the sync window (month or week, whichever is earlier)
-  const allDatesInWindow: string[] = [];
-  const cursor = new Date(syncStart);
-  while (toLocalDateStr(cursor) <= today) {
-    allDatesInWindow.push(toLocalDateStr(cursor));
-    cursor.setDate(cursor.getDate() + 1);
-  }
-
-  // Dates that have local data within the sync window
-  const localDatesInWindow = new Set(
-    stats.daily
-      .filter((d) => d.date >= syncStart && d.date <= today)
-      .map((d) => d.date)
-  );
-
-  // Delete stale rows (dates in sync window with no local data)
-  const cleanKey = (date: string) => `${provider}:clean:${date}`;
-  const staleDates = allDatesInWindow.filter((d) => !localDatesInWindow.has(d));
-  const toClean = staleDates.filter((d) => !syncedPastDates.has(cleanKey(d)));
-
-  if (localDatesInWindow.has(today)) {
-    syncedPastDates.delete(cleanKey(today));
-  }
-
-  // Always upload today; upload past days only once per session
-  const syncKey = (date: string) => `${provider}:${date}`;
-  const toSync = stats.daily.filter(
-    (d) => d.date >= syncStart && d.date <= today &&
-      (d.date === today || !syncedPastDates.has(syncKey(d.date)))
-  );
-  if (toSync.length === 0 && toClean.length === 0) return;
-
-  const rows = toSync.map((d) => ({
-    date: d.date,
-    total_tokens: getTotalTokens(d.tokens),
-    cost_usd: d.cost_usd,
-    messages: d.messages,
-    sessions: d.sessions,
-  }));
-
-  const { error } = await supabase.rpc("sync_device_snapshots", {
-    p_provider: provider,
-    p_device_id: deviceId,
-    p_rows: rows,
-    p_stale_dates: toClean,
-  });
-
-  if (!error) {
-    toClean.forEach((d) => syncedPastDates.add(cleanKey(d)));
-    toSync.forEach((d) => { if (d.date !== today) syncedPastDates.add(syncKey(d.date)); });
-  }
 }

--- a/src/hooks/useSnapshotUploader.ts
+++ b/src/hooks/useSnapshotUploader.ts
@@ -1,0 +1,174 @@
+import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { supabase } from "../lib/supabase";
+import type { AllStats, LeaderboardProvider } from "../lib/types";
+import { getTotalTokens, toLocalDateStr } from "../lib/format";
+import type { User } from "@supabase/supabase-js";
+
+interface UseSnapshotUploaderProps {
+  stats: AllStats | null;
+  user: User | null;
+  optedIn: boolean;
+  provider: LeaderboardProvider;
+}
+
+/**
+ * Custom event dispatched after a successful snapshot upload. Leaderboard
+ * display hooks listen for this to invalidate their caches and refetch.
+ */
+export const SNAPSHOT_UPLOADED_EVENT = "leaderboard-snapshot-uploaded";
+
+export interface SnapshotUploadedDetail {
+  provider: LeaderboardProvider;
+}
+
+// Shared caches so multiple uploader instances (e.g. one per provider)
+// don't re-derive device IDs or re-upload the same past days.
+const stableDeviceIdCache = new Map<string, string>();
+const syncedPastDatesPerProvider = new Map<LeaderboardProvider, Set<string>>();
+
+function getSyncedPastDates(provider: LeaderboardProvider): Set<string> {
+  let set = syncedPastDatesPerProvider.get(provider);
+  if (!set) {
+    set = new Set<string>();
+    syncedPastDatesPerProvider.set(provider, set);
+  }
+  return set;
+}
+
+/**
+ * Uploads the user's daily snapshot for a given provider to Supabase,
+ * decoupled from the Leaderboard UI. This hook is mounted at the App level
+ * (via `LeaderboardUploader`) so every opted-in provider keeps its 60-day
+ * history in sync — even if the user never opens the Leaderboard tab.
+ *
+ * Why this matters: the MiniProfile heatmap for *other* users reads from
+ * `daily_snapshots` via `get_user_activity`. If snapshot upload is gated on
+ * Leaderboard tab visits, most users only ever upload a few days and the
+ * heatmap shows up empty for everyone else.
+ */
+export function useSnapshotUploader({ stats, user, optedIn, provider }: UseSnapshotUploaderProps) {
+  const [deviceId, setDeviceId] = useState<string | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  // Resolve stable device id once per user
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!user) {
+      setDeviceId(null);
+      return () => { cancelled = true; };
+    }
+
+    const cached = stableDeviceIdCache.get(user.id);
+    if (cached) {
+      setDeviceId(cached);
+      return () => { cancelled = true; };
+    }
+
+    invoke<string>("get_stable_device_id", { userId: user.id })
+      .then((derivedId) => {
+        if (cancelled) return;
+        stableDeviceIdCache.set(user.id, derivedId);
+        setDeviceId(derivedId);
+      })
+      .catch(() => {
+        if (!cancelled) setDeviceId(null);
+      });
+
+    return () => { cancelled = true; };
+  }, [user?.id]);
+
+  // Debounced upload whenever stats change
+  useEffect(() => {
+    if (!supabase || !user || !optedIn || !stats || !deviceId) return;
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      const ok = await uploadSnapshot(stats, provider, deviceId, getSyncedPastDates(provider));
+      if (ok) {
+        window.dispatchEvent(
+          new CustomEvent<SnapshotUploadedDetail>(SNAPSHOT_UPLOADED_EVENT, {
+            detail: { provider },
+          }),
+        );
+      }
+    }, 500);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [stats, user, optedIn, provider, deviceId]);
+}
+
+async function uploadSnapshot(
+  stats: AllStats,
+  provider: LeaderboardProvider,
+  deviceId: string,
+  syncedPastDates: Set<string>,
+): Promise<boolean> {
+  if (!supabase) return false;
+
+  const now = new Date();
+  const today = toLocalDateStr(now);
+  // Sync the last 60 days so the MiniProfile 8-week heatmap has full history
+  // for *every* user, not just whoever opened the app this month. Past dates
+  // are still uploaded only once per session via syncedPastDates, so the
+  // wider window only affects the first sync after launch.
+  const windowStartDate = new Date(now);
+  windowStartDate.setDate(now.getDate() - 59);
+  const syncStart = toLocalDateStr(windowStartDate);
+
+  // Build full list of dates in the sync window (last 60 days)
+  const allDatesInWindow: string[] = [];
+  const cursor = new Date(syncStart);
+  while (toLocalDateStr(cursor) <= today) {
+    allDatesInWindow.push(toLocalDateStr(cursor));
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  // Dates that have local data within the sync window
+  const localDatesInWindow = new Set(
+    stats.daily
+      .filter((d) => d.date >= syncStart && d.date <= today)
+      .map((d) => d.date),
+  );
+
+  // Delete stale rows (dates in sync window with no local data)
+  const cleanKey = (date: string) => `${provider}:clean:${date}`;
+  const staleDates = allDatesInWindow.filter((d) => !localDatesInWindow.has(d));
+  const toClean = staleDates.filter((d) => !syncedPastDates.has(cleanKey(d)));
+
+  if (localDatesInWindow.has(today)) {
+    syncedPastDates.delete(cleanKey(today));
+  }
+
+  // Always upload today; upload past days only once per session
+  const syncKey = (date: string) => `${provider}:${date}`;
+  const toSync = stats.daily.filter(
+    (d) => d.date >= syncStart && d.date <= today &&
+      (d.date === today || !syncedPastDates.has(syncKey(d.date))),
+  );
+  if (toSync.length === 0 && toClean.length === 0) return false;
+
+  const rows = toSync.map((d) => ({
+    date: d.date,
+    total_tokens: getTotalTokens(d.tokens),
+    cost_usd: d.cost_usd,
+    messages: d.messages,
+    sessions: d.sessions,
+  }));
+
+  const { error } = await supabase.rpc("sync_device_snapshots", {
+    p_provider: provider,
+    p_device_id: deviceId,
+    p_rows: rows,
+    p_stale_dates: toClean,
+  });
+
+  if (error) return false;
+
+  toClean.forEach((d) => syncedPastDates.add(cleanKey(d)));
+  toSync.forEach((d) => { if (d.date !== today) syncedPastDates.add(syncKey(d.date)); });
+  return true;
+}

--- a/src/hooks/useUserActivity.ts
+++ b/src/hooks/useUserActivity.ts
@@ -36,16 +36,12 @@ export function useUserActivity(userId: string | null) {
     setLoading(true);
     setError(false);
 
-    const eightWeeksAgo = new Date();
-    eightWeeksAgo.setDate(eightWeeksAgo.getDate() - 56);
-    const dateFrom = eightWeeksAgo.toISOString().slice(0, 10);
-
+    // Use security-definer RPC instead of direct SELECT so the query works
+    // regardless of daily_snapshots RLS state, and stays consistent with
+    // leaderboard_hidden filtering applied elsewhere. Server aggregates across
+    // providers, so no client-side byDate loop is needed.
     supabase
-      .from("daily_snapshots")
-      .select("date, total_tokens, cost_usd, messages, sessions")
-      .eq("user_id", userId)
-      .gte("date", dateFrom)
-      .order("date", { ascending: true })
+      .rpc("get_user_activity", { p_user_id: userId, p_weeks: 8 })
       .then(({ data, error: err }) => {
         if (cancelled) return;
 
@@ -55,23 +51,18 @@ export function useUserActivity(userId: string | null) {
           return;
         }
 
-        // Aggregate across providers per date
-        const byDate = new Map<string, { tokens: number; cost: number; messages: number; sessions: number }>();
-        for (const row of data) {
-          const existing = byDate.get(row.date) ?? { tokens: 0, cost: 0, messages: 0, sessions: 0 };
-          existing.tokens += Number(row.total_tokens);
-          existing.cost += Number(row.cost_usd);
-          existing.messages += row.messages;
-          existing.sessions += row.sessions;
-          byDate.set(row.date, existing);
-        }
-
-        const result: DailyUsage[] = Array.from(byDate.entries()).map(([date, agg]) => ({
-          date,
-          tokens: { total: agg.tokens },
-          cost_usd: agg.cost,
-          messages: agg.messages,
-          sessions: agg.sessions,
+        const result: DailyUsage[] = data.map((row: {
+          date: string;
+          total_tokens: number | string;
+          cost_usd: number | string;
+          messages: number;
+          sessions: number;
+        }) => ({
+          date: row.date,
+          tokens: { total: Number(row.total_tokens) },
+          cost_usd: Number(row.cost_usd),
+          messages: row.messages,
+          sessions: row.sessions,
           tool_calls: 0,
           input_tokens: 0,
           output_tokens: 0,

--- a/supabase/migrations/20260411010000_add_get_user_activity.sql
+++ b/supabase/migrations/20260411010000_add_get_user_activity.sql
@@ -1,0 +1,40 @@
+-- Per-user activity (last N weeks) for MiniProfile heatmap.
+-- Mirrors leaderboard RPC pattern: security definer to bypass direct-table RLS,
+-- respects leaderboard_hidden for consistency with leaderboard policies.
+--
+-- Why: the frontend previously did a direct SELECT on daily_snapshots from
+-- useUserActivity.ts, which is the ONLY direct-select path on that table.
+-- Production RLS/GRANT drift made other users' rows invisible while the
+-- reporter's own profile kept working (it reads from local Rust stats, not DB).
+
+create or replace function get_user_activity(
+  p_user_id uuid,
+  p_weeks integer default 8
+) returns table (
+  date date,
+  total_tokens bigint,
+  cost_usd numeric(10,4),
+  messages integer,
+  sessions integer
+)
+language sql
+security definer
+set search_path = public
+as $$
+  select
+    s.date,
+    sum(s.total_tokens)::bigint as total_tokens,
+    sum(s.cost_usd)::numeric(10,4) as cost_usd,
+    sum(s.messages)::integer as messages,
+    sum(s.sessions)::integer as sessions
+  from daily_snapshots s
+  join profiles p on p.id = s.user_id
+  where s.user_id = p_user_id
+    and p.leaderboard_hidden = false
+    and s.date >= current_date - (p_weeks * 7 - 1)
+  group by s.date
+  order by s.date asc;
+$$;
+
+revoke all on function get_user_activity(uuid, integer) from public;
+grant execute on function get_user_activity(uuid, integer) to authenticated;


### PR DESCRIPTION
## Summary

- 타인 프로필의 **"활동 (8주)" 히트맵이 비어 보이던 버그**를 구조적으로 해결
- 업로드 훅을 App 레벨로 끌어올려 리더보드 탭 방문 여부와 무관하게 3개 provider 모두 60일 윈도우로 동기화
- `get_user_activity` security-definer RPC 추가로 RLS/정책 드리프트 영향 제거 및 `leaderboard_hidden` 필터 일관성 확보

## 근본 원인

두 가지 문제가 겹쳐서 발생:

1. **업로드 윈도우가 너무 좁고 게이팅됨**
   - `useLeaderboardSync` 안의 `uploadSnapshot`은 Leaderboard 컴포넌트가 마운트되어야 실행
   - 윈도우가 `min(weekStart, monthStart)` — 월초~오늘 정도만 업로드
   - 결과: 활성 사용자라도 `daily_snapshots`에 10~20일치 행만 존재, 8주 히트맵에서 대부분 빈 칸

2. **조회 경로가 RLS에 취약**
   - `useUserActivity`가 `daily_snapshots`를 **direct SELECT**로 조회 (프론트에서 이 테이블을 직접 SELECT하는 유일한 경로)
   - 프로덕션 RLS/GRANT가 migration과 벌어졌을 경우 추가로 비어보임

## 변경 내용

### 1. `useSnapshotUploader` 훅 분리 + `LeaderboardUploader` headless 컴포넌트
- 업로드 로직을 `useSnapshotUploader.ts`로 분리
- `LeaderboardUploader.tsx`가 App 레벨에서 3개 provider(`claude`, `codex`, `opencode`)의 업로드를 항상 구동
- 업로드 윈도우를 **최근 60일**로 확장 — MiniProfile의 8주 히트맵에 충분한 히스토리 확보
- 업로드 성공 시 `SNAPSHOT_UPLOADED_EVENT` custom event 브로드캐스트
- `useLeaderboardSync` / `useLeaderboardGrid`는 이벤트를 구독해 캐시 무효화 후 재조회

### 2. `get_user_activity` RPC 신설 + `useUserActivity` 교체
- `20260411010000_add_get_user_activity.sql`
  - `security definer`로 RLS 우회 (리더보드 RPC와 동일 패턴)
  - `leaderboard_hidden = false` 일관 적용
  - 서버 사이드 provider 집계
- `useUserActivity`는 direct SELECT를 버리고 이 RPC를 호출
- 클라이언트 측 byDate aggregation 루프 제거

## 검증

프로덕션 Supabase RPC를 curl로 직접 호출해 정상 동작 확인:

| user | days | earliest | 비고 |
|---|---|---|---|
| **soulduse (신 클라이언트)** | **56일** | **2026-02-15** | 정확히 8주 풀 |
| dokdo2013 | 11 | 2026-04-01 | 구 clients monthStart |
| daylab-official | 13 | 2026-03-30 | 구 client weekStart |
| shindonghwi | 20 | 2026-03-23 | 구 client weekStart |

신 클라이언트를 돌린 본인 계정만 56일 풀, 나머지는 전부 구 클라이언트 윈도우 경계와 일치 → **이 릴리즈가 배포되면 사용자들이 앱 한 번 열 때마다 자동으로 60일로 확장됨**.

## 번들된 부수 커밋

`703cc19 fix: 채팅 답글 버튼 클릭 시 입력창 자동 포커스` — main 로컬에 이미 있던 소형 채팅 UX 수정이 이 PR에도 포함됨.

## Test plan

- [ ] 릴리즈 후 본인 앱에서 MiniProfile을 열어 8주 히트맵이 full로 채워지는지 확인
- [ ] 리더보드에서 타인 프로필 클릭 → 활동 그리드 렌더 확인 (구 client 사용자는 여전히 sparse, 업데이트한 사용자는 점진적으로 full)
- [ ] 채팅에서 타인 아바타 클릭 → 활동 그리드 렌더 확인
- [ ] 본인 프로필(isMe 분기) regression 없는지 확인 — `stats.daily` 로컬 데이터 그대로 사용
- [ ] 숨김 유저(`leaderboard_hidden = true`)는 빈 그리드가 나오는지

## 배포 후 후속 작업

- Supabase Studio에서 `20260411010000_add_get_user_activity.sql` 마이그레이션 적용 확인 (이미 배포되어 있음 — curl 검증 완료)
- 릴리즈 후 며칠 내 리더보드 상위 사용자들의 days 카운트가 60일로 수렴하는지 모니터링

🤖 Generated with [Claude Code](https://claude.com/claude-code)