### PR TITLE
perf: Disk IO 2차 개선 (인덱스 정리 + 폴링 완화 + bulk UPSERT)

### DIFF
--- a/src/hooks/useLeaderboardGrid.ts
+++ b/src/hooks/useLeaderboardGrid.ts
@@ -32,8 +32,8 @@ interface RpcRow {
   total_tokens: number;
 }
 
-const CACHE_TTL = 15 * 60_000; // 15 minutes — matches useLeaderboardSync
-const POLL_INTERVAL = 15 * 60_000;
+const CACHE_TTL = 30 * 60_000; // 30 minutes — matches useLeaderboardSync
+const POLL_INTERVAL = 30 * 60_000;
 
 export function useLeaderboardGrid({
   provider,

--- a/src/hooks/useLeaderboardSync.ts
+++ b/src/hooks/useLeaderboardSync.ts
@@ -20,8 +20,8 @@ interface UseLeaderboardSyncProps {
   userId?: string;
 }
 
-const LEADERBOARD_CACHE_TTL = 15 * 60_000; // 15 minutes
-const LEADERBOARD_POLL_INTERVAL = 15 * 60_000; // 15 minutes
+const LEADERBOARD_CACHE_TTL = 30 * 60_000; // 30 minutes
+const LEADERBOARD_POLL_INTERVAL = 30 * 60_000; // 30 minutes
 
 export type LeaderboardPeriod = "today" | "week" | "month" | "grid";
 

--- a/supabase/migrations/20260417010000_drop_unused_indexes.sql
+++ b/supabase/migrations/20260417010000_drop_unused_indexes.sql
@@ -1,0 +1,39 @@
+-- Drop unused indexes on daily_snapshots to reduce WAL amplification per UPDATE.
+--
+-- Rationale: pg_stat_user_indexes shows idx_scan=0 for idx_snapshots_date
+-- despite daily_snapshots receiving 203k+ total index scans. Each UPDATE
+-- currently maintains 5 indexes — every write amplifies WAL and burns Disk
+-- IO burst budget on the Nano instance. idx_snapshots_date is fully shadowed
+-- by idx_snapshots_date_provider(date,provider) via btree prefix matching.
+--
+-- Step 1 (this migration): drop unused secondary index and swap the PK from
+-- the synthetic id column to the natural composite key. The id column is
+-- retained for now as a rollback safety net — it will be dropped in a
+-- follow-up migration once the schema change has been observed for 24-48h.
+--
+-- Code/constraint audit confirms id is unreferenced:
+--   - 0 matches in src/ and src-tauri/
+--   - 0 foreign keys referencing daily_snapshots.id
+--   - 0 RLS policies referencing id (all use user_id)
+
+-- Build a dedicated unique index for the natural composite key. Doing this
+-- BEFORE dropping the existing unique constraint avoids a gap where writes
+-- could race past uniqueness enforcement.
+create unique index if not exists daily_snapshots_pk_idx
+  on daily_snapshots (user_id, date, provider);
+
+-- Drop the synthetic id-based PK
+alter table daily_snapshots drop constraint if exists daily_snapshots_pkey;
+
+-- Drop the old unique constraint (this also drops its auto-generated index,
+-- which is why we created daily_snapshots_pk_idx up front).
+alter table daily_snapshots
+  drop constraint if exists daily_snapshots_user_id_date_provider_key;
+
+-- Drop unused secondary index
+drop index if exists idx_snapshots_date;
+
+-- Promote the new index to primary key in place.
+alter table daily_snapshots
+  add constraint daily_snapshots_pkey
+  primary key using index daily_snapshots_pk_idx;

--- a/supabase/migrations/20260417020000_sync_device_snapshots_bulk.sql
+++ b/supabase/migrations/20260417020000_sync_device_snapshots_bulk.sql
@@ -1,0 +1,182 @@
+-- Rewrite sync_device_snapshots() from a row-by-row PL/pgSQL loop into a
+-- set-based bulk UPSERT + bulk stale cleanup.
+--
+-- Original structure executed INSERT + SELECT FOR UPDATE + UPDATE per row,
+-- plus a separate per-date loop for stale cleanup. A 60-day backfill meant
+-- ~180 DB ops; automatic today-only uploads still hit 3 ops. Per 67 active
+-- users × 2 providers this dominated Disk IO burst on Nano.
+--
+-- New structure uses two set-based statements:
+--
+--   1) Bulk stale cleanup: a single UPDATE against all p_stale_dates at once,
+--      with a CASE that either strips the device entry or deletes the row
+--      when no entries remain after the 30-day cutoff.
+--
+--   2) Bulk upsert: one INSERT ... SELECT ... ON CONFLICT DO UPDATE that
+--      takes jsonb_array_elements(p_rows), merges the new device entry into
+--      the existing device_snapshots JSONB (with 30-day cutoff applied),
+--      and recomputes totals via snapshot_totals() in the same statement.
+--
+-- Correctness invariants preserved from the original:
+--   - auth.uid() must match row user_id
+--   - provider whitelist ('claude','codex','opencode')
+--   - 30-day cutoff on device_snapshots entries (based on submitted_at)
+--   - __legacy__ placeholder is dropped after merge
+--   - snapshot_totals() remains the single source of truth for aggregate fields
+--   - Row is deleted when all device entries are evicted (all older than 30d)
+--
+-- Expected reduction: 60-day backfill 180 → 2 ops (99%), auto-upload 3 → 1 ops.
+
+create or replace function sync_device_snapshots_v2(
+  p_provider text,
+  p_device_id text,
+  p_rows jsonb default '[]'::jsonb,
+  p_stale_dates date[] default '{}'::date[]
+) returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+begin
+  if v_user_id is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  if p_provider not in ('claude', 'codex', 'opencode') then
+    raise exception 'Invalid provider';
+  end if;
+
+  if p_device_id is null or btrim(p_device_id) = '' then
+    raise exception 'Missing device_id';
+  end if;
+
+  -- Step 1: bulk stale cleanup.
+  -- For each stale date, remove this device's entry and re-apply the 30-day
+  -- cutoff. Rows with nothing left after pruning are deleted; others get
+  -- totals recomputed. Two statements because CTEs inside UPDATE cannot
+  -- guarantee a sibling DELETE runs when it isn't referenced.
+  if p_stale_dates is not null and array_length(p_stale_dates, 1) is not null then
+    -- 1a: delete rows where pruning would leave no device entries.
+    delete from daily_snapshots d
+    where d.user_id = v_user_id
+      and d.provider = p_provider
+      and d.date = any(p_stale_dates)
+      and coalesce(
+        (
+          select jsonb_object_agg(key, value)
+          from jsonb_each(coalesce(d.device_snapshots, '{}'::jsonb) - p_device_id) e
+          where coalesce((e.value->>'submitted_at')::timestamptz, now())
+                >= now() - interval '30 days'
+        ),
+        '{}'::jsonb
+      ) = '{}'::jsonb;
+
+    -- 1b: update surviving rows with pruned device_snapshots and fresh totals.
+    with pruned as (
+      select
+        s.user_id,
+        s.date,
+        s.provider,
+        (
+          select jsonb_object_agg(key, value)
+          from jsonb_each(coalesce(s.device_snapshots, '{}'::jsonb) - p_device_id) e
+          where coalesce((e.value->>'submitted_at')::timestamptz, now())
+                >= now() - interval '30 days'
+        ) as next_snapshots
+      from daily_snapshots s
+      where s.user_id = v_user_id
+        and s.provider = p_provider
+        and s.date = any(p_stale_dates)
+      for update
+    )
+    update daily_snapshots d
+    set
+      device_snapshots = p.next_snapshots,
+      total_tokens = t.total_tokens,
+      cost_usd = t.cost_usd,
+      messages = t.messages,
+      sessions = t.sessions,
+      submitted_at = now()
+    from pruned p, lateral snapshot_totals(p.next_snapshots) t
+    where d.user_id = p.user_id
+      and d.provider = p.provider
+      and d.date = p.date
+      and p.next_snapshots is not null;
+  end if;
+
+  -- Step 2: bulk upsert.
+  -- For each incoming row, merge the new device entry into device_snapshots,
+  -- drop __legacy__, apply the 30-day cutoff, and recompute totals — all in
+  -- a single INSERT ... ON CONFLICT DO UPDATE.
+  if p_rows is not null and jsonb_array_length(p_rows) > 0 then
+    with incoming as (
+      select
+        (row_data->>'date')::date as date,
+        jsonb_build_object(
+          'total_tokens', coalesce((row_data->>'total_tokens')::bigint, 0),
+          'cost_usd',     coalesce((row_data->>'cost_usd')::numeric(10,4), 0),
+          'messages',     coalesce((row_data->>'messages')::integer, 0),
+          'sessions',     coalesce((row_data->>'sessions')::integer, 0),
+          'submitted_at', now()
+        ) as device_payload
+      from jsonb_array_elements(coalesce(p_rows, '[]'::jsonb)) row_data
+    ),
+    merged as (
+      select
+        i.date,
+        -- Merge order: start from existing snapshots (or empty), drop __legacy__,
+        -- overlay the incoming device entry via jsonb_set, then apply the
+        -- 30-day cutoff on submitted_at.
+        coalesce(
+          (
+            select jsonb_object_agg(key, value)
+            from jsonb_each(
+              jsonb_set(
+                coalesce(existing.device_snapshots, '{}'::jsonb) - '__legacy__',
+                array[p_device_id],
+                i.device_payload,
+                true
+              )
+            ) e
+            where coalesce((e.value->>'submitted_at')::timestamptz, now())
+                  >= now() - interval '30 days'
+          ),
+          jsonb_build_object(p_device_id, i.device_payload)
+        ) as next_snapshots
+      from incoming i
+      left join daily_snapshots existing
+        on existing.user_id = v_user_id
+       and existing.provider = p_provider
+       and existing.date = i.date
+    )
+    insert into daily_snapshots (
+      user_id, date, provider,
+      total_tokens, cost_usd, messages, sessions,
+      device_snapshots, submitted_at
+    )
+    select
+      v_user_id,
+      m.date,
+      p_provider,
+      t.total_tokens,
+      t.cost_usd,
+      t.messages,
+      t.sessions,
+      m.next_snapshots,
+      now()
+    from merged m, lateral snapshot_totals(m.next_snapshots) t
+    on conflict (user_id, date, provider) do update set
+      device_snapshots = excluded.device_snapshots,
+      total_tokens     = excluded.total_tokens,
+      cost_usd         = excluded.cost_usd,
+      messages         = excluded.messages,
+      sessions         = excluded.sessions,
+      submitted_at     = excluded.submitted_at;
+  end if;
+end;
+$$;
+
+revoke all on function sync_device_snapshots_v2(text, text, jsonb, date[]) from public;
+grant execute on function sync_device_snapshots_v2(text, text, jsonb, date[]) to authenticated;

--- a/supabase/migrations/20260417030000_swap_sync_device_snapshots_to_v2.sql
+++ b/supabase/migrations/20260417030000_swap_sync_device_snapshots_to_v2.sql
@@ -1,0 +1,155 @@
+-- Replace sync_device_snapshots() body with the v2 bulk-UPSERT implementation.
+--
+-- The v2 function (20260417020000_sync_device_snapshots_bulk.sql) was deployed
+-- in parallel and verified against v1 via _test_sync_equivalence.sql — the
+-- EXCEPT-based diff returned 0 rows across 7 scenarios (single insert, multi-
+-- device merge, bulk 3-date upload, sole-device stale delete, multi-device
+-- stale prune, device update, non-existent stale date).
+--
+-- This migration flips the production RPC to the bulk path by rewriting the
+-- existing sync_device_snapshots() function. Clients continue calling the same
+-- name — no client change required. sync_device_snapshots_v2 is kept for now
+-- as an explicit alias for rollback parity and will be dropped in a follow-up
+-- once the bulk path has been observed in production for 24-48h.
+
+create or replace function sync_device_snapshots(
+  p_provider text,
+  p_device_id text,
+  p_rows jsonb default '[]'::jsonb,
+  p_stale_dates date[] default '{}'::date[]
+) returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+begin
+  if v_user_id is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  if p_provider not in ('claude', 'codex', 'opencode') then
+    raise exception 'Invalid provider';
+  end if;
+
+  if p_device_id is null or btrim(p_device_id) = '' then
+    raise exception 'Missing device_id';
+  end if;
+
+  -- Step 1: bulk stale cleanup.
+  if p_stale_dates is not null and array_length(p_stale_dates, 1) is not null then
+    delete from daily_snapshots d
+    where d.user_id = v_user_id
+      and d.provider = p_provider
+      and d.date = any(p_stale_dates)
+      and coalesce(
+        (
+          select jsonb_object_agg(key, value)
+          from jsonb_each(coalesce(d.device_snapshots, '{}'::jsonb) - p_device_id) e
+          where coalesce((e.value->>'submitted_at')::timestamptz, now())
+                >= now() - interval '30 days'
+        ),
+        '{}'::jsonb
+      ) = '{}'::jsonb;
+
+    with pruned as (
+      select
+        s.user_id,
+        s.date,
+        s.provider,
+        (
+          select jsonb_object_agg(key, value)
+          from jsonb_each(coalesce(s.device_snapshots, '{}'::jsonb) - p_device_id) e
+          where coalesce((e.value->>'submitted_at')::timestamptz, now())
+                >= now() - interval '30 days'
+        ) as next_snapshots
+      from daily_snapshots s
+      where s.user_id = v_user_id
+        and s.provider = p_provider
+        and s.date = any(p_stale_dates)
+      for update
+    )
+    update daily_snapshots d
+    set
+      device_snapshots = p.next_snapshots,
+      total_tokens = t.total_tokens,
+      cost_usd = t.cost_usd,
+      messages = t.messages,
+      sessions = t.sessions,
+      submitted_at = now()
+    from pruned p, lateral snapshot_totals(p.next_snapshots) t
+    where d.user_id = p.user_id
+      and d.provider = p.provider
+      and d.date = p.date
+      and p.next_snapshots is not null;
+  end if;
+
+  -- Step 2: bulk upsert.
+  if p_rows is not null and jsonb_array_length(p_rows) > 0 then
+    with incoming as (
+      select
+        (row_data->>'date')::date as date,
+        jsonb_build_object(
+          'total_tokens', coalesce((row_data->>'total_tokens')::bigint, 0),
+          'cost_usd',     coalesce((row_data->>'cost_usd')::numeric(10,4), 0),
+          'messages',     coalesce((row_data->>'messages')::integer, 0),
+          'sessions',     coalesce((row_data->>'sessions')::integer, 0),
+          'submitted_at', now()
+        ) as device_payload
+      from jsonb_array_elements(coalesce(p_rows, '[]'::jsonb)) row_data
+    ),
+    merged as (
+      select
+        i.date,
+        coalesce(
+          (
+            select jsonb_object_agg(key, value)
+            from jsonb_each(
+              jsonb_set(
+                coalesce(existing.device_snapshots, '{}'::jsonb) - '__legacy__',
+                array[p_device_id],
+                i.device_payload,
+                true
+              )
+            ) e
+            where coalesce((e.value->>'submitted_at')::timestamptz, now())
+                  >= now() - interval '30 days'
+          ),
+          jsonb_build_object(p_device_id, i.device_payload)
+        ) as next_snapshots
+      from incoming i
+      left join daily_snapshots existing
+        on existing.user_id = v_user_id
+       and existing.provider = p_provider
+       and existing.date = i.date
+    )
+    insert into daily_snapshots (
+      user_id, date, provider,
+      total_tokens, cost_usd, messages, sessions,
+      device_snapshots, submitted_at
+    )
+    select
+      v_user_id,
+      m.date,
+      p_provider,
+      t.total_tokens,
+      t.cost_usd,
+      t.messages,
+      t.sessions,
+      m.next_snapshots,
+      now()
+    from merged m, lateral snapshot_totals(m.next_snapshots) t
+    on conflict (user_id, date, provider) do update set
+      device_snapshots = excluded.device_snapshots,
+      total_tokens     = excluded.total_tokens,
+      cost_usd         = excluded.cost_usd,
+      messages         = excluded.messages,
+      sessions         = excluded.sessions,
+      submitted_at     = excluded.submitted_at;
+  end if;
+end;
+$$;
+
+revoke all on function sync_device_snapshots(text, text, jsonb, date[]) from public;
+grant execute on function sync_device_snapshots(text, text, jsonb, date[]) to authenticated;

--- a/supabase/tests/sync_device_snapshots_equivalence.sql
+++ b/supabase/tests/sync_device_snapshots_equivalence.sql
@@ -1,0 +1,281 @@
+-- Equivalence test for sync_device_snapshots vs sync_device_snapshots_v2.
+--
+-- Creates two isolated test tables (daily_snapshots_v1_test, _v2_test) that
+-- mirror the schema of daily_snapshots, wraps each sync implementation to
+-- target the test tables, drives the same sequence of calls against both,
+-- then diffs the resulting rows. Does NOT touch production daily_snapshots.
+--
+-- Run inside a single transaction so everything rolls back at the end,
+-- leaving the production DB untouched.
+
+begin;
+
+-- 1. Mirror schema (DROP COLUMNs and constraints simplified for test isolation).
+create table daily_snapshots_v1_test (
+  user_id uuid not null,
+  date date not null,
+  provider text not null,
+  total_tokens bigint not null default 0,
+  cost_usd numeric(10,4) not null default 0,
+  messages integer not null default 0,
+  sessions integer not null default 0,
+  device_snapshots jsonb,
+  submitted_at timestamptz,
+  primary key (user_id, date, provider)
+);
+
+create table daily_snapshots_v2_test (like daily_snapshots_v1_test including all);
+
+-- 2. Wrap v1 / v2 logic against the test tables.
+--    We inline the same logic but point at the *_test tables. This keeps the
+--    test self-contained and avoids mutating production.
+
+-- Helper to seed a user_id without auth.uid()
+create or replace function _test_run_v1(
+  p_target regclass, p_user_id uuid, p_provider text, p_device_id text,
+  p_rows jsonb, p_stale_dates date[]
+) returns void language plpgsql as $$
+declare
+  v_row jsonb;
+  v_date date;
+  v_existing jsonb;
+  v_next jsonb;
+  v_payload jsonb;
+  v_t bigint; v_c numeric(10,4); v_m integer; v_s integer;
+begin
+  if p_stale_dates is not null and array_length(p_stale_dates, 1) is not null then
+    foreach v_date in array p_stale_dates loop
+      execute format($f$
+        select device_snapshots from %s
+         where user_id=$1 and provider=$2 and date=$3 for update
+      $f$, p_target) into v_existing using p_user_id, p_provider, v_date;
+
+      if v_existing is null then continue; end if;
+
+      v_next := v_existing - p_device_id;
+      select coalesce(jsonb_object_agg(key, value), '{}'::jsonb) into v_next
+      from jsonb_each(v_next)
+      where coalesce((value->>'submitted_at')::timestamptz, now()) >= now() - interval '30 days';
+
+      if v_next = '{}'::jsonb then
+        execute format('delete from %s where user_id=$1 and provider=$2 and date=$3', p_target)
+          using p_user_id, p_provider, v_date;
+      else
+        select * into v_t, v_c, v_m, v_s from snapshot_totals(v_next);
+        execute format($f$
+          update %s set device_snapshots=$1, total_tokens=$2, cost_usd=$3,
+                        messages=$4, sessions=$5, submitted_at=now()
+          where user_id=$6 and provider=$7 and date=$8
+        $f$, p_target) using v_next, v_t, v_c, v_m, v_s, p_user_id, p_provider, v_date;
+      end if;
+    end loop;
+  end if;
+
+  for v_row in select value from jsonb_array_elements(coalesce(p_rows, '[]'::jsonb)) loop
+    v_date := (v_row->>'date')::date;
+
+    execute format($f$
+      insert into %s (user_id, date, provider, device_snapshots, submitted_at)
+      values ($1,$2,$3,'{}'::jsonb, now())
+      on conflict (user_id, date, provider) do nothing
+    $f$, p_target) using p_user_id, v_date, p_provider;
+
+    execute format($f$
+      select device_snapshots from %s where user_id=$1 and provider=$2 and date=$3 for update
+    $f$, p_target) into v_existing using p_user_id, p_provider, v_date;
+
+    v_payload := jsonb_build_object(
+      'total_tokens', coalesce((v_row->>'total_tokens')::bigint, 0),
+      'cost_usd',     coalesce((v_row->>'cost_usd')::numeric(10,4), 0),
+      'messages',     coalesce((v_row->>'messages')::integer, 0),
+      'sessions',     coalesce((v_row->>'sessions')::integer, 0),
+      'submitted_at', now()
+    );
+
+    v_next := jsonb_set(coalesce(v_existing, '{}'::jsonb), array[p_device_id], v_payload, true);
+    v_next := v_next - '__legacy__';
+    select coalesce(jsonb_object_agg(key, value), '{}'::jsonb) into v_next
+    from jsonb_each(v_next)
+    where coalesce((value->>'submitted_at')::timestamptz, now()) >= now() - interval '30 days';
+
+    select * into v_t, v_c, v_m, v_s from snapshot_totals(v_next);
+
+    execute format($f$
+      update %s set device_snapshots=$1, total_tokens=$2, cost_usd=$3,
+                    messages=$4, sessions=$5, submitted_at=now()
+      where user_id=$6 and provider=$7 and date=$8
+    $f$, p_target) using v_next, v_t, v_c, v_m, v_s, p_user_id, p_provider, v_date;
+  end loop;
+end; $$;
+
+-- v2 wrapper: same as production v2 but parameterised on target table
+create or replace function _test_run_v2(
+  p_target regclass, p_user_id uuid, p_provider text, p_device_id text,
+  p_rows jsonb, p_stale_dates date[]
+) returns void language plpgsql as $$
+begin
+  if p_stale_dates is not null and array_length(p_stale_dates, 1) is not null then
+    execute format($f$
+      delete from %s d
+      where d.user_id=$1 and d.provider=$2 and d.date = any($3)
+        and coalesce((
+          select jsonb_object_agg(key, value)
+          from jsonb_each(coalesce(d.device_snapshots, '{}'::jsonb) - $4) e
+          where coalesce((e.value->>'submitted_at')::timestamptz, now())
+                >= now() - interval '30 days'
+        ), '{}'::jsonb) = '{}'::jsonb
+    $f$, p_target) using p_user_id, p_provider, p_stale_dates, p_device_id;
+
+    execute format($f$
+      with pruned as (
+        select s.user_id, s.date, s.provider,
+          (select jsonb_object_agg(key, value)
+             from jsonb_each(coalesce(s.device_snapshots, '{}'::jsonb) - $4) e
+             where coalesce((e.value->>'submitted_at')::timestamptz, now())
+                   >= now() - interval '30 days') as next_snapshots
+        from %s s
+        where s.user_id=$1 and s.provider=$2 and s.date = any($3)
+        for update
+      )
+      update %s d
+      set device_snapshots = p.next_snapshots,
+          total_tokens = t.total_tokens, cost_usd = t.cost_usd,
+          messages = t.messages, sessions = t.sessions, submitted_at = now()
+      from pruned p, lateral snapshot_totals(p.next_snapshots) t
+      where d.user_id = p.user_id and d.provider = p.provider and d.date = p.date
+        and p.next_snapshots is not null
+    $f$, p_target, p_target) using p_user_id, p_provider, p_stale_dates, p_device_id;
+  end if;
+
+  if p_rows is not null and jsonb_array_length(p_rows) > 0 then
+    execute format($f$
+      with incoming as (
+        select (row_data->>'date')::date as date,
+          jsonb_build_object(
+            'total_tokens', coalesce((row_data->>'total_tokens')::bigint, 0),
+            'cost_usd',     coalesce((row_data->>'cost_usd')::numeric(10,4), 0),
+            'messages',     coalesce((row_data->>'messages')::integer, 0),
+            'sessions',     coalesce((row_data->>'sessions')::integer, 0),
+            'submitted_at', now()
+          ) as device_payload
+        from jsonb_array_elements($4) row_data
+      ),
+      merged as (
+        select i.date,
+          coalesce((
+            select jsonb_object_agg(key, value)
+            from jsonb_each(
+              jsonb_set(
+                coalesce(existing.device_snapshots, '{}'::jsonb) - '__legacy__',
+                array[$3], i.device_payload, true
+              )
+            ) e
+            where coalesce((e.value->>'submitted_at')::timestamptz, now())
+                  >= now() - interval '30 days'
+          ), jsonb_build_object($3, i.device_payload)) as next_snapshots
+        from incoming i
+        left join %s existing
+          on existing.user_id=$1 and existing.provider=$2 and existing.date=i.date
+      )
+      insert into %s (user_id, date, provider, total_tokens, cost_usd,
+                      messages, sessions, device_snapshots, submitted_at)
+      select $1, m.date, $2, t.total_tokens, t.cost_usd, t.messages, t.sessions,
+             m.next_snapshots, now()
+      from merged m, lateral snapshot_totals(m.next_snapshots) t
+      on conflict (user_id, date, provider) do update set
+        device_snapshots = excluded.device_snapshots,
+        total_tokens = excluded.total_tokens, cost_usd = excluded.cost_usd,
+        messages = excluded.messages, sessions = excluded.sessions,
+        submitted_at = excluded.submitted_at
+    $f$, p_target, p_target) using p_user_id, p_provider, p_device_id, p_rows;
+  end if;
+end; $$;
+
+-- 3. Test scenarios.
+-- Use a single user_id across scenarios; two device ids to cover multi-device.
+do $$
+declare
+  u uuid := '00000000-0000-0000-0000-000000000001'::uuid;
+  d1 text := 'device-alpha';
+  d2 text := 'device-beta';
+begin
+  -- Scenario 1: insert today from device 1
+  perform _test_run_v1('daily_snapshots_v1_test', u, 'claude', d1,
+    '[{"date":"2026-04-17","total_tokens":100,"cost_usd":0.5,"messages":5,"sessions":1}]'::jsonb, '{}'::date[]);
+  perform _test_run_v2('daily_snapshots_v2_test', u, 'claude', d1,
+    '[{"date":"2026-04-17","total_tokens":100,"cost_usd":0.5,"messages":5,"sessions":1}]'::jsonb, '{}'::date[]);
+
+  -- Scenario 2: add device 2 to same date (multi-device merge)
+  perform _test_run_v1('daily_snapshots_v1_test', u, 'claude', d2,
+    '[{"date":"2026-04-17","total_tokens":200,"cost_usd":1.0,"messages":10,"sessions":2}]'::jsonb, '{}'::date[]);
+  perform _test_run_v2('daily_snapshots_v2_test', u, 'claude', d2,
+    '[{"date":"2026-04-17","total_tokens":200,"cost_usd":1.0,"messages":10,"sessions":2}]'::jsonb, '{}'::date[]);
+
+  -- Scenario 3: device 1 uploads 3 dates at once (bulk)
+  perform _test_run_v1('daily_snapshots_v1_test', u, 'claude', d1, $j$[
+    {"date":"2026-04-16","total_tokens":50,"cost_usd":0.2,"messages":3,"sessions":1},
+    {"date":"2026-04-15","total_tokens":80,"cost_usd":0.3,"messages":4,"sessions":1},
+    {"date":"2026-04-14","total_tokens":120,"cost_usd":0.6,"messages":6,"sessions":2}
+  ]$j$::jsonb, '{}'::date[]);
+  perform _test_run_v2('daily_snapshots_v2_test', u, 'claude', d1, $j$[
+    {"date":"2026-04-16","total_tokens":50,"cost_usd":0.2,"messages":3,"sessions":1},
+    {"date":"2026-04-15","total_tokens":80,"cost_usd":0.3,"messages":4,"sessions":1},
+    {"date":"2026-04-14","total_tokens":120,"cost_usd":0.6,"messages":6,"sessions":2}
+  ]$j$::jsonb, '{}'::date[]);
+
+  -- Scenario 4: stale cleanup for device 1 on 2026-04-14 (sole device → row delete)
+  -- First ensure device 2 never touched 2026-04-14, then remove device 1 via stale.
+  perform _test_run_v1('daily_snapshots_v1_test', u, 'claude', d1,
+    '[]'::jsonb, array['2026-04-14'::date]);
+  perform _test_run_v2('daily_snapshots_v2_test', u, 'claude', d1,
+    '[]'::jsonb, array['2026-04-14'::date]);
+
+  -- Scenario 5: stale cleanup for device 1 on 2026-04-17 (device 2 survives)
+  perform _test_run_v1('daily_snapshots_v1_test', u, 'claude', d1,
+    '[]'::jsonb, array['2026-04-17'::date]);
+  perform _test_run_v2('daily_snapshots_v2_test', u, 'claude', d1,
+    '[]'::jsonb, array['2026-04-17'::date]);
+
+  -- Scenario 6: update same (device, date) with new values
+  perform _test_run_v1('daily_snapshots_v1_test', u, 'claude', d2,
+    '[{"date":"2026-04-17","total_tokens":300,"cost_usd":1.5,"messages":15,"sessions":3}]'::jsonb, '{}'::date[]);
+  perform _test_run_v2('daily_snapshots_v2_test', u, 'claude', d2,
+    '[{"date":"2026-04-17","total_tokens":300,"cost_usd":1.5,"messages":15,"sessions":3}]'::jsonb, '{}'::date[]);
+
+  -- Scenario 7: stale cleanup referencing a date that doesn't exist (no-op)
+  perform _test_run_v1('daily_snapshots_v1_test', u, 'claude', d1,
+    '[]'::jsonb, array['2020-01-01'::date]);
+  perform _test_run_v2('daily_snapshots_v2_test', u, 'claude', d1,
+    '[]'::jsonb, array['2020-01-01'::date]);
+end $$;
+
+-- 4. Diff. Any rows returned here are bugs.
+-- Compare by tuple ignoring submitted_at (timing differs between calls).
+select 'only_in_v1' as side, user_id, date, provider,
+       total_tokens, cost_usd, messages, sessions,
+       device_snapshots - 'submitted_at' as device_snapshots_excl_time
+from (
+  select user_id, date, provider, total_tokens, cost_usd, messages, sessions,
+         device_snapshots
+  from daily_snapshots_v1_test
+  except
+  select user_id, date, provider, total_tokens, cost_usd, messages, sessions,
+         device_snapshots
+  from daily_snapshots_v2_test
+) diff
+union all
+select 'only_in_v2', user_id, date, provider,
+       total_tokens, cost_usd, messages, sessions,
+       device_snapshots - 'submitted_at'
+from (
+  select user_id, date, provider, total_tokens, cost_usd, messages, sessions,
+         device_snapshots
+  from daily_snapshots_v2_test
+  except
+  select user_id, date, provider, total_tokens, cost_usd, messages, sessions,
+         device_snapshots
+  from daily_snapshots_v1_test
+) diff;
+
+-- Roll back so nothing persists.
+rollback;


### PR DESCRIPTION
## Summary

Nano 인스턴스의 Disk IO burst를 추가로 줄이기 위한 2차 작업. PR #123(크론 완화 + stale cleanup 제거)에 이어 쓰기/읽기 양쪽에서 비용을 깎는다.

- **A. 미사용 인덱스 제거 + PK 재구조화** — `idx_snapshots_date`는 `idx_scan=0`이라 WAL 증폭만 먹고 있었고, 합성 `id` 기반 PK는 클라이언트/RLS/FK 어디에서도 참조되지 않아 자연키 `(user_id, date, provider)`로 교체. `id` 컬럼은 롤백 여유로 한 사이클 보존.
- **C. 리더보드 폴링 15m → 30m** — 67명 × 2 provider × 4 req/h가 매 burst 위에 얹혀 있었음. 본인 row는 `SNAPSHOT_UPLOADED_EVENT`로 이미 optimistic patch되므로 폴링은 reconciliation 용도.
- **D. `sync_device_snapshots` bulk UPSERT 재작성** — row-by-row PL/pgSQL 루프 + 별도 per-date 루프 → 2개의 set-based 문장(bulk DELETE/UPDATE + `INSERT ... ON CONFLICT DO UPDATE`)으로 교체. v2를 먼저 배포해 `supabase/tests/sync_device_snapshots_equivalence.sql`의 7개 시나리오 EXCEPT diff가 0 rows임을 확인한 뒤 프로덕션 함수 본문을 스왑.

예상 효과: 60일 백필 180 → 2 ops (~99%), 자동 업로드 3 → 1 ops. A/D 마이그레이션은 이미 원격에 적용 완료.

## Test plan

- [ ] CI 통과 확인
- [ ] 머지 후 v0.19.3 패치 릴리스
- [ ] 릴리스 후 24-48h 동안 Supabase Infrastructure Activity 대시보드에서 Disk IO burst 사용량 관찰
- [ ] 기존 클라이언트가 교체된 `sync_device_snapshots`를 정상 호출하는지 (자동 업로드 / 수동 백필) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)