### PR TITLE
feat: 앱 공유 버튼 추가 + 'AI Wrapped' 라벨을 '나의 AI 리포트'로 변경

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "ai-token-monitor"
-version = "0.18.0"
+version = "0.18.2"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -101,6 +101,12 @@ export function Header({ stats, updater }: Props) {
     });
   }, [stats]);
 
+  const handleShareApp = useCallback(() => {
+    writeText(t("share.appMessage")).then(() => {
+      showToast(t("share.copied"));
+    });
+  }, [t, showToast]);
+
   const menuItems: {
     key: string;
     label: string;
@@ -233,6 +239,32 @@ export function Header({ stats, updater }: Props) {
           )}
         </div>
       </div>
+
+      {/* Share app button */}
+      <button
+        onClick={handleShareApp}
+        title={t("header.share")}
+        style={{
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          padding: 4,
+          borderRadius: 6,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "var(--text-secondary)",
+          transition: "color 0.2s ease",
+        }}
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="18" cy="5" r="3"/>
+          <circle cx="6" cy="12" r="3"/>
+          <circle cx="18" cy="19" r="3"/>
+          <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/>
+          <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
+        </svg>
+      </button>
 
       {/* Actions menu (collapsed dropdown) */}
       <div ref={menuRef} style={{ position: "relative" }}>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -95,7 +95,10 @@
   "leaderboard.msgs": "Nachr.",
 
   "header.menu": "Mehr",
+  "header.share": "App teilen",
   "header.github": "GitHub-Repository anzeigen",
+  "share.appMessage": "Behalte deinen Claude Code- und Codex-Token-Verbrauch mit AI Token Monitor im Blick — einer kostenlosen macOS/Windows-Taskleisten-App!\nhttps://github.com/soulduse/ai-token-monitor",
+  "share.copied": "Teilen-Nachricht kopiert!",
   "header.copySummary": "Zusammenfassung in Zwischenablage kopieren",
   "header.captureScreenshot": "Screenshot in Zwischenablage erfassen",
   "header.settings": "Einstellungen",
@@ -137,7 +140,7 @@
 
   "support.buyMeCoffee": "Kaffee spendieren",
 
-  "wrapped.title": "AI Wrapped",
+  "wrapped.title": "Mein KI-Bericht",
   "wrapped.month": "Diesen Monat",
   "wrapped.year": "Dieses Jahr",
   "wrapped.totalCost": "Ausgaben für AI-Coding",
@@ -149,7 +152,7 @@
   "wrapped.streakDays": "Tage am Stück",
   "wrapped.currentStreak": "Aktuelle Serie",
   "wrapped.longestStreak": "Längste Serie",
-  "wrapped.summary": "Dein AI Wrapped",
+  "wrapped.summary": "Dein KI-Bericht",
   "wrapped.summaryTokens": "Tokens",
   "wrapped.summaryCost": "Kosten",
   "wrapped.summaryMessages": "Nachrichten",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -95,7 +95,10 @@
   "leaderboard.msgs": "msgs",
 
   "header.menu": "More",
+  "header.share": "Share this app",
   "header.github": "View GitHub repository",
+  "share.appMessage": "Track your Claude Code and Codex token usage at a glance with AI Token Monitor — a free macOS/Windows tray app!\nhttps://github.com/soulduse/ai-token-monitor",
+  "share.copied": "Share message copied!",
   "header.copySummary": "Copy summary to clipboard",
   "header.captureScreenshot": "Capture screenshot to clipboard",
   "header.settings": "Settings",
@@ -137,7 +140,7 @@
 
   "support.buyMeCoffee": "Buy me a coffee",
 
-  "wrapped.title": "AI Wrapped",
+  "wrapped.title": "My AI Report",
   "wrapped.month": "This Month",
   "wrapped.year": "This Year",
   "wrapped.totalCost": "You spent on AI coding",
@@ -149,7 +152,7 @@
   "wrapped.streakDays": "days straight",
   "wrapped.currentStreak": "Current streak",
   "wrapped.longestStreak": "Longest streak ever",
-  "wrapped.summary": "Your AI Wrapped",
+  "wrapped.summary": "Your AI Report",
   "wrapped.summaryTokens": "Tokens",
   "wrapped.summaryCost": "Cost",
   "wrapped.summaryMessages": "Messages",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -95,7 +95,10 @@
   "leaderboard.msgs": "msgs",
 
   "header.menu": "Más",
+  "header.share": "Compartir esta app",
   "header.github": "Ver repositorio de GitHub",
+  "share.appMessage": "¡Sigue el uso de tokens de Claude Code y Codex de un vistazo con AI Token Monitor, una app gratuita de bandeja para macOS/Windows!\nhttps://github.com/soulduse/ai-token-monitor",
+  "share.copied": "¡Mensaje de compartir copiado!",
   "header.copySummary": "Copiar resumen al portapapeles",
   "header.captureScreenshot": "Capturar pantalla al portapapeles",
   "header.settings": "Configuración",
@@ -137,7 +140,7 @@
 
   "support.buyMeCoffee": "Invítame un café",
 
-  "wrapped.title": "AI Wrapped",
+  "wrapped.title": "Mi informe de IA",
   "wrapped.month": "Este mes",
   "wrapped.year": "Este año",
   "wrapped.totalCost": "Gastaste en codificación IA",
@@ -149,7 +152,7 @@
   "wrapped.streakDays": "días seguidos",
   "wrapped.currentStreak": "Racha actual",
   "wrapped.longestStreak": "Racha más larga",
-  "wrapped.summary": "Tu AI Wrapped",
+  "wrapped.summary": "Tu informe de IA",
   "wrapped.summaryTokens": "Tokens",
   "wrapped.summaryCost": "Costo",
   "wrapped.summaryMessages": "Mensajes",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -95,7 +95,10 @@
   "leaderboard.msgs": "msgs",
 
   "header.menu": "Plus",
+  "header.share": "Partager cette app",
   "header.github": "Voir le dépôt GitHub",
+  "share.appMessage": "Suivez l'utilisation de vos jetons Claude Code et Codex en un coup d'œil avec AI Token Monitor — une app barre des tâches macOS/Windows gratuite !\nhttps://github.com/soulduse/ai-token-monitor",
+  "share.copied": "Message de partage copié !",
   "header.copySummary": "Copier le résumé dans le presse-papiers",
   "header.captureScreenshot": "Capturer la capture d'écran dans le presse-papiers",
   "header.settings": "Paramètres",
@@ -137,7 +140,7 @@
 
   "support.buyMeCoffee": "Offrez-moi un café",
 
-  "wrapped.title": "AI Wrapped",
+  "wrapped.title": "Mon rapport IA",
   "wrapped.month": "Ce mois",
   "wrapped.year": "Cette année",
   "wrapped.totalCost": "Dépenses en codage IA",
@@ -149,7 +152,7 @@
   "wrapped.streakDays": "jours consécutifs",
   "wrapped.currentStreak": "Série en cours",
   "wrapped.longestStreak": "Plus longue série",
-  "wrapped.summary": "Votre AI Wrapped",
+  "wrapped.summary": "Votre rapport IA",
   "wrapped.summaryTokens": "Tokens",
   "wrapped.summaryCost": "Coût",
   "wrapped.summaryMessages": "Messages",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -95,7 +95,10 @@
   "leaderboard.msgs": "メッセージ",
 
   "header.menu": "もっと見る",
+  "header.share": "アプリを共有",
   "header.github": "GitHubリポジトリを表示",
+  "share.appMessage": "Claude CodeとCodexのトークン使用量を一目で確認できる無料のmacOS/Windowsトレイアプリ「AI Token Monitor」がおすすめです！\nhttps://github.com/soulduse/ai-token-monitor",
+  "share.copied": "共有メッセージをコピーしました！",
   "header.copySummary": "要約をクリップボードにコピー",
   "header.captureScreenshot": "スクリーンショットをクリップボードにキャプチャ",
   "header.settings": "設定",
@@ -137,7 +140,7 @@
 
   "support.buyMeCoffee": "コーヒーをおごる",
 
-  "wrapped.title": "AI Wrapped",
+  "wrapped.title": "マイAIレポート",
   "wrapped.month": "今月",
   "wrapped.year": "今年",
   "wrapped.totalCost": "AIコーディングに使った費用",
@@ -149,7 +152,7 @@
   "wrapped.streakDays": "日連続",
   "wrapped.currentStreak": "現在進行中",
   "wrapped.longestStreak": "歴代最長記録",
-  "wrapped.summary": "あなたのAI Wrapped",
+  "wrapped.summary": "あなたのAIレポート",
   "wrapped.summaryTokens": "トークン",
   "wrapped.summaryCost": "費用",
   "wrapped.summaryMessages": "メッセージ",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -95,7 +95,10 @@
   "leaderboard.msgs": "메시지",
 
   "header.menu": "더 보기",
+  "header.share": "앱 공유하기",
   "header.github": "GitHub 저장소 보기",
+  "share.appMessage": "Claude Code와 Codex 토큰 사용량을 한눈에 보여주는 트레이 앱, AI Token Monitor 추천해요!\nhttps://github.com/soulduse/ai-token-monitor",
+  "share.copied": "공유 메시지가 복사됐어요!",
   "header.copySummary": "요약을 클립보드에 복사",
   "header.captureScreenshot": "스크린샷을 클립보드에 캡처",
   "header.settings": "설정",
@@ -137,7 +140,7 @@
 
   "support.buyMeCoffee": "커피 한 잔 사주기",
 
-  "wrapped.title": "AI Wrapped",
+  "wrapped.title": "나의 AI 리포트",
   "wrapped.month": "이번 달",
   "wrapped.year": "올해",
   "wrapped.totalCost": "AI 코딩에 사용한 비용",
@@ -149,7 +152,7 @@
   "wrapped.streakDays": "일 연속",
   "wrapped.currentStreak": "현재 진행 중",
   "wrapped.longestStreak": "역대 최장 기록",
-  "wrapped.summary": "나의 AI Wrapped",
+  "wrapped.summary": "나의 AI 리포트",
   "wrapped.summaryTokens": "토큰",
   "wrapped.summaryCost": "비용",
   "wrapped.summaryMessages": "메시지",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -95,7 +95,10 @@
   "leaderboard.msgs": "条消息",
 
   "header.menu": "更多",
+  "header.share": "分享此应用",
   "header.github": "查看 GitHub 仓库",
+  "share.appMessage": "推荐一款让你一目了然查看 Claude Code 和 Codex 令牌使用量的免费 macOS/Windows 托盘应用——AI Token Monitor！\nhttps://github.com/soulduse/ai-token-monitor",
+  "share.copied": "分享内容已复制！",
   "header.copySummary": "复制摘要到剪贴板",
   "header.captureScreenshot": "截图到剪贴板",
   "header.settings": "设置",
@@ -137,7 +140,7 @@
 
   "support.buyMeCoffee": "请我喝杯咖啡",
 
-  "wrapped.title": "AI Wrapped",
+  "wrapped.title": "我的 AI 报告",
   "wrapped.month": "本月",
   "wrapped.year": "今年",
   "wrapped.totalCost": "AI编程花费",
@@ -149,7 +152,7 @@
   "wrapped.streakDays": "天连续",
   "wrapped.currentStreak": "当前进行中",
   "wrapped.longestStreak": "历史最长记录",
-  "wrapped.summary": "你的AI Wrapped",
+  "wrapped.summary": "你的 AI 报告",
   "wrapped.summaryTokens": "令牌",
   "wrapped.summaryCost": "费用",
   "wrapped.summaryMessages": "消息",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -95,7 +95,10 @@
   "leaderboard.msgs": "則訊息",
 
   "header.menu": "更多",
+  "header.share": "分享此應用",
   "header.github": "查看 GitHub 儲存庫",
+  "share.appMessage": "推薦一款讓你一目了然查看 Claude Code 和 Codex 權杖使用量的免費 macOS/Windows 托盤應用——AI Token Monitor！\nhttps://github.com/soulduse/ai-token-monitor",
+  "share.copied": "分享內容已複製！",
   "header.copySummary": "複製摘要到剪貼簿",
   "header.captureScreenshot": "擷取螢幕截圖到剪貼簿",
   "header.settings": "設定",
@@ -137,7 +140,7 @@
 
   "support.buyMeCoffee": "請我喝杯咖啡",
 
-  "wrapped.title": "AI Wrapped",
+  "wrapped.title": "我的 AI 報告",
   "wrapped.month": "本月",
   "wrapped.year": "今年",
   "wrapped.totalCost": "AI程式設計花費",
@@ -149,7 +152,7 @@
   "wrapped.streakDays": "天連續",
   "wrapped.currentStreak": "目前進行中",
   "wrapped.longestStreak": "歷史最長記錄",
-  "wrapped.summary": "你的AI Wrapped",
+  "wrapped.summary": "你的 AI 報告",
   "wrapped.summaryTokens": "令牌",
   "wrapped.summaryCost": "費用",
   "wrapped.summaryMessages": "訊息",


### PR DESCRIPTION
## Summary
- 헤더 우측에 **앱 공유 버튼**(share-2 아이콘) 신규 추가. 클릭 시 각 언어별 추천 문구 + GitHub 저장소 링크를 클립보드로 복사하고 "공유 메시지가 복사됐어요!" 토스트 표시
- `wrapped.title` / `wrapped.summary` 라벨을 **AI Wrapped → 나의 AI 리포트**(각 로케일별 자연스러운 표현)로 교체
  - ko: 나의 AI 리포트
  - en: My AI Report / Your AI Report
  - ja: マイAIレポート / あなたのAIレポート
  - zh-CN: 我的 AI 报告 / 你的 AI 报告
  - zh-TW: 我的 AI 報告 / 你的 AI 報告
  - fr: Mon rapport IA / Votre rapport IA
  - es: Mi informe de IA / Tu informe de IA
  - de: Mein KI-Bericht / Dein KI-Bericht
- `header.share`, `share.appMessage`, `share.copied` 3개 키를 8개 로케일에 추가
- 헤더 구조: `[드래그 타이틀] … [📤 share] [⋯ menu] [⚙ settings]`

## Test plan
- [ ] 공유 버튼 클릭 → 클립보드에 추천 문구 + URL이 정상 복사되는지 확인
- [ ] 토스트 노출 확인
- [ ] 메뉴(⋯) 열었을 때 항목이 "나의 AI 리포트"로 표시되는지 확인
- [ ] 메뉴에서 "나의 AI 리포트" 클릭 → 오버레이의 요약 카드도 "나의 AI 리포트"로 표시되는지 확인
- [ ] 8개 로케일 모두 라벨/문구가 자연스럽게 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)