### PR TITLE
feat: add Kimi/GLM provider support (client-side)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "ai-token-monitor"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/pricing.json
+++ b/src-tauri/pricing.json
@@ -70,5 +70,24 @@
       { "match": "deepseek-reasoner", "label": "DeepSeek R1",              "input": 0.55,  "output": 2.19,   "cache_read": 0.14,  "cache_write": 0.0    },
       { "match": "deepseek",          "label": "DeepSeek V3",              "input": 0.27,  "output": 1.10,   "cache_read": 0.07,  "cache_write": 0.0    }
     ]
+  },
+  "kimi": {
+    "default": "kimi-k2",
+    "models": [
+      { "match": "kimi-k2-instruct", "label": "Kimi K2 Instruct", "input": 0.60, "output": 2.00, "cache_read": 0.0, "cache_write": 0.0 },
+      { "match": "kimi-k2",          "label": "Kimi K2",          "input": 0.60, "output": 2.00, "cache_read": 0.0, "cache_write": 0.0 },
+      { "match": "kimi-k1.5",        "label": "Kimi K1.5",        "input": 0.40, "output": 1.20, "cache_read": 0.0, "cache_write": 0.0 },
+      { "match": "moonshot",         "label": "Moonshot",         "input": 0.60, "output": 2.00, "cache_read": 0.0, "cache_write": 0.0 },
+      { "match": "kimi",             "label": "Kimi K2",          "input": 0.60, "output": 2.00, "cache_read": 0.0, "cache_write": 0.0 }
+    ]
+  },
+  "glm": {
+    "default": "glm-4",
+    "models": [
+      { "match": "glm-5-turbo", "label": "GLM-5 Turbo", "input": 0.50, "output": 1.00, "cache_read": 0.0, "cache_write": 0.0 },
+      { "match": "glm-5",      "label": "GLM-5",       "input": 1.00, "output": 2.00, "cache_read": 0.0, "cache_write": 0.0 },
+      { "match": "glm-4",      "label": "GLM-4",       "input": 0.50, "output": 1.00, "cache_read": 0.0, "cache_write": 0.0 },
+      { "match": "glm",        "label": "GLM-4",       "input": 0.50, "output": 1.00, "cache_read": 0.0, "cache_write": 0.0 }
+    ]
   }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -9,6 +9,8 @@ use sha2::{Digest, Sha256};
 
 use crate::providers::claude_code::ClaudeCodeProvider;
 use crate::providers::codex::CodexProvider;
+use crate::providers::glm::GlmProvider;
+use crate::providers::kimi::KimiProvider;
 use crate::providers::opencode::OpenCodeProvider;
 use crate::providers::pricing;
 use crate::providers::traits::TokenProvider;
@@ -90,6 +92,52 @@ pub async fn get_opencode_stats(app: tauri::AppHandle) -> Result<AllStats, Strin
 #[tauri::command]
 pub fn is_opencode_available() -> bool {
     OpenCodeProvider::new().is_available()
+}
+
+#[tauri::command]
+pub async fn get_kimi_stats(app: tauri::AppHandle) -> Result<AllStats, String> {
+    let result = tauri::async_runtime::spawn_blocking(|| {
+        let provider = KimiProvider::new();
+        if !provider.is_available() {
+            return Err("Kimi stats not available".to_string());
+        }
+        provider.fetch_stats()
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+
+    if result.is_ok() {
+        crate::update_tray_title(&app);
+    }
+    result
+}
+
+#[tauri::command]
+pub fn is_kimi_available() -> bool {
+    KimiProvider::new().is_available()
+}
+
+#[tauri::command]
+pub async fn get_glm_stats(app: tauri::AppHandle) -> Result<AllStats, String> {
+    let result = tauri::async_runtime::spawn_blocking(|| {
+        let provider = GlmProvider::new();
+        if !provider.is_available() {
+            return Err("GLM stats not available".to_string());
+        }
+        provider.fetch_stats()
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+
+    if result.is_ok() {
+        crate::update_tray_title(&app);
+    }
+    result
+}
+
+#[tauri::command]
+pub fn is_glm_available() -> bool {
+    GlmProvider::new().is_available()
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -282,7 +282,23 @@ pub fn update_tray_title(app_handle: &tauri::AppHandle) {
             0.0
         };
 
-        let today_cost = claude_cost + codex_cost + opencode_cost;
+        let kimi_cost = if prefs.include_kimi {
+            providers::kimi::get_cached_stats()
+                .and_then(|s| s.daily.iter().find(|d| d.date == today).map(|d| d.cost_usd))
+                .unwrap_or(0.0)
+        } else {
+            0.0
+        };
+
+        let glm_cost = if prefs.include_glm {
+            providers::glm::get_cached_stats()
+                .and_then(|s| s.daily.iter().find(|d| d.date == today).map(|d| d.cost_usd))
+                .unwrap_or(0.0)
+        } else {
+            0.0
+        };
+
+        let today_cost = claude_cost + codex_cost + opencode_cost + kimi_cost + glm_cost;
         let cost_str = if today_cost >= 1.0 {
             format!("${:.0}", today_cost)
         } else {
@@ -332,6 +348,22 @@ fn get_all_watch_dirs() -> Vec<PathBuf> {
     let opencode_provider = providers::opencode::OpenCodeProvider::new();
     if opencode_provider.is_available() {
         dirs.push(opencode_provider.data_dir.clone());
+    }
+
+    // Add Kimi session directory
+    let kimi_sessions = home.join(".kimi").join("sessions");
+    if kimi_sessions.exists() {
+        dirs.push(kimi_sessions);
+    }
+
+    // Add GLM session directories (future)
+    let glm_sessions = home.join(".glm").join("sessions");
+    if glm_sessions.exists() {
+        dirs.push(glm_sessions);
+    }
+    let zhipu_sessions = home.join(".zhipu").join("sessions");
+    if zhipu_sessions.exists() {
+        dirs.push(zhipu_sessions);
     }
 
     dirs
@@ -401,6 +433,8 @@ fn start_file_watcher(app_handle: tauri::AppHandle) {
                     providers::claude_code::invalidate_stats_cache();
                     providers::codex::invalidate_stats_cache();
                     providers::opencode::invalidate_stats_cache();
+                    providers::kimi::invalidate_stats_cache();
+                    providers::glm::invalidate_stats_cache();
                     let _ = app_handle.emit("stats-updated", ());
                     // Re-parse in background so the tray reflects new data even when the
                     // popup is closed (get_all_stats is only called by the frontend).
@@ -414,6 +448,12 @@ fn start_file_watcher(app_handle: tauri::AppHandle) {
                         }
                         if prefs.include_opencode {
                             let _ = providers::opencode::OpenCodeProvider::new().fetch_stats();
+                        }
+                        if prefs.include_kimi {
+                            let _ = providers::kimi::KimiProvider::new().fetch_stats();
+                        }
+                        if prefs.include_glm {
+                            let _ = providers::glm::GlmProvider::new().fetch_stats();
                         }
                         update_tray_title(&app_for_refresh);
                     });
@@ -435,6 +475,8 @@ fn start_file_watcher(app_handle: tauri::AppHandle) {
                         providers::claude_code::invalidate_stats_cache();
                         providers::codex::invalidate_stats_cache();
                         providers::opencode::invalidate_stats_cache();
+                        providers::kimi::invalidate_stats_cache();
+                        providers::glm::invalidate_stats_cache();
                         let _ = app_handle.emit("stats-updated", ());
                     }
                     update_tray_title(&app_handle);
@@ -780,6 +822,10 @@ pub fn run() {
             commands::is_codex_available,
             commands::get_opencode_stats,
             commands::is_opencode_available,
+            commands::get_kimi_stats,
+            commands::is_kimi_available,
+            commands::get_glm_stats,
+            commands::is_glm_available,
             commands::get_preferences,
             commands::set_preferences,
             commands::get_stable_device_id,

--- a/src-tauri/src/providers/glm.rs
+++ b/src-tauri/src/providers/glm.rs
@@ -38,7 +38,9 @@ pub fn get_cached_stats() -> Option<AllStats> {
 /// Expected future session path: ~/.glm/sessions/ or ~/.zhipu/sessions/
 /// Expected wire format: JSONL with OpenAI-compatible usage fields
 pub struct GlmProvider {
+    #[allow(dead_code)]
     glm_dir: PathBuf,
+    #[allow(dead_code)]
     zhipu_dir: PathBuf,
 }
 
@@ -90,7 +92,10 @@ impl TokenProvider for GlmProvider {
     }
 
     fn is_available(&self) -> bool {
-        // Check both potential paths for a future GLM CLI
-        self.glm_dir.join("sessions").exists() || self.zhipu_dir.join("sessions").exists()
+        // Gated off until parsing is implemented. Detecting ~/.glm or ~/.zhipu
+        // would surface the toggle while fetch_stats() still returns an empty
+        // AllStats — users would see "0 tokens" with no explanation. Flip this
+        // to an actual directory check once wire.jsonl parsing lands.
+        false
     }
 }

--- a/src-tauri/src/providers/glm.rs
+++ b/src-tauri/src/providers/glm.rs
@@ -1,0 +1,96 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use super::traits::TokenProvider;
+use super::types::AllStats;
+
+// --- Cache infrastructure (stub — minimal for future use) ---
+
+struct StubCache {
+    stats: AllStats,
+    computed_at: Instant,
+}
+
+static STATS_CACHE: Mutex<Option<StubCache>> = Mutex::new(None);
+static CACHE_INVALIDATED: AtomicBool = AtomicBool::new(false);
+const CACHE_TTL: Duration = Duration::from_secs(60);
+
+/// Invalidate cache — called by file watcher.
+pub fn invalidate_stats_cache() {
+    CACHE_INVALIDATED.store(true, Ordering::Relaxed);
+}
+
+/// Return cached stats without triggering a re-parse.
+pub fn get_cached_stats() -> Option<AllStats> {
+    STATS_CACHE.lock().ok()?.as_ref().map(|c| c.stats.clone())
+}
+
+// --- Provider ---
+
+/// GLM (Zhipu AI) provider stub.
+/// Currently no widely-used CLI agent with local session storage exists for GLM.
+/// This provider is a placeholder that returns empty stats and is_available() = false
+/// until a GLM CLI tool is established.
+///
+/// Expected future session path: ~/.glm/sessions/ or ~/.zhipu/sessions/
+/// Expected wire format: JSONL with OpenAI-compatible usage fields
+pub struct GlmProvider {
+    glm_dir: PathBuf,
+    zhipu_dir: PathBuf,
+}
+
+impl GlmProvider {
+    pub fn new() -> Self {
+        let home = dirs::home_dir().unwrap_or_default();
+        Self {
+            glm_dir: home.join(".glm"),
+            zhipu_dir: home.join(".zhipu"),
+        }
+    }
+}
+
+impl TokenProvider for GlmProvider {
+    fn name(&self) -> &str {
+        "GLM"
+    }
+
+    fn fetch_stats(&self) -> Result<AllStats, String> {
+        let was_invalidated = CACHE_INVALIDATED.swap(false, Ordering::Relaxed);
+
+        if !was_invalidated {
+            if let Ok(cache) = STATS_CACHE.lock() {
+                if let Some(ref cached) = *cache {
+                    if cached.computed_at.elapsed() < CACHE_TTL {
+                        return Ok(cached.stats.clone());
+                    }
+                }
+            }
+        }
+
+        let stats = AllStats {
+            daily: vec![],
+            model_usage: HashMap::new(),
+            total_sessions: 0,
+            total_messages: 0,
+            first_session_date: None,
+            analytics: None,
+        };
+
+        if let Ok(mut cache) = STATS_CACHE.lock() {
+            *cache = Some(StubCache {
+                stats: stats.clone(),
+                computed_at: Instant::now(),
+            });
+        }
+
+        Ok(stats)
+    }
+
+    fn is_available(&self) -> bool {
+        // Check both potential paths for a future GLM CLI
+        self.glm_dir.join("sessions").exists() || self.zhipu_dir.join("sessions").exists()
+    }
+}

--- a/src-tauri/src/providers/kimi.rs
+++ b/src-tauri/src/providers/kimi.rs
@@ -1,0 +1,493 @@
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant, SystemTime};
+
+use serde_json::Value;
+
+use super::pricing;
+use super::traits::TokenProvider;
+use super::types::{AllStats, DailyUsage, ModelUsage};
+
+// --- Cache infrastructure (mirrors codex.rs patterns) ---
+
+struct IncrementalCache {
+    stats: AllStats,
+    computed_at: Instant,
+    entries: HashMap<String, KimiEntry>,
+    file_meta: HashMap<PathBuf, (SystemTime, u64)>,
+}
+
+static STATS_CACHE: Mutex<Option<IncrementalCache>> = Mutex::new(None);
+static PARSING: AtomicBool = AtomicBool::new(false);
+static CACHE_INVALIDATED: AtomicBool = AtomicBool::new(false);
+const CACHE_TTL: Duration = Duration::from_secs(30);
+
+/// Invalidate cache — called by file watcher on .kimi/ changes.
+pub fn invalidate_stats_cache() {
+    CACHE_INVALIDATED.store(true, Ordering::Relaxed);
+}
+
+/// Return cached stats without triggering a re-parse (used by tray update).
+pub fn get_cached_stats() -> Option<AllStats> {
+    STATS_CACHE.lock().ok()?.as_ref().map(|c| c.stats.clone())
+}
+
+fn calculate_cost(pricing: &pricing::KimiPricing, input: u64, output: u64, cached: u64) -> f64 {
+    let uncached_input = input.saturating_sub(cached);
+    (uncached_input as f64 / 1_000_000.0) * pricing.input
+        + (output as f64 / 1_000_000.0) * pricing.output
+        + (cached as f64 / 1_000_000.0) * pricing.cache_read
+}
+
+// --- Entry type ---
+
+#[derive(Clone)]
+struct KimiEntry {
+    date: String,
+    model: String,
+    session_id: String,
+    input_tokens: u64,
+    output_tokens: u64,
+    cached_tokens: u64,
+}
+
+// --- Provider ---
+
+pub struct KimiProvider {
+    #[allow(dead_code)]
+    primary_dir: PathBuf,
+}
+
+impl KimiProvider {
+    pub fn new() -> Self {
+        let home = dirs::home_dir().unwrap_or_default();
+        let primary = home.join(".kimi");
+        Self { primary_dir: primary }
+    }
+
+    fn session_root(&self) -> PathBuf {
+        self.primary_dir.join("sessions")
+    }
+
+    /// Collect mtime/size metadata for all JSONL files.
+    fn collect_file_meta(&self) -> HashMap<PathBuf, (SystemTime, u64)> {
+        let mut meta = HashMap::new();
+        let root = self.session_root();
+        if !root.exists() {
+            return meta;
+        }
+        // Pattern: ~/.kimi/sessions/{GROUP_ID}/{SESSION_UUID}/wire.jsonl
+        let pattern = root
+            .join("**")
+            .join("*.jsonl")
+            .to_string_lossy()
+            .to_string();
+        let files = glob::glob(&pattern).unwrap_or_else(|_| glob::glob("").unwrap());
+        for path in files.flatten() {
+            if let Ok(m) = fs::metadata(&path) {
+                let mtime = m.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+                meta.insert(path, (mtime, m.len()));
+            }
+        }
+        meta
+    }
+
+    /// Parse a single JSONL file and return entries keyed by dedup key.
+    fn parse_single_file(path: &Path) -> HashMap<String, KimiEntry> {
+        let mut entries = HashMap::new();
+        let Ok(file) = fs::File::open(path) else {
+            return entries;
+        };
+
+        // Extract session ID from directory structure:
+        // ~/.kimi/sessions/{GROUP_ID}/{SESSION_UUID}/wire.jsonl
+        let session_id = path
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|s| s.to_str())
+            .unwrap_or("kimi-session")
+            .to_string();
+
+        let mut current_model = String::new();
+        let mut line_index: u32 = 0;
+
+        let reader = BufReader::with_capacity(64 * 1024, file);
+        for line in reader.lines().map_while(Result::ok) {
+            line_index += 1;
+
+            let Ok(value) = serde_json::from_str::<Value>(&line) else {
+                continue;
+            };
+
+            // Try to extract model from various possible locations
+            if current_model.is_empty() {
+                if let Some(model) = value.get("model").and_then(|v| v.as_str()) {
+                    if !model.is_empty() {
+                        current_model = model.to_string();
+                    }
+                }
+            }
+
+            // Look for usage data in the response
+            // Kimi wire format may use OpenAI-compatible structure:
+            // {"usage": {"prompt_tokens": N, "completion_tokens": N, "total_tokens": N}}
+            let usage = value.get("usage")
+                .or_else(|| value.pointer("/data/usage"));
+
+            let Some(usage_obj) = usage else {
+                // Also try to extract model from response objects without usage
+                if let Some(model) = value.get("model").and_then(|v| v.as_str()) {
+                    if !model.is_empty() {
+                        current_model = model.to_string();
+                    }
+                }
+                continue;
+            };
+
+            if usage_obj.is_null() {
+                continue;
+            }
+
+            let input = usage_obj
+                .get("prompt_tokens")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let output = usage_obj
+                .get("completion_tokens")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let cached = usage_obj
+                .get("cached_tokens")
+                .or_else(|| usage_obj.pointer("/prompt_tokens_details/cached_tokens"))
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+
+            if input == 0 && output == 0 {
+                continue;
+            }
+
+            // Update model from this response if available
+            if let Some(model) = value.get("model").and_then(|v| v.as_str()) {
+                if !model.is_empty() {
+                    current_model = model.to_string();
+                }
+            }
+
+            let date = extract_date_from_value(&value)
+                .unwrap_or_else(|| extract_date_from_file_mtime(path));
+
+            let model = if current_model.is_empty() {
+                "kimi-k2".to_string()
+            } else {
+                current_model.clone()
+            };
+
+            let key = format!("{}:{}", session_id, line_index);
+            entries.insert(
+                key,
+                KimiEntry {
+                    date,
+                    model,
+                    session_id: session_id.clone(),
+                    input_tokens: input,
+                    output_tokens: output,
+                    cached_tokens: cached,
+                },
+            );
+        }
+
+        entries
+    }
+
+    /// Incrementally parse only changed files.
+    fn parse_incremental(
+        current_meta: &HashMap<PathBuf, (SystemTime, u64)>,
+        cached_entries: &HashMap<String, KimiEntry>,
+        cached_meta: &HashMap<PathBuf, (SystemTime, u64)>,
+    ) -> HashMap<String, KimiEntry> {
+        let mut entries = cached_entries.clone();
+
+        let mut changed_files: Vec<&PathBuf> = Vec::new();
+        for (path, (mtime, size)) in current_meta {
+            match cached_meta.get(path) {
+                Some((cached_mtime, cached_size))
+                    if cached_mtime == mtime && cached_size == size => {}
+                _ => {
+                    changed_files.push(path);
+                }
+            }
+        }
+
+        // If files were deleted, do a full re-parse
+        let has_deleted = cached_meta.keys().any(|p| !current_meta.contains_key(p));
+        if has_deleted {
+            let mut fresh = HashMap::new();
+            for path in current_meta.keys() {
+                fresh.extend(Self::parse_single_file(path));
+            }
+            return fresh;
+        }
+
+        if !changed_files.is_empty() {
+            let start = Instant::now();
+            let count = changed_files.len();
+            for path in &changed_files {
+                let file_entries = Self::parse_single_file(path);
+                entries.extend(file_entries);
+            }
+            eprintln!(
+                "[PERF][Kimi] Incremental parse: {} changed files in {:?} (total {} files)",
+                count,
+                start.elapsed(),
+                current_meta.len()
+            );
+        }
+
+        entries
+    }
+
+    /// Build AllStats from parsed entries.
+    fn build_stats(entries: &HashMap<String, KimiEntry>) -> AllStats {
+        let mut daily_map: HashMap<String, DailyUsage> = HashMap::new();
+        let mut model_usage_map: HashMap<String, ModelUsage> = HashMap::new();
+        let mut total_messages: u32 = 0;
+        let mut first_date: Option<String> = None;
+        let mut daily_session_ids: HashMap<String, HashSet<String>> = HashMap::new();
+
+        for entry in entries.values() {
+            total_messages += 1;
+
+            if first_date.as_ref().map_or(true, |d| entry.date < *d) {
+                first_date = Some(entry.date.clone());
+            }
+
+            let pricing = pricing::get_kimi_pricing(&entry.model);
+            let cost = calculate_cost(
+                &pricing,
+                entry.input_tokens,
+                entry.output_tokens,
+                entry.cached_tokens,
+            );
+
+            let daily = daily_map
+                .entry(entry.date.clone())
+                .or_insert_with(|| DailyUsage {
+                    date: entry.date.clone(),
+                    tokens: HashMap::new(),
+                    cost_usd: 0.0,
+                    messages: 0,
+                    sessions: 0,
+                    tool_calls: 0,
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    cache_read_tokens: 0,
+                    cache_write_tokens: 0,
+                });
+            let total_tokens = entry.input_tokens + entry.output_tokens;
+            *daily.tokens.entry(entry.model.clone()).or_insert(0) += total_tokens;
+            daily.cost_usd += cost;
+            daily.messages += 1;
+            daily.input_tokens += entry.input_tokens.saturating_sub(entry.cached_tokens);
+            daily.output_tokens += entry.output_tokens;
+            daily.cache_read_tokens += entry.cached_tokens;
+
+            daily_session_ids
+                .entry(entry.date.clone())
+                .or_default()
+                .insert(entry.session_id.clone());
+
+            let mu = model_usage_map
+                .entry(entry.model.clone())
+                .or_insert_with(|| ModelUsage {
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    cache_read: 0,
+                    cache_write: 0,
+                    cost_usd: 0.0,
+                });
+            mu.input_tokens += entry.input_tokens.saturating_sub(entry.cached_tokens);
+            mu.output_tokens += entry.output_tokens;
+            mu.cache_read += entry.cached_tokens;
+            mu.cost_usd += cost;
+        }
+
+        // Set session counts from unique session IDs per day
+        for (date, session_ids) in &daily_session_ids {
+            if let Some(daily) = daily_map.get_mut(date) {
+                daily.sessions = session_ids.len() as u32;
+            }
+        }
+
+        let mut daily: Vec<DailyUsage> = daily_map.into_values().collect();
+        daily.sort_by(|a, b| a.date.cmp(&b.date));
+
+        let total_sessions = daily.iter().map(|d| d.sessions as u32).sum();
+
+        AllStats {
+            daily,
+            model_usage: model_usage_map,
+            total_sessions,
+            total_messages,
+            first_session_date: first_date,
+            analytics: None,
+        }
+    }
+
+    fn do_fetch_stats(&self) -> Result<AllStats, String> {
+        let start = Instant::now();
+        let current_meta = self.collect_file_meta();
+
+        let entries = if let Ok(cache) = STATS_CACHE.lock() {
+            if let Some(ref cached) = *cache {
+                if cached.file_meta == current_meta {
+                    drop(cache);
+                    if let Ok(mut cache) = STATS_CACHE.lock() {
+                        if let Some(ref mut cached) = *cache {
+                            cached.computed_at = Instant::now();
+                        }
+                    }
+                    eprintln!(
+                        "[PERF][Kimi] No files changed, reusing cache ({:?})",
+                        start.elapsed()
+                    );
+                    if let Ok(cache) = STATS_CACHE.lock() {
+                        if let Some(ref cached) = *cache {
+                            return Ok(cached.stats.clone());
+                        }
+                    }
+                    return Err("Cache lost during refresh".to_string());
+                }
+
+                Self::parse_incremental(&current_meta, &cached.entries, &cached.file_meta)
+            } else {
+                drop(cache);
+                eprintln!(
+                    "[PERF][Kimi] First run, full parse of {} files...",
+                    current_meta.len()
+                );
+                let full_start = Instant::now();
+                let mut entries = HashMap::new();
+                for path in current_meta.keys() {
+                    entries.extend(Self::parse_single_file(path));
+                }
+                eprintln!(
+                    "[PERF][Kimi] Full parse completed in {:?}",
+                    full_start.elapsed()
+                );
+                entries
+            }
+        } else {
+            return Err("Failed to acquire cache lock".to_string());
+        };
+
+        let stats = Self::build_stats(&entries);
+
+        if let Ok(mut cache) = STATS_CACHE.lock() {
+            *cache = Some(IncrementalCache {
+                stats: stats.clone(),
+                computed_at: Instant::now(),
+                entries,
+                file_meta: current_meta,
+            });
+        }
+
+        eprintln!("[PERF][Kimi] Total fetch_stats: {:?}", start.elapsed());
+        Ok(stats)
+    }
+}
+
+impl TokenProvider for KimiProvider {
+    fn name(&self) -> &str {
+        "Kimi"
+    }
+
+    fn fetch_stats(&self) -> Result<AllStats, String> {
+        let was_invalidated = CACHE_INVALIDATED.swap(false, Ordering::Relaxed);
+
+        if !was_invalidated {
+            if let Ok(cache) = STATS_CACHE.lock() {
+                if let Some(ref cached) = *cache {
+                    if cached.computed_at.elapsed() < CACHE_TTL {
+                        return Ok(cached.stats.clone());
+                    }
+                }
+            }
+        }
+
+        // Thundering herd prevention
+        if PARSING
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            if let Ok(cache) = STATS_CACHE.lock() {
+                if let Some(ref cached) = *cache {
+                    return Ok(cached.stats.clone());
+                }
+            }
+            std::thread::sleep(Duration::from_millis(100));
+            if let Ok(cache) = STATS_CACHE.lock() {
+                if let Some(ref cached) = *cache {
+                    return Ok(cached.stats.clone());
+                }
+            }
+            return Err("Kimi stats computation in progress".to_string());
+        }
+
+        let result = self.do_fetch_stats();
+        PARSING.store(false, Ordering::SeqCst);
+        result
+    }
+
+    fn is_available(&self) -> bool {
+        self.session_root().exists()
+    }
+}
+
+/// Extract date from a timestamp field in the JSON value (UTC → local).
+fn extract_date_from_value(value: &Value) -> Option<String> {
+    // Try common timestamp field names
+    let ts = value.get("created")
+        .or_else(|| value.get("created_at"))
+        .or_else(|| value.get("timestamp"));
+
+    if let Some(ts_val) = ts {
+        // Epoch seconds
+        if let Some(epoch) = ts_val.as_i64() {
+            let dt = chrono::DateTime::from_timestamp(epoch, 0)?;
+            let local = dt.with_timezone(&chrono::Local);
+            return Some(local.format("%Y-%m-%d").to_string());
+        }
+        // Epoch milliseconds
+        if let Some(epoch) = ts_val.as_f64() {
+            let secs = if epoch > 1e12 { (epoch / 1000.0) as i64 } else { epoch as i64 };
+            let dt = chrono::DateTime::from_timestamp(secs, 0)?;
+            let local = dt.with_timezone(&chrono::Local);
+            return Some(local.format("%Y-%m-%d").to_string());
+        }
+        // ISO string
+        if let Some(s) = ts_val.as_str() {
+            if s.len() >= 10 {
+                return Some(s[..10].to_string());
+            }
+        }
+    }
+
+    None
+}
+
+/// Fallback: extract date from file modification time.
+fn extract_date_from_file_mtime(path: &Path) -> String {
+    fs::metadata(path)
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .and_then(|t| {
+            let dt = chrono::DateTime::<chrono::Utc>::from(t);
+            let local = dt.with_timezone(&chrono::Local);
+            Some(local.format("%Y-%m-%d").to_string())
+        })
+        .unwrap_or_else(|| chrono::Local::now().format("%Y-%m-%d").to_string())
+}

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -1,5 +1,7 @@
 pub mod claude_code;
 pub mod codex;
+pub mod glm;
+pub mod kimi;
 pub mod opencode;
 pub mod pricing;
 pub mod traits;

--- a/src-tauri/src/providers/pricing.rs
+++ b/src-tauri/src/providers/pricing.rs
@@ -14,6 +14,10 @@ struct PricingConfig {
     codex: ProviderConfig,
     #[serde(default)]
     opencode: Option<ProviderConfig>,
+    #[serde(default)]
+    kimi: Option<ProviderConfig>,
+    #[serde(default)]
+    glm: Option<ProviderConfig>,
 }
 
 #[derive(Deserialize)]
@@ -61,6 +65,19 @@ pub struct OpenCodePricing {
     pub output: f64,
     pub cache_read: f64,
     pub cache_write: f64,
+}
+
+pub struct KimiPricing {
+    pub input: f64,
+    pub output: f64,
+    pub cache_read: f64,
+}
+
+#[allow(dead_code)]
+pub struct GlmPricing {
+    pub input: f64,
+    pub output: f64,
+    pub cache_read: f64,
 }
 
 // --- Loading ---
@@ -122,6 +139,35 @@ pub fn get_codex_pricing(model: &str) -> CodexPricing {
     }
 }
 
+pub fn get_kimi_pricing(model: &str) -> KimiPricing {
+    let cfg = config();
+    if let Some(ref kimi) = cfg.kimi {
+        let entry = find_pricing(kimi, model);
+        return KimiPricing {
+            input: entry.input,
+            output: entry.output,
+            cache_read: entry.cache_read,
+        };
+    }
+    // Fallback defaults
+    KimiPricing { input: 0.60, output: 2.00, cache_read: 0.0 }
+}
+
+#[allow(dead_code)]
+pub fn get_glm_pricing(model: &str) -> GlmPricing {
+    let cfg = config();
+    if let Some(ref glm) = cfg.glm {
+        let entry = find_pricing(glm, model);
+        return GlmPricing {
+            input: entry.input,
+            output: entry.output,
+            cache_read: entry.cache_read,
+        };
+    }
+    // Fallback defaults
+    GlmPricing { input: 0.50, output: 1.00, cache_read: 0.0 }
+}
+
 pub fn get_opencode_pricing(model: &str) -> OpenCodePricing {
     let cfg = config();
     // Use dedicated opencode pricing if available, otherwise try to match
@@ -175,6 +221,10 @@ pub struct PricingTable {
     pub codex: Vec<PricingRow>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub opencode: Vec<PricingRow>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub kimi: Vec<PricingRow>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub glm: Vec<PricingRow>,
 }
 
 fn format_price(val: f64) -> String {
@@ -217,6 +267,8 @@ pub fn get_pricing_table() -> PricingTable {
         claude: deduplicated_rows(&cfg.claude, false),
         codex: deduplicated_rows(&cfg.codex, true),
         opencode: cfg.opencode.as_ref().map(|oc| deduplicated_rows(oc, false)).unwrap_or_default(),
+        kimi: cfg.kimi.as_ref().map(|k| deduplicated_rows(k, false)).unwrap_or_default(),
+        glm: cfg.glm.as_ref().map(|g| deduplicated_rows(g, false)).unwrap_or_default(),
     }
 }
 
@@ -231,6 +283,10 @@ mod tests {
         assert!(!cfg.codex.models.is_empty());
         assert!(cfg.opencode.is_some());
         assert!(!cfg.opencode.unwrap().models.is_empty());
+        assert!(cfg.kimi.is_some());
+        assert!(!cfg.kimi.unwrap().models.is_empty());
+        assert!(cfg.glm.is_some());
+        assert!(!cfg.glm.unwrap().models.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/providers/types.rs
+++ b/src-tauri/src/providers/types.rs
@@ -93,6 +93,10 @@ pub struct UserPreferences {
     pub include_codex: bool,
     #[serde(default)]
     pub include_opencode: bool,
+    #[serde(default)]
+    pub include_kimi: bool,
+    #[serde(default)]
+    pub include_glm: bool,
     #[serde(default = "default_codex_dirs")]
     pub codex_dirs: Vec<String>,
     #[serde(default)]
@@ -244,6 +248,8 @@ impl Default for UserPreferences {
             include_claude: true,
             include_codex: false,
             include_opencode: false,
+            include_kimi: false,
+            include_glm: false,
             codex_dirs: default_codex_dirs(),
             salary_enabled: false,
             monthly_salary: None,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,6 +72,8 @@ function AppContent() {
     includeClaude: prefs.include_claude,
     includeCodex: prefs.include_codex,
     includeOpencode: prefs.include_opencode,
+    includeKimi: prefs.include_kimi,
+    includeGlm: prefs.include_glm,
   });
   const t = useI18n();
   const { user, profile } = useAuth();

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -153,6 +153,8 @@ function LeaderboardContent({ user }: { user: User }) {
   if (prefs.include_claude) availableProviders.push("claude");
   if (prefs.include_codex) availableProviders.push("codex");
   if (prefs.include_opencode) availableProviders.push("opencode");
+  if (prefs.include_kimi) availableProviders.push("kimi");
+  if (prefs.include_glm) availableProviders.push("glm");
   // Default to claude if nothing enabled
   if (availableProviders.length === 0) availableProviders.push("claude");
 

--- a/src/components/LeaderboardUploader.tsx
+++ b/src/components/LeaderboardUploader.tsx
@@ -28,6 +28,8 @@ export function LeaderboardUploader() {
   const { stats: claudeStats } = useTokenStats("claude");
   const { stats: codexStats } = useTokenStats("codex");
   const { stats: opencodeStats } = useTokenStats("opencode");
+  const { stats: kimiStats } = useTokenStats("kimi");
+  const { stats: glmStats } = useTokenStats("glm");
 
   const claude = useSnapshotUploader({
     stats: prefs.include_claude ? claudeStats : null,
@@ -47,23 +49,43 @@ export function LeaderboardUploader() {
     optedIn,
     provider: "opencode",
   });
+  const kimi = useSnapshotUploader({
+    stats: prefs.include_kimi ? kimiStats : null,
+    user,
+    optedIn,
+    provider: "kimi",
+  });
+  const glm = useSnapshotUploader({
+    stats: prefs.include_glm ? glmStats : null,
+    user,
+    optedIn,
+    provider: "glm",
+  });
 
   const runners = useMemo<Partial<Record<LeaderboardProvider, BackfillRunner>>>(
     () => ({
       claude: prefs.include_claude && claude.ready ? claude.manualBackfill : undefined,
       codex: prefs.include_codex && codex.ready ? codex.manualBackfill : undefined,
       opencode: prefs.include_opencode && opencode.ready ? opencode.manualBackfill : undefined,
+      kimi: prefs.include_kimi && kimi.ready ? kimi.manualBackfill : undefined,
+      glm: prefs.include_glm && glm.ready ? glm.manualBackfill : undefined,
     }),
     [
       prefs.include_claude,
       prefs.include_codex,
       prefs.include_opencode,
+      prefs.include_kimi,
+      prefs.include_glm,
       claude.ready,
       codex.ready,
       opencode.ready,
+      kimi.ready,
+      glm.ready,
       claude.manualBackfill,
       codex.manualBackfill,
       opencode.manualBackfill,
+      kimi.manualBackfill,
+      glm.manualBackfill,
     ],
   );
 

--- a/src/components/SourceSelector.tsx
+++ b/src/components/SourceSelector.tsx
@@ -1,13 +1,30 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useSettings } from "../contexts/SettingsContext";
 import { useI18n } from "../i18n/I18nContext";
+
+type SourceKey =
+  | "include_claude"
+  | "include_codex"
+  | "include_opencode"
+  | "include_kimi"
+  | "include_glm";
+
+interface SourceDef {
+  key: SourceKey;
+  label: string;
+  available: boolean;
+}
 
 export function SourceSelector() {
   const { prefs, updatePrefs } = useSettings();
   const t = useI18n();
   const [codexAvailable, setCodexAvailable] = useState(false);
   const [opencodeAvailable, setOpencodeAvailable] = useState(false);
+  const [kimiAvailable, setKimiAvailable] = useState(false);
+  const [glmAvailable, setGlmAvailable] = useState(false);
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     invoke<boolean>("is_codex_available")
@@ -16,18 +33,66 @@ export function SourceSelector() {
     invoke<boolean>("is_opencode_available")
       .then(setOpencodeAvailable)
       .catch(() => setOpencodeAvailable(false));
+    invoke<boolean>("is_kimi_available")
+      .then(setKimiAvailable)
+      .catch(() => setKimiAvailable(false));
+    invoke<boolean>("is_glm_available")
+      .then(setGlmAvailable)
+      .catch(() => setGlmAvailable(false));
   }, []);
 
-  // Hide entirely if no additional sources are available
-  if (!codexAvailable && !opencodeAvailable) return null;
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey, true);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey, true);
+    };
+  }, [open]);
 
-  const toggleSource = (key: "include_claude" | "include_codex" | "include_opencode") => {
+  const sources: SourceDef[] = useMemo(() => [
+    { key: "include_claude", label: t("sources.claude"), available: true },
+    { key: "include_codex", label: t("sources.codex"), available: codexAvailable },
+    { key: "include_opencode", label: t("sources.opencode"), available: opencodeAvailable },
+    { key: "include_kimi", label: t("sources.kimi"), available: kimiAvailable },
+    { key: "include_glm", label: t("sources.glm"), available: glmAvailable },
+  ], [t, codexAvailable, opencodeAvailable, kimiAvailable, glmAvailable]);
+
+  const visibleSources = sources.filter((s) => s.available);
+  const totalCount = visibleSources.length;
+  const activeCount = visibleSources.reduce((n, s) => n + (prefs[s.key] ? 1 : 0), 0);
+
+  // Hide entirely if only Claude is available (no multi-source UX needed)
+  if (totalCount <= 1) return null;
+
+  const toggleSource = (key: SourceKey) => {
     const nextValue = !prefs[key];
-    const activeCount = Number(prefs.include_claude) + Number(prefs.include_codex) + Number(prefs.include_opencode);
-    // Must keep at least one source active
-    if (!nextValue && activeCount === 1) return;
+    // Must keep at least one source active among visible/available ones
+    const currentActiveVisible = visibleSources.reduce(
+      (n, s) => n + (prefs[s.key] ? 1 : 0),
+      0,
+    );
+    if (!nextValue && currentActiveVisible === 1 && prefs[key]) return;
     updatePrefs({ [key]: nextValue });
   };
+
+  const summary = t("sources.summary.count", {
+    active: String(activeCount),
+    total: String(totalCount),
+  });
 
   return (
     <div style={{
@@ -47,86 +112,122 @@ export function SourceSelector() {
         {t("sources.title")}
       </div>
 
-      <div style={{ display: "flex", gap: 8 }}>
-        <SourceToggle
-          label={t("sources.claude")}
-          checked={prefs.include_claude}
-          locked={!prefs.include_codex && !prefs.include_opencode}
-          onClick={() => toggleSource("include_claude")}
-        />
-        {codexAvailable && (
-          <SourceToggle
-            label={t("sources.codex")}
-            checked={prefs.include_codex}
-            locked={!prefs.include_claude && !prefs.include_opencode}
-            onClick={() => toggleSource("include_codex")}
-          />
-        )}
-        {opencodeAvailable && (
-          <SourceToggle
-            label={t("sources.opencode")}
-            checked={prefs.include_opencode}
-            locked={!prefs.include_claude && !prefs.include_codex}
-            onClick={() => toggleSource("include_opencode")}
-          />
+      <div ref={menuRef} style={{ position: "relative" }}>
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-label={t("sources.open")}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            padding: "4px 10px",
+            borderRadius: 999,
+            border: open ? "1px solid var(--accent-purple)" : "1px solid var(--heat-2)",
+            background: "var(--bg-card)",
+            color: "var(--text-primary)",
+            fontSize: 11,
+            fontWeight: 700,
+            cursor: "pointer",
+            transition: "border-color 0.15s ease",
+          }}
+        >
+          <span>{summary}</span>
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            style={{
+              transform: open ? "rotate(180deg)" : "none",
+              transition: "transform 0.15s ease",
+            }}
+            aria-hidden="true"
+          >
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </button>
+
+        {open && (
+          <div
+            role="menu"
+            style={{
+              position: "absolute",
+              top: "calc(100% + 6px)",
+              right: 0,
+              minWidth: 180,
+              padding: 4,
+              background: "var(--bg-card)",
+              borderRadius: 10,
+              border: "1px solid rgba(128,128,128,0.15)",
+              boxShadow: "0 12px 32px rgba(0,0,0,0.18), 0 2px 8px rgba(0,0,0,0.08)",
+              zIndex: 60,
+              transformOrigin: "top right",
+              animation: "headerMenuPop 0.16s cubic-bezier(.2,.9,.2,1) both",
+            }}
+          >
+            {visibleSources.map((s) => {
+              const checked = !!prefs[s.key];
+              const activeVisible = visibleSources.reduce(
+                (n, v) => n + (prefs[v.key] ? 1 : 0),
+                0,
+              );
+              const locked = checked && activeVisible === 1;
+              return (
+                <button
+                  key={s.key}
+                  role="menuitemcheckbox"
+                  aria-checked={checked}
+                  onClick={() => toggleSource(s.key)}
+                  disabled={locked}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 10,
+                    width: "100%",
+                    padding: "6px 8px",
+                    background: "none",
+                    border: "none",
+                    borderRadius: 6,
+                    cursor: locked ? "default" : "pointer",
+                    color: "var(--text-primary)",
+                    fontSize: 12,
+                    fontWeight: 600,
+                    textAlign: "left",
+                    opacity: locked ? 0.7 : 1,
+                  }}
+                >
+                  <span style={{
+                    width: 14,
+                    height: 14,
+                    borderRadius: 3,
+                    border: checked ? "1px solid var(--accent-purple)" : "1px solid var(--heat-2)",
+                    background: checked ? "var(--accent-purple)" : "transparent",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    color: "#fff",
+                    flexShrink: 0,
+                  }}>
+                    {checked ? (
+                      <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                        <polyline points="20 6 9 17 4 12" />
+                      </svg>
+                    ) : null}
+                  </span>
+                  <span>{s.label}</span>
+                </button>
+              );
+            })}
+          </div>
         )}
       </div>
     </div>
-  );
-}
-
-function SourceToggle({
-  label,
-  checked,
-  locked,
-  onClick,
-}: {
-  label: string;
-  checked: boolean;
-  locked: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      aria-pressed={checked}
-      onClick={onClick}
-      style={{
-        display: "inline-flex",
-        alignItems: "center",
-        gap: 6,
-        padding: "4px 10px",
-        borderRadius: 999,
-        border: checked ? "1px solid var(--heat-2)" : "1px solid transparent",
-        background: checked ? "var(--bg-card)" : "var(--heat-0)",
-        color: checked ? "var(--text-primary)" : "var(--text-secondary)",
-        fontSize: 11,
-        fontWeight: 700,
-        cursor: locked ? "default" : "pointer",
-        opacity: locked && checked ? 0.88 : 1,
-        boxShadow: checked ? "0 1px 4px rgba(0,0,0,0.06)" : "none",
-        transition: "all 0.15s ease",
-      }}
-    >
-      <span style={{
-        width: 12,
-        height: 12,
-        borderRadius: 3,
-        border: checked ? "1px solid var(--accent-purple)" : "1px solid var(--heat-2)",
-        background: checked ? "var(--accent-purple)" : "transparent",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        color: "#fff",
-        flexShrink: 0,
-      }}>
-        {checked ? (
-          <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
-            <polyline points="20 6 9 17 4 12" />
-          </svg>
-        ) : null}
-      </span>
-      {label}
-    </button>
   );
 }

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -20,6 +20,8 @@ const defaultPrefs: UserPreferences = {
   include_claude: true,
   include_codex: false,
   include_opencode: false,
+  include_kimi: false,
+  include_glm: false,
   theme: "github",
   color_mode: "system",
   language: "en",

--- a/src/hooks/useBackfill.ts
+++ b/src/hooks/useBackfill.ts
@@ -10,17 +10,21 @@ import {
 } from "../lib/backfillRegistry";
 import type { LeaderboardProvider } from "../lib/types";
 
-const PROVIDERS: LeaderboardProvider[] = ["claude", "codex", "opencode"];
+const PROVIDERS: LeaderboardProvider[] = ["claude", "codex", "opencode", "kimi", "glm"];
 
 function activeProviders(prefs: {
   include_claude: boolean;
   include_codex: boolean;
   include_opencode: boolean;
+  include_kimi: boolean;
+  include_glm: boolean;
 }): LeaderboardProvider[] {
   return PROVIDERS.filter((p) => {
     if (p === "claude") return prefs.include_claude;
     if (p === "codex") return prefs.include_codex;
-    return prefs.include_opencode;
+    if (p === "opencode") return prefs.include_opencode;
+    if (p === "kimi") return prefs.include_kimi;
+    return prefs.include_glm;
   });
 }
 

--- a/src/hooks/useCombinedStats.ts
+++ b/src/hooks/useCombinedStats.ts
@@ -6,36 +6,51 @@ interface UseCombinedStatsProps {
   includeClaude: boolean;
   includeCodex: boolean;
   includeOpencode: boolean;
+  includeKimi: boolean;
+  includeGlm: boolean;
 }
 
-export function useCombinedStats({ includeClaude, includeCodex, includeOpencode }: UseCombinedStatsProps) {
+export function useCombinedStats({ includeClaude, includeCodex, includeOpencode, includeKimi, includeGlm }: UseCombinedStatsProps) {
   const claude = useTokenStats("claude");
   const codex = useTokenStats("codex");
   const opencode = useTokenStats("opencode");
+  const kimi = useTokenStats("kimi");
+  const glm = useTokenStats("glm");
 
   const stats = useMemo<AllStats | null>(() => {
     const sources: (AllStats | null)[] = [];
     if (includeClaude) sources.push(claude.stats);
     if (includeCodex) sources.push(codex.stats);
     if (includeOpencode) sources.push(opencode.stats);
+    if (includeKimi) sources.push(kimi.stats);
+    if (includeGlm) sources.push(glm.stats);
 
     const validStats = sources.filter((s): s is AllStats => s !== null);
-    if (validStats.length === 0) return includeClaude ? claude.stats : includeCodex ? codex.stats : opencode.stats;
+    if (validStats.length === 0) {
+      if (includeClaude) return claude.stats;
+      if (includeCodex) return codex.stats;
+      if (includeOpencode) return opencode.stats;
+      if (includeKimi) return kimi.stats;
+      if (includeGlm) return glm.stats;
+      return null;
+    }
     if (validStats.length === 1) return validStats[0];
 
     return mergeStats(validStats);
-  }, [claude.stats, codex.stats, opencode.stats, includeClaude, includeCodex, includeOpencode]);
+  }, [claude.stats, codex.stats, opencode.stats, kimi.stats, glm.stats, includeClaude, includeCodex, includeOpencode, includeKimi, includeGlm]);
 
-  const loading = (includeClaude && claude.loading) || (includeCodex && codex.loading) || (includeOpencode && opencode.loading);
+  const loading = (includeClaude && claude.loading) || (includeCodex && codex.loading) || (includeOpencode && opencode.loading) || (includeKimi && kimi.loading) || (includeGlm && glm.loading);
   const error = useMemo(() => {
     if (stats) return null;
 
     if (includeClaude && claude.error) return claude.error;
     if (includeCodex && codex.error) return codex.error;
     if (includeOpencode && opencode.error) return opencode.error;
+    if (includeKimi && kimi.error) return kimi.error;
+    if (includeGlm && glm.error) return glm.error;
 
     return null;
-  }, [stats, includeClaude, includeCodex, includeOpencode, claude.error, codex.error, opencode.error]);
+  }, [stats, includeClaude, includeCodex, includeOpencode, includeKimi, includeGlm, claude.error, codex.error, opencode.error, kimi.error, glm.error]);
 
   return { stats, loading, error };
 }

--- a/src/hooks/useTokenStats.ts
+++ b/src/hooks/useTokenStats.ts
@@ -3,7 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import type { AllStats } from "../lib/types";
 
-export type StatsProvider = "claude" | "codex" | "opencode";
+export type StatsProvider = "claude" | "codex" | "opencode" | "kimi" | "glm";
 
 export function useTokenStats(provider: StatsProvider = "claude") {
   const [stats, setStats] = useState<AllStats | null>(null);
@@ -15,7 +15,7 @@ export function useTokenStats(provider: StatsProvider = "claude") {
   const fetchStats = useCallback(async () => {
     const requestId = ++requestIdRef.current;
     try {
-      const command = provider === "codex" ? "get_codex_stats" : provider === "opencode" ? "get_opencode_stats" : "get_all_stats";
+      const command = provider === "codex" ? "get_codex_stats" : provider === "opencode" ? "get_opencode_stats" : provider === "kimi" ? "get_kimi_stats" : provider === "glm" ? "get_glm_stats" : "get_all_stats";
       const data = await invoke<AllStats>(command);
       if (requestId !== requestIdRef.current) return;
       setStats(data);

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -14,6 +14,10 @@
   "sources.claude": "Claude",
   "sources.codex": "Codex",
   "sources.opencode": "OpenCode",
+  "sources.kimi": "Kimi",
+  "sources.glm": "GLM",
+  "sources.summary.count": "{{active}} von {{total}} aktiv",
+  "sources.open": "Quellenmenü öffnen",
 
   "today.title": "Heute",
   "today.tokens": "Token",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -14,6 +14,10 @@
   "sources.claude": "Claude",
   "sources.codex": "Codex",
   "sources.opencode": "OpenCode",
+  "sources.kimi": "Kimi",
+  "sources.glm": "GLM",
+  "sources.summary.count": "{{active}} of {{total}} active",
+  "sources.open": "Open sources menu",
 
   "today.title": "Today",
   "today.tokens": "tokens",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -14,6 +14,10 @@
   "sources.claude": "Claude",
   "sources.codex": "Codex",
   "sources.opencode": "OpenCode",
+  "sources.kimi": "Kimi",
+  "sources.glm": "GLM",
+  "sources.summary.count": "{{active}} de {{total}} activas",
+  "sources.open": "Abrir menú de fuentes",
 
   "today.title": "Hoy",
   "today.tokens": "tokens",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -14,6 +14,10 @@
   "sources.claude": "Claude",
   "sources.codex": "Codex",
   "sources.opencode": "OpenCode",
+  "sources.kimi": "Kimi",
+  "sources.glm": "GLM",
+  "sources.summary.count": "{{active}} sur {{total}} actives",
+  "sources.open": "Ouvrir le menu des sources",
 
   "today.title": "Aujourd'hui",
   "today.tokens": "jetons",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -14,6 +14,10 @@
   "sources.claude": "Claude",
   "sources.codex": "Codex",
   "sources.opencode": "OpenCode",
+  "sources.kimi": "Kimi",
+  "sources.glm": "GLM",
+  "sources.summary.count": "{{active}} di {{total}} attive",
+  "sources.open": "Apri menu sorgenti",
 
   "today.title": "Oggi",
   "today.tokens": "token",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -14,6 +14,10 @@
   "sources.claude": "Claude",
   "sources.codex": "Codex",
   "sources.opencode": "OpenCode",
+  "sources.kimi": "Kimi",
+  "sources.glm": "GLM",
+  "sources.summary.count": "{{total}}中{{active}}使用",
+  "sources.open": "ソースメニューを開く",
 
   "today.title": "今日",
   "today.tokens": "トークン",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -14,6 +14,10 @@
   "sources.claude": "Claude",
   "sources.codex": "Codex",
   "sources.opencode": "OpenCode",
+  "sources.kimi": "Kimi",
+  "sources.glm": "GLM",
+  "sources.summary.count": "{{total}}개 중 {{active}}개 사용",
+  "sources.open": "소스 메뉴 열기",
 
   "today.title": "오늘",
   "today.tokens": "토큰",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -14,6 +14,10 @@
   "sources.claude": "Claude",
   "sources.codex": "Codex",
   "sources.opencode": "OpenCode",
+  "sources.kimi": "Kimi",
+  "sources.glm": "GLM",
+  "sources.summary.count": "{{total}} içinden {{active}} aktif",
+  "sources.open": "Kaynak menüsünü aç",
 
   "today.title": "Bugün",
   "today.tokens": "token",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -14,6 +14,10 @@
   "sources.claude": "Claude",
   "sources.codex": "Codex",
   "sources.opencode": "OpenCode",
+  "sources.kimi": "Kimi",
+  "sources.glm": "GLM",
+  "sources.summary.count": "{{total}} 个中 {{active}} 个启用",
+  "sources.open": "打开来源菜单",
 
   "today.title": "今日",
   "today.tokens": "令牌",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -14,6 +14,10 @@
   "sources.claude": "Claude",
   "sources.codex": "Codex",
   "sources.opencode": "OpenCode",
+  "sources.kimi": "Kimi",
+  "sources.glm": "GLM",
+  "sources.summary.count": "{{total}} 個中 {{active}} 個啟用",
+  "sources.open": "開啟來源選單",
 
   "today.title": "今日",
   "today.tokens": "令牌",

--- a/src/lib/badgeSvgTemplate.ts
+++ b/src/lib/badgeSvgTemplate.ts
@@ -14,12 +14,16 @@ export const PROVIDER_COLORS: Record<LeaderboardProvider, string> = {
   claude: "#7C5CFC",
   codex: "#0ea5e9",
   opencode: "#d97706",
+  kimi: "#1a73e8",
+  glm: "#00b96b",
 };
 
 export const PROVIDER_LABELS: Record<LeaderboardProvider, string> = {
   claude: "Claude",
   codex: "Codex",
   opencode: "OpenCode",
+  kimi: "Kimi",
+  glm: "GLM",
 };
 
 export const PERIOD_LABELS: Record<string, string> = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -60,7 +60,7 @@ export interface AllStats {
   analytics?: AnalyticsData;
 }
 
-export type LeaderboardProvider = "claude" | "codex" | "opencode";
+export type LeaderboardProvider = "claude" | "codex" | "opencode" | "kimi" | "glm";
 
 export interface UserPreferences {
   number_format: "compact" | "full";
@@ -70,6 +70,8 @@ export interface UserPreferences {
   include_claude: boolean;
   include_codex: boolean;
   include_opencode: boolean;
+  include_kimi: boolean;
+  include_glm: boolean;
   theme: "github" | "purple" | "ocean" | "sunset";
   color_mode: "system" | "light" | "dark";
   language: "en" | "ko" | "ja" | "zh-CN" | "zh-TW" | "fr" | "es" | "de" | "tr" | "it";

--- a/supabase/functions/badge/index.ts
+++ b/supabase/functions/badge/index.ts
@@ -4,12 +4,16 @@ const PROVIDER_COLORS: Record<string, string> = {
   claude: "#7C5CFC",
   codex: "#0ea5e9",
   opencode: "#d97706",
+  kimi: "#1a73e8",
+  glm: "#00b96b",
 };
 
 const PROVIDER_LABELS: Record<string, string> = {
   claude: "Claude",
   codex: "Codex",
   opencode: "OpenCode",
+  kimi: "Kimi",
+  glm: "GLM",
 };
 
 const PERIOD_LABELS: Record<string, string> = {
@@ -18,7 +22,7 @@ const PERIOD_LABELS: Record<string, string> = {
   month: "This Month",
 };
 
-const VALID_PROVIDERS = new Set(["claude", "codex", "opencode"]);
+const VALID_PROVIDERS = new Set(["claude", "codex", "opencode", "kimi", "glm"]);
 const VALID_PERIODS = new Set(["today", "week", "month"]);
 const VALID_STYLES = new Set(["flat", "flat-square", "card"]);
 

--- a/supabase/migrations/20260417040000_add_kimi_glm_providers.sql
+++ b/supabase/migrations/20260417040000_add_kimi_glm_providers.sql
@@ -1,0 +1,162 @@
+-- Extend the provider whitelist on daily_snapshots to accept 'kimi' and 'glm'.
+--
+-- Client-side Kimi/GLM providers were added in PR #125 but the Supabase layer
+-- still rejects those values at two points:
+--   1. the daily_snapshots_provider_check CHECK constraint
+--   2. the sync_device_snapshots() RPC's provider validation
+-- Without this migration, leaderboard uploads for Kimi/GLM silently fail at
+-- the RPC boundary.
+--
+-- The function body below is copied verbatim from
+-- 20260417030000_swap_sync_device_snapshots_to_v2.sql (the current bulk-UPSERT
+-- implementation) with only the `p_provider not in (...)` list widened.
+-- Keeping the rest identical avoids accidental behavior drift.
+
+alter table daily_snapshots
+drop constraint if exists daily_snapshots_provider_check;
+
+alter table daily_snapshots
+add constraint daily_snapshots_provider_check
+check (provider in ('claude', 'codex', 'opencode', 'kimi', 'glm'));
+
+create or replace function sync_device_snapshots(
+  p_provider text,
+  p_device_id text,
+  p_rows jsonb default '[]'::jsonb,
+  p_stale_dates date[] default '{}'::date[]
+) returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+begin
+  if v_user_id is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  if p_provider not in ('claude', 'codex', 'opencode', 'kimi', 'glm') then
+    raise exception 'Invalid provider';
+  end if;
+
+  if p_device_id is null or btrim(p_device_id) = '' then
+    raise exception 'Missing device_id';
+  end if;
+
+  -- Step 1: bulk stale cleanup.
+  if p_stale_dates is not null and array_length(p_stale_dates, 1) is not null then
+    delete from daily_snapshots d
+    where d.user_id = v_user_id
+      and d.provider = p_provider
+      and d.date = any(p_stale_dates)
+      and coalesce(
+        (
+          select jsonb_object_agg(key, value)
+          from jsonb_each(coalesce(d.device_snapshots, '{}'::jsonb) - p_device_id) e
+          where coalesce((e.value->>'submitted_at')::timestamptz, now())
+                >= now() - interval '30 days'
+        ),
+        '{}'::jsonb
+      ) = '{}'::jsonb;
+
+    with pruned as (
+      select
+        s.user_id,
+        s.date,
+        s.provider,
+        (
+          select jsonb_object_agg(key, value)
+          from jsonb_each(coalesce(s.device_snapshots, '{}'::jsonb) - p_device_id) e
+          where coalesce((e.value->>'submitted_at')::timestamptz, now())
+                >= now() - interval '30 days'
+        ) as next_snapshots
+      from daily_snapshots s
+      where s.user_id = v_user_id
+        and s.provider = p_provider
+        and s.date = any(p_stale_dates)
+      for update
+    )
+    update daily_snapshots d
+    set
+      device_snapshots = p.next_snapshots,
+      total_tokens = t.total_tokens,
+      cost_usd = t.cost_usd,
+      messages = t.messages,
+      sessions = t.sessions,
+      submitted_at = now()
+    from pruned p, lateral snapshot_totals(p.next_snapshots) t
+    where d.user_id = p.user_id
+      and d.provider = p.provider
+      and d.date = p.date
+      and p.next_snapshots is not null;
+  end if;
+
+  -- Step 2: bulk upsert.
+  if p_rows is not null and jsonb_array_length(p_rows) > 0 then
+    with incoming as (
+      select
+        (row_data->>'date')::date as date,
+        jsonb_build_object(
+          'total_tokens', coalesce((row_data->>'total_tokens')::bigint, 0),
+          'cost_usd',     coalesce((row_data->>'cost_usd')::numeric(10,4), 0),
+          'messages',     coalesce((row_data->>'messages')::integer, 0),
+          'sessions',     coalesce((row_data->>'sessions')::integer, 0),
+          'submitted_at', now()
+        ) as device_payload
+      from jsonb_array_elements(coalesce(p_rows, '[]'::jsonb)) row_data
+    ),
+    merged as (
+      select
+        i.date,
+        coalesce(
+          (
+            select jsonb_object_agg(key, value)
+            from jsonb_each(
+              jsonb_set(
+                coalesce(existing.device_snapshots, '{}'::jsonb) - '__legacy__',
+                array[p_device_id],
+                i.device_payload,
+                true
+              )
+            ) e
+            where coalesce((e.value->>'submitted_at')::timestamptz, now())
+                  >= now() - interval '30 days'
+          ),
+          jsonb_build_object(p_device_id, i.device_payload)
+        ) as next_snapshots
+      from incoming i
+      left join daily_snapshots existing
+        on existing.user_id = v_user_id
+       and existing.provider = p_provider
+       and existing.date = i.date
+    )
+    insert into daily_snapshots (
+      user_id, date, provider,
+      total_tokens, cost_usd, messages, sessions,
+      device_snapshots, submitted_at
+    )
+    select
+      v_user_id,
+      m.date,
+      p_provider,
+      t.total_tokens,
+      t.cost_usd,
+      t.messages,
+      t.sessions,
+      m.next_snapshots,
+      now()
+    from merged m, lateral snapshot_totals(m.next_snapshots) t
+    on conflict (user_id, date, provider) do update set
+      device_snapshots = excluded.device_snapshots,
+      total_tokens     = excluded.total_tokens,
+      cost_usd         = excluded.cost_usd,
+      messages         = excluded.messages,
+      sessions         = excluded.sessions,
+      submitted_at     = excluded.submitted_at;
+  end if;
+end;
+$$;
+
+revoke all on function sync_device_snapshots(text, text, jsonb, date[]) from public;
+grant execute on function sync_device_snapshots(text, text, jsonb, date[]) to authenticated;


### PR DESCRIPTION
## Summary

GitHub 이슈 요청(Johnny-xuan)으로 **Kimi** (full implementation) + **GLM** (stub, gated off) 신규 프로바이더 추가. tokscale(1.9K stars)의 하드코딩 경로 디스커버리 패턴을 따라, 사용자 기기에 CLI가 설치된 경우에만 UI에 노출됩니다.

### 백엔드 (Rust)
- **Kimi**: `~/.kimi/sessions/{GROUP_ID}/{SESSION_UUID}/wire.jsonl` JSONL 파서, 증분 갱신, mtime/size 기반 캐시 (codex.rs 패턴 재사용)
- **GLM**: 구조체/커맨드는 존재하나 `is_available()`을 `false`로 고정 (파싱 실구현 시 해제)
- `pricing.json`: kimi/glm 섹션 신규 (Kimi \$0.60/\$2.00, GLM \$0.50/\$1.00)
- Tauri 커맨드 4개 + file watcher/tray title 통합

### 프론트엔드 (TypeScript/React)
- `LeaderboardProvider` union에 kimi/glm 추가, 훅/컨텍스트/배지 배선
- **`SourceSelector` Pill → 드롭다운화**: `{{active}}/{{total}} active ▾` 트리거, Header.tsx 드롭다운 패턴(외부 클릭/ESC/`headerMenuPop` 애니메이션) 재사용, `role=menuitemcheckbox` + `aria-checked`
- i18n 10개 로케일에 `sources.kimi`, `sources.glm`, `sources.summary.count`, `sources.open` 키 추가

### Supabase 백엔드 (Codex 리뷰 반영)
- 신규 마이그레이션 `20260417040000_add_kimi_glm_providers.sql`:
  - `daily_snapshots_provider_check`에 kimi/glm 추가
  - `sync_device_snapshots` RPC 본문은 20260417030000 v2 bulk 구현을 그대로 복제하고 provider 검증만 확장 (behavior drift 방지)
- `supabase/functions/badge/index.ts`:
  - `VALID_PROVIDERS` set에 kimi/glm 추가
  - `PROVIDER_COLORS`/`PROVIDER_LABELS`도 클라이언트와 동일 값으로 동기화

### 남은 후속 과제
- **GLM 파싱 실구현**: CLI 포맷 확정되는 대로 `is_available()` 원복 + wire.jsonl 파서 추가
- **Kimi 실사용자 리포트**: wire.jsonl 파서가 관대하게 설계되었으나 실제 사용자 데이터로 검증 필요

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml` 통과 (기존 warning만)
- [x] `npx tsc --noEmit` 통과 (EXIT=0)
- [x] `npm run tauri dev` 기동 확인, 기존 Claude/Codex/OpenCode 무회귀
- [x] `~/.kimi/sessions`, `~/.glm/sessions` 디렉터리 생성 후 GLM 엄격화 반영 전엔 5개 노출, 반영 후 4개(GLM 숨김) 노출 확인
- [x] 디렉터리 미존재 시 Kimi/GLM 자동 숨김
- [x] 드롭다운 외부 클릭 닫힘, ESC 닫힘, 최소 1개 소스 고정(disabled) 동작
- [ ] 실제 Kimi CLI 설치 환경에서 wire.jsonl 파싱 검증 (리포트 기다림)
- [ ] Supabase migration `db push` 후 `sync_device_snapshots(p_provider:='kimi')` 정상 수용 확인
- [ ] `supabase functions deploy badge` 후 `?provider=kimi`/`?provider=glm` URL 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)