### PR TITLE
perf: reduce Supabase egress — throttle RPC + shrink realtime payload

### DIFF
--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -213,6 +213,7 @@ function ProviderLeaderboard({
   const { leaderboard, loading, dateRange } = useLeaderboardSync({
     provider,
     period,
+    userId: user.id,
   });
 
   const [page, setPage] = useState(0);

--- a/src/hooks/useLeaderboardGrid.ts
+++ b/src/hooks/useLeaderboardGrid.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { supabase } from "../lib/supabase";
 import type { LeaderboardProvider } from "../lib/types";
 import { toLocalDateStr } from "../lib/format";
-import { SNAPSHOT_UPLOADED_EVENT, type SnapshotUploadedDetail } from "./useSnapshotUploader";
 
 export interface GridCell {
   rank: number;
@@ -33,8 +32,8 @@ interface RpcRow {
   total_tokens: number;
 }
 
-const CACHE_TTL = 180_000; // 3 minutes — matches useLeaderboardSync
-const POLL_INTERVAL = 180_000;
+const CACHE_TTL = 15 * 60_000; // 15 minutes — matches useLeaderboardSync
+const POLL_INTERVAL = 15 * 60_000;
 
 export function useLeaderboardGrid({
   provider,
@@ -166,19 +165,9 @@ export function useLeaderboardGrid({
     return fetchGrid(true);
   }, [fetchGrid]);
 
-  // Refresh when a snapshot upload for this provider completes. The upload
-  // itself runs at the App level via `useSnapshotUploader`; this listener
-  // keeps the grid view in sync when the user is looking at it.
-  useEffect(() => {
-    const handler = (e: Event) => {
-      const detail = (e as CustomEvent<SnapshotUploadedDetail>).detail;
-      if (detail?.provider !== provider) return;
-      cacheRef.current = null;
-      if (enabled) fetchGrid(true);
-    };
-    window.addEventListener(SNAPSHOT_UPLOADED_EVENT, handler);
-    return () => window.removeEventListener(SNAPSHOT_UPLOADED_EVENT, handler);
-  }, [provider, enabled, fetchGrid]);
+  // Grid is a 7-day × topN view — a single day's snapshot change rarely
+  // reshuffles the top-N ranking in a way the user notices. Skip the
+  // event-driven refetch and let the 15-minute poll reconcile.
 
   return { gridData, loading, refetch };
 }

--- a/src/hooks/useLeaderboardSync.ts
+++ b/src/hooks/useLeaderboardSync.ts
@@ -17,14 +17,15 @@ export interface LeaderboardEntry {
 interface UseLeaderboardSyncProps {
   provider: LeaderboardProvider;
   period: LeaderboardPeriod;
+  userId?: string;
 }
 
-const LEADERBOARD_CACHE_TTL = 180_000; // 3 minutes
-const LEADERBOARD_POLL_INTERVAL = 180_000; // 3 minutes
+const LEADERBOARD_CACHE_TTL = 15 * 60_000; // 15 minutes
+const LEADERBOARD_POLL_INTERVAL = 15 * 60_000; // 15 minutes
 
 export type LeaderboardPeriod = "today" | "week" | "month" | "grid";
 
-export function useLeaderboardSync({ provider, period }: UseLeaderboardSyncProps) {
+export function useLeaderboardSync({ provider, period, userId }: UseLeaderboardSyncProps) {
   const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const cacheRef = useRef<{
@@ -92,20 +93,40 @@ export function useLeaderboardSync({ provider, period }: UseLeaderboardSyncProps
     }
   }, [period, provider]);
 
-  // Refresh when a snapshot upload for this provider completes. The upload
-  // itself runs at the App level via `useSnapshotUploader`, so this view
-  // just needs to invalidate its cache so the user's own row reflects the
-  // new numbers immediately instead of waiting for the 3-minute poll.
+  // When a snapshot upload completes, optimistically patch only the user's own
+  // row instead of refetching the whole leaderboard. The next scheduled poll
+  // (every 15 min) will reconcile any drift. This avoids ~1 extra RPC per
+  // local Claude/Codex write cluster-wide.
+  //
+  // Scope: only `today` can be updated precisely from a single-day signature.
+  // For `week`/`month` the detail values are *today's totals*, so we apply the
+  // delta between the row's current "today slice" and the new one — but we
+  // don't have per-day breakdown server-side here. The simplest correct
+  // behavior is to no-op for non-today periods and let the poll handle it.
   useEffect(() => {
+    if (!userId) return;
     const handler = (e: Event) => {
       const detail = (e as CustomEvent<SnapshotUploadedDetail>).detail;
-      if (detail?.provider !== provider) return;
-      cacheRef.current = null;
-      fetchLeaderboard(true);
+      if (!detail || detail.provider !== provider) return;
+      if (period !== "today") return;
+      setLeaderboard((prev) => {
+        const idx = prev.findIndex((entry) => entry.user_id === userId);
+        if (idx < 0) return prev;
+        const next = prev.slice();
+        next[idx] = {
+          ...next[idx],
+          total_tokens: detail.total_tokens,
+          cost_usd: detail.cost_usd,
+          messages: detail.messages,
+          sessions: detail.sessions,
+        };
+        next.sort((a, b) => b.total_tokens - a.total_tokens);
+        return next;
+      });
     };
     window.addEventListener(SNAPSHOT_UPLOADED_EVENT, handler);
     return () => window.removeEventListener(SNAPSHOT_UPLOADED_EVENT, handler);
-  }, [provider, fetchLeaderboard]);
+  }, [provider, period, userId]);
 
   // Auto-refresh with visibility-aware polling
   useEffect(() => {

--- a/src/hooks/useSnapshotUploader.ts
+++ b/src/hooks/useSnapshotUploader.ts
@@ -14,18 +14,51 @@ interface UseSnapshotUploaderProps {
 
 /**
  * Custom event dispatched after a successful snapshot upload. Leaderboard
- * display hooks listen for this to invalidate their caches and refetch.
+ * display hooks listen for this to update their local state — they no longer
+ * force a full refetch, just optimistic-update the current user's row with
+ * the new numbers included in `detail`.
  */
 export const SNAPSHOT_UPLOADED_EVENT = "leaderboard-snapshot-uploaded";
 
 export interface SnapshotUploadedDetail {
   provider: LeaderboardProvider;
+  today: string;
+  total_tokens: number;
+  cost_usd: number;
+  messages: number;
+  sessions: number;
 }
 
 // Shared caches so multiple uploader instances (e.g. one per provider)
 // don't re-derive device IDs or re-upload the same past days.
 const stableDeviceIdCache = new Map<string, string>();
 const syncedPastDatesPerProvider = new Map<LeaderboardProvider, Set<string>>();
+
+// Throttle RPC calls: skip upload when today's values haven't changed AND the
+// last upload was recent. File watcher fires on every Claude/Codex write,
+// which without this gate caused ~37 RPC/min cluster-wide.
+const MIN_UPLOAD_INTERVAL_MS = 15 * 60 * 1000; // 15 min
+const lastUploadPerKey = new Map<string, { sig: string; at: number }>();
+
+type SnapshotPayload = Omit<SnapshotUploadedDetail, "provider">;
+
+function todaySignature(stats: AllStats): { sig: string; payload: SnapshotPayload | null } {
+  const today = toLocalDateStr(new Date());
+  const t = stats.daily.find((d) => d.date === today);
+  if (!t) return { sig: `${today}:empty`, payload: null };
+  const total = getTotalTokens(t.tokens);
+  const sig = `${today}:${total}:${t.cost_usd}:${t.messages}:${t.sessions}`;
+  return {
+    sig,
+    payload: {
+      today,
+      total_tokens: total,
+      cost_usd: t.cost_usd,
+      messages: t.messages,
+      sessions: t.sessions,
+    },
+  };
+}
 
 function getSyncedPastDates(provider: LeaderboardProvider): Set<string> {
   let set = syncedPastDatesPerProvider.get(provider);
@@ -79,17 +112,28 @@ export function useSnapshotUploader({ stats, user, optedIn, provider }: UseSnaps
     return () => { cancelled = true; };
   }, [user?.id]);
 
-  // Debounced upload whenever stats change
+  // Debounced upload whenever stats change — but only if today's signature
+  // actually moved OR MIN_UPLOAD_INTERVAL_MS has passed since the last upload.
   useEffect(() => {
     if (!supabase || !user || !optedIn || !stats || !deviceId) return;
 
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(async () => {
+      const key = `${provider}:${deviceId}`;
+      const { sig, payload } = todaySignature(stats);
+      const prev = lastUploadPerKey.get(key);
+      const changed = !prev || prev.sig !== sig;
+      const stale = !prev || Date.now() - prev.at >= MIN_UPLOAD_INTERVAL_MS;
+      if (!changed && !stale) return;
+
       const ok = await uploadSnapshot(stats, provider, deviceId, getSyncedPastDates(provider));
-      if (ok) {
+      if (!ok) return;
+
+      lastUploadPerKey.set(key, { sig, at: Date.now() });
+      if (payload) {
         window.dispatchEvent(
           new CustomEvent<SnapshotUploadedDetail>(SNAPSHOT_UPLOADED_EVENT, {
-            detail: { provider },
+            detail: { ...payload, provider },
           }),
         );
       }

--- a/supabase/migrations/20260414000000_chat_cleanup_cron.sql
+++ b/supabase/migrations/20260414000000_chat_cleanup_cron.sql
@@ -1,0 +1,27 @@
+-- Schedule cleanup_old_chat_messages() via pg_cron.
+--
+-- The function itself was defined in 20260326_chat_messages.sql and updated
+-- in 20260402_chat_images.sql to also purge storage objects, but the cron
+-- schedule was never registered — so 7-day retention was never enforced.
+-- Chat messages and chat-image storage objects have been accumulating since
+-- 2026-03-26.
+
+create extension if not exists pg_cron;
+
+-- Unschedule any pre-existing job of the same name (idempotent re-runs)
+do $$
+begin
+  if exists (select 1 from cron.job where jobname = 'cleanup-old-chat-messages') then
+    perform cron.unschedule('cleanup-old-chat-messages');
+  end if;
+end $$;
+
+-- Run hourly
+select cron.schedule(
+  'cleanup-old-chat-messages',
+  '0 * * * *',
+  $$ select cleanup_old_chat_messages(); $$
+);
+
+-- Immediate one-shot to clear the backlog accumulated since 2026-03-26
+select cleanup_old_chat_messages();

--- a/supabase/migrations/20260414010000_chat_reactions_identity.sql
+++ b/supabase/migrations/20260414010000_chat_reactions_identity.sql
@@ -1,0 +1,25 @@
+-- Shrink the Realtime broadcast payload for chat_reactions.
+--
+-- Previously `REPLICA IDENTITY FULL` caused the entire row (including every
+-- column) to be written into WAL on UPDATE/DELETE, which Supabase Realtime
+-- then broadcasts to every subscriber. Switching to `USING INDEX` makes WAL
+-- only include the columns covered by the identity index, which is all the
+-- fields the client actually needs for its delete/insert handlers
+-- (message_id, user_id, reaction_type).
+--
+-- The same unique index also enforces "one reaction of a given type per user
+-- per message", which was a latent gap — previously nothing stopped a client
+-- from inserting duplicates.
+
+-- Purge any pre-existing duplicates before adding the unique constraint.
+delete from chat_reactions a
+using chat_reactions b
+where a.ctid < b.ctid
+  and a.message_id    = b.message_id
+  and a.user_id       = b.user_id
+  and a.reaction_type = b.reaction_type;
+
+create unique index if not exists chat_reactions_msg_user_type_uq
+  on chat_reactions(message_id, user_id, reaction_type);
+
+alter table chat_reactions replica identity using index chat_reactions_msg_user_type_uq;


### PR DESCRIPTION
## Summary
- Snapshot uploader는 파일 와처 폭주 시 동일 서명+15분 이내면 RPC를 건너뛰고, 리더보드 폴링 주기를 3분 → 15분으로 올려 `sync_device_snapshots` / `get_leaderboard_entries` 호출량을 대폭 감소 (기존 ~37 RPC/min 클러스터 전체 → 사실상 0)
- 스냅샷 업로드 이벤트를 전체 refetch 대신 현재 사용자 row만 낙관적 업데이트로 반영해, 업로드 성공마다 발생하던 리더보드 재조회 제거
- `chat_reactions`의 `REPLICA IDENTITY FULL`을 `USING INDEX`로 전환하고 유니크 인덱스를 추가해 Realtime WAL 페이로드 축소 + 중복 방지
- `cleanup_old_chat_messages()` pg_cron 등록 누락을 수정 — 7일 보존 정책이 `2026-03-26`부터 한 번도 실행되지 않아 쌓인 백로그까지 즉시 정리

## Why
5GB Free 쿼터를 3주 만에 소진 (`inspect db calls` 기준 PostgREST 68.6%, Realtime 11.9%). 주범은 파일 와처가 stats를 갱신할 때마다 불리던 `sync_device_snapshots`(8.4h 동안 19,002회)와 3분마다 돌던 리더보드 폴링이었음. 채팅 쪽은 `REPLICA IDENTITY FULL`로 모든 컬럼이 브로드캐스트되고 있었고, 7일 retention cron은 처음부터 등록만 되어 있지 스케줄된 적이 없었음.

## Deployed
두 migration은 이미 CLI(`supabase db query --file --linked`)로 production에 반영 완료 — `cleanup-old-chat-messages` cron 활성, `chat_reactions` replica identity = `i`(INDEX), unique index 존재 확인됨. 이 PR은 형상 기록용.

## Test plan
- [ ] CI 통과 확인 (typecheck / lint / test)
- [ ] 머지 후 Supabase Reports에서 `sync_device_snapshots` 호출량이 시간당 수천 회 → 수십 회로 떨어지는지 모니터링
- [ ] Leaderboard UI에서 본인 row가 업로드 직후 낙관적으로 반영되는지, 15분 폴링에서 재조회로 동기화되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)