### PR TITLE
perf: Disk IO 대역폭 부담 완화 (크론 완화 + stale cleanup 제거)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "ai-token-monitor"
-version = "0.18.7"
+version = "0.19.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src/hooks/useSnapshotUploader.ts
+++ b/src/hooks/useSnapshotUploader.ts
@@ -31,7 +31,6 @@ export interface SnapshotUploadedDetail {
 // 15 min auto-upload floor. File watcher fires on every Claude/Codex write,
 // which without this gate caused ~37 RPC/min cluster-wide (PR #117).
 const MIN_AUTO_UPLOAD_INTERVAL_MS = 15 * 60 * 1000;
-const STALE_CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const BACKFILL_DAYS = 60;
 
 // Shared caches so multiple uploader instances (e.g. one per provider)
@@ -208,16 +207,15 @@ export function useSnapshotUploader({ stats, user, optedIn, provider }: UseSnaps
         return;
       }
 
-      const staleDates =
-        now - state.lastCleanupAt >= STALE_CLEANUP_INTERVAL_MS
-          ? buildStaleDates(liveStats, today)
-          : [];
-
-      const ok = await callSyncRpc(provider, deviceId, [todayRow], staleDates);
+      // Stale-date cleanup is intentionally skipped on the auto-upload path:
+      // a 60-day scan every 24h per (user × provider) was dominating Disk IO
+      // on the Nano instance. The 30-day cutoff inside sync_device_snapshots
+      // already self-prunes unused device entries, and manualBackfill still
+      // runs buildStaleDates when users trigger a full resync.
+      const ok = await callSyncRpc(provider, deviceId, [todayRow], []);
       if (ok) {
         state.lastUploadAt = now;
         state.lastTodayPayload = fingerprint;
-        if (staleDates.length > 0) state.lastCleanupAt = now;
         dispatchUploaded(provider, todayRow);
       }
     };

--- a/supabase/migrations/20260417000000_relax_chat_cleanup_cron.sql
+++ b/supabase/migrations/20260417000000_relax_chat_cleanup_cron.sql
@@ -1,0 +1,25 @@
+-- Relax cleanup_old_chat_messages() cron from hourly to daily.
+--
+-- Rationale: Nano instance Disk IO budget (30-min daily burst) has been
+-- exhausted every day, degrading all queries to baseline 43 Mbps. Hourly
+-- DELETE + storage.delete_object() across chat_messages and chat-images
+-- triggers heavy WAL write + VACUUM IO.
+--
+-- 7-day retention still holds — a single daily sweep covers the same
+-- delete volume in one batch during off-peak hours instead of spiking
+-- every hour.
+
+-- Drop the hourly schedule if it exists (idempotent)
+do $$
+begin
+  if exists (select 1 from cron.job where jobname = 'cleanup-old-chat-messages') then
+    perform cron.unschedule('cleanup-old-chat-messages');
+  end if;
+end $$;
+
+-- Run once daily at 18:00 UTC (03:00 KST) — off-peak for Korean users
+select cron.schedule(
+  'cleanup-old-chat-messages',
+  '0 18 * * *',
+  $$ select cleanup_old_chat_messages(); $$
+);


### PR DESCRIPTION
## Summary

Supabase Nano 인스턴스의 Disk IO burst(30분/일 한도)가 매일 소진되어 장애가 반복되는 문제에 대한 응급 완화.

- **크론 완화**: `cleanup_old_chat_messages()` 스케줄을 매시간(`0 * * * *`) → 일 1회 03:00 KST(`0 18 * * *`)로 변경. DELETE + VACUUM + WAL 증폭이 낮시간 대역폭을 잠식하던 문제 해소.
- **Stale cleanup 제거**: `useSnapshotUploader` 자동 업로드 경로에서 24h마다 도는 60일 stale-date 스캔 제거. RPC 내부 30일 cutoff가 이미 self-prune 수행 중이라 정합성 영향 없음. `manualBackfill` 경로는 유지.

추정 감소: 자동 업로드 경로에서 ~10,700 DB ops/일 제거 + 크론 실행 횟수 24회 → 1회.

## 배포 상태

- 마이그레이션 파일은 `supabase db query --linked`로 **원격 DB에 이미 적용 완료**
- `supabase_migrations.schema_migrations`에 레코드 등록까지 완료
- 이 PR은 **코드 변경(stale cleanup 제거)이 실제 사용자 앱에 반영**되는 것이 핵심

## Test plan

- [ ] CI 빌드/타입체크 통과
- [ ] 머지 후 v0.19.1 릴리스 트리거
- [ ] 배포 후 Supabase Infrastructure Activity 대시보드에서 Disk IO burst 소진 추이 관찰 (24~48h)
- [ ] `manualBackfill`(설정 UI → 리더보드 동기화 버튼)이 여전히 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)