### PR TITLE
[codex] Keep Codex stats visible when Claude is unavailable

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,6 +90,7 @@ function AppContent() {
     return (
       <PopoverShell>
         <Header updater={updater} />
+        <SourceSelector />
         <div style={{
           display: "flex",
           alignItems: "center",
@@ -109,6 +110,7 @@ function AppContent() {
     return (
       <PopoverShell>
         <Header updater={updater} />
+        <SourceSelector />
         <div style={{
           display: "flex",
           flexDirection: "column",

--- a/src/hooks/useCombinedStats.ts
+++ b/src/hooks/useCombinedStats.ts
@@ -27,7 +27,15 @@ export function useCombinedStats({ includeClaude, includeCodex, includeOpencode 
   }, [claude.stats, codex.stats, opencode.stats, includeClaude, includeCodex, includeOpencode]);
 
   const loading = (includeClaude && claude.loading) || (includeCodex && codex.loading) || (includeOpencode && opencode.loading);
-  const error = includeClaude ? claude.error : includeCodex ? codex.error : opencode.error;
+  const error = useMemo(() => {
+    if (stats) return null;
+
+    if (includeClaude && claude.error) return claude.error;
+    if (includeCodex && codex.error) return codex.error;
+    if (includeOpencode && opencode.error) return opencode.error;
+
+    return null;
+  }, [stats, includeClaude, includeCodex, includeOpencode, claude.error, codex.error, opencode.error]);
 
   return { stats, loading, error };
 }


### PR DESCRIPTION
## What changed

- keep the source selector visible in loading and empty/error states
- avoid showing a global error when at least one enabled provider returned valid stats

## Why

The app could show an empty "no stats found" state for users who had valid Codex data but no local Claude data configured. In practice, a Claude fetch error could mask successful Codex stats, and the UI hid the source toggle in the very states where the user needed it.

## Impact

- Codex-only users can recover from the empty state without digging into settings
- mixed-provider users no longer lose visible stats just because one provider failed

## Root cause

The combined stats hook prioritized provider errors even when another enabled provider had valid stats, and the empty/error screens did not render `SourceSelector`.

## Validation

- `npm run build`
- `cargo test codex --lib`
