### PR TITLE
feat: 드롭다운 메뉴 아이템별 바로가기 핀 기능 추가

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "ai-token-monitor"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/src/providers/types.rs
+++ b/src-tauri/src/providers/types.rs
@@ -74,6 +74,8 @@ pub struct UserPreferences {
     pub webhook_config: Option<WebhookConfig>,
     #[serde(default)]
     pub autostart_enabled: bool,
+    #[serde(default)]
+    pub quick_action_items: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -213,6 +215,7 @@ impl Default for UserPreferences {
             ai_model: None,
             webhook_config: None,
             autostart_enabled: false,
+            quick_action_items: vec![],
         }
     }
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,6 +10,7 @@ import type { AllStats } from "../lib/types";
 import type { UpdaterState } from "../hooks/useUpdater";
 import { formatTokens, formatCost, getTotalTokens, toLocalDateStr } from "../lib/format";
 import { useI18n } from "../i18n/I18nContext";
+import { useSettings } from "../contexts/SettingsContext";
 
 interface Props {
   stats?: AllStats | null;
@@ -24,6 +25,15 @@ export function Header({ stats, updater }: Props) {
   const [toast, setToast] = useState<string | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const t = useI18n();
+  const { prefs, updatePrefs } = useSettings();
+
+  const toggleQuickAction = useCallback((key: string) => {
+    const items = prefs.quick_action_items ?? [];
+    const next = items.includes(key)
+      ? items.filter((k) => k !== key)
+      : [...items, key];
+    updatePrefs({ quick_action_items: next });
+  }, [prefs.quick_action_items, updatePrefs]);
 
   // Outside click + ESC to close the actions menu
   useEffect(() => {
@@ -240,6 +250,31 @@ export function Header({ stats, updater }: Props) {
         </div>
       </div>
 
+      {/* Quick action buttons (pinned items) */}
+      {(prefs.quick_action_items ?? []).length > 0 && menuItems
+        .filter((item) => (prefs.quick_action_items ?? []).includes(item.key))
+        .map((item) => (
+          <button
+            key={item.key}
+            onClick={item.onClick}
+            title={item.label}
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              padding: 4,
+              borderRadius: 6,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: "var(--text-secondary)",
+              transition: "color 0.2s ease",
+            }}
+          >
+            {item.icon}
+          </button>
+        ))}
+
       {/* Share app button */}
       <button
         onClick={handleShareApp}
@@ -311,21 +346,67 @@ export function Header({ stats, updater }: Props) {
               animation: "headerMenuPop 0.16s cubic-bezier(.2,.9,.2,1) both",
             }}
           >
-            {menuItems.map((item, i) => (
-              <button
-                key={item.key}
-                role="menuitem"
-                className="header-action-menu-item"
-                onClick={() => {
-                  setShowMenu(false);
-                  item.onClick();
-                }}
-                style={{ animationDelay: `${40 + 35 * i}ms` }}
-              >
-                <span style={{ display: "flex", color: "var(--text-secondary)" }}>{item.icon}</span>
-                <span>{item.label}</span>
-              </button>
-            ))}
+            {menuItems.map((item, i) => {
+              const pinned = (prefs.quick_action_items ?? []).includes(item.key);
+              return (
+                <div
+                  key={item.key}
+                  className="header-action-menu-item"
+                  style={{
+                    animationDelay: `${40 + 35 * i}ms`,
+                    justifyContent: "space-between",
+                  }}
+                >
+                  <button
+                    role="menuitem"
+                    onClick={() => {
+                      setShowMenu(false);
+                      item.onClick();
+                    }}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 10,
+                      background: "none",
+                      border: "none",
+                      padding: 0,
+                      cursor: "pointer",
+                      color: "inherit",
+                      font: "inherit",
+                      flex: 1,
+                      minWidth: 0,
+                    }}
+                  >
+                    <span style={{ display: "flex", color: "var(--text-secondary)" }}>{item.icon}</span>
+                    <span>{item.label}</span>
+                  </button>
+                  <button
+                    aria-label={t("header.quickActions")}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggleQuickAction(item.key);
+                    }}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      background: "none",
+                      border: "none",
+                      padding: 2,
+                      cursor: "pointer",
+                      borderRadius: 4,
+                      color: pinned ? "var(--accent-purple)" : "rgba(128,128,128,0.3)",
+                      transition: "color 0.2s ease",
+                      flexShrink: 0,
+                    }}
+                  >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill={pinned ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+                    </svg>
+                  </button>
+                </div>
+              );
+            })}
           </div>
         )}
       </div>

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -29,6 +29,7 @@ const defaultPrefs: UserPreferences = {
   usage_alerts_enabled: true,
   usage_tracking_enabled: false,
   autostart_enabled: false,
+  quick_action_items: [],
 };
 
 const SettingsContext = createContext<SettingsContextType>({

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -105,6 +105,7 @@
   "header.copied": "In Zwischenablage kopiert!",
   "header.captureFailed": "Erfassung fehlgeschlagen",
   "header.summaryCopied": "Zusammenfassung kopiert!",
+  "header.quickActions": "Schnellzugriff",
 
   "settings.title": "Einstellungen",
   "settings.tab.general": "Allgemein",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -105,6 +105,7 @@
   "header.copied": "Copied to clipboard!",
   "header.captureFailed": "Capture failed",
   "header.summaryCopied": "Summary copied!",
+  "header.quickActions": "Quick Actions",
 
   "settings.title": "Settings",
   "settings.tab.general": "General",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -105,6 +105,7 @@
   "header.copied": "¡Copiado al portapapeles!",
   "header.captureFailed": "Error al capturar",
   "header.summaryCopied": "¡Resumen copiado!",
+  "header.quickActions": "Acceso rápido",
 
   "settings.title": "Configuración",
   "settings.tab.general": "General",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -105,6 +105,7 @@
   "header.copied": "Copié dans le presse-papiers !",
   "header.captureFailed": "Échec de la capture",
   "header.summaryCopied": "Résumé copié !",
+  "header.quickActions": "Accès rapide",
 
   "settings.title": "Paramètres",
   "settings.tab.general": "Général",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -105,6 +105,7 @@
   "header.copied": "クリップボードにコピーしました！",
   "header.captureFailed": "キャプチャ失敗",
   "header.summaryCopied": "要約をコピーしました！",
+  "header.quickActions": "クイックアクション",
 
   "settings.title": "設定",
   "settings.tab.general": "一般",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -105,6 +105,7 @@
   "header.copied": "클립보드에 복사됨!",
   "header.captureFailed": "캡처 실패",
   "header.summaryCopied": "요약이 복사됨!",
+  "header.quickActions": "바로가기 버튼",
 
   "settings.title": "설정",
   "settings.tab.general": "일반",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -105,6 +105,7 @@
   "header.copied": "已复制到剪贴板！",
   "header.captureFailed": "截图失败",
   "header.summaryCopied": "摘要已复制！",
+  "header.quickActions": "快捷操作",
 
   "settings.title": "设置",
   "settings.tab.general": "通用",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -105,6 +105,7 @@
   "header.copied": "已複製到剪貼簿！",
   "header.captureFailed": "擷取失敗",
   "header.summaryCopied": "摘要已複製！",
+  "header.quickActions": "快捷操作",
 
   "settings.title": "設定",
   "settings.tab.general": "一般",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -58,6 +58,7 @@ export interface UserPreferences {
   ai_model?: string;
   webhook_config?: WebhookConfig;
   autostart_enabled: boolean;
+  quick_action_items: string[];
 }
 
 export interface WebhookConfig {


### PR DESCRIPTION
## Summary
- 드롭다운 메뉴 각 아이템에 별(star) 핀 버튼을 추가하여 사용자가 원하는 액션을 개별적으로 헤더에 바로가기로 고정할 수 있도록 함
- `UserPreferences`에 `quick_action_items: string[]` 추가로 핀 설정이 디스크에 저장되어 앱 재시작 후에도 유지
- 8개 언어 로케일 파일 업데이트 (en, ko, ja, zh-CN, zh-TW, fr, es, de)

## Test plan
- [ ] 드롭다운 메뉴 열어서 각 아이템 우측에 별 핀 버튼 확인
- [ ] 핀 클릭 시 해당 아이콘이 헤더에 바로가기로 표시되는지 확인
- [ ] 핀 해제 시 바로가기에서 제거되는지 확인
- [ ] 여러 아이템을 동시에 핀할 수 있는지 확인
- [ ] 앱 재시작 후에도 핀 설정이 유지되는지 확인
- [ ] 바로가기 아이콘 클릭 시 해당 기능이 정상 동작하는지 확인

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)