### PR TITLE
fix: add Opus 4.7 pricing to prevent fallback to Opus 4.1 rates

### DIFF
--- a/src-tauri/pricing.json
+++ b/src-tauri/pricing.json
@@ -8,6 +8,7 @@
   "claude": {
     "default": "sonnet",
     "models": [
+      { "match": "opus-4-7",  "label": "Opus 4.7",      "input": 5.0,  "output": 25.0,  "cache_read": 0.50, "cache_write": 6.25,  "cache_write_1h": 10.0  },
       { "match": "opus-4-6",  "label": "Opus 4.6/4.5",  "input": 5.0,  "output": 25.0,  "cache_read": 0.50, "cache_write": 6.25,  "cache_write_1h": 10.0  },
       { "match": "opus-4-5",  "label": "Opus 4.6/4.5",  "input": 5.0,  "output": 25.0,  "cache_read": 0.50, "cache_write": 6.25,  "cache_write_1h": 10.0  },
       { "match": "opus-4-1",  "label": "Opus 4.1/4",    "input": 15.0, "output": 75.0,  "cache_read": 1.50, "cache_write": 18.75, "cache_write_1h": 30.0  },
@@ -41,6 +42,7 @@
   "opencode": {
     "default": "sonnet",
     "models": [
+      { "match": "opus-4-7",          "label": "Claude Opus 4.7",           "input": 5.0,   "output": 25.0,   "cache_read": 0.50,  "cache_write": 6.25   },
       { "match": "opus-4-6",          "label": "Claude Opus 4.6/4.5",      "input": 5.0,   "output": 25.0,   "cache_read": 0.50,  "cache_write": 6.25   },
       { "match": "opus-4-5",          "label": "Claude Opus 4.6/4.5",      "input": 5.0,   "output": 25.0,   "cache_read": 0.50,  "cache_write": 6.25   },
       { "match": "opus-4-1",          "label": "Claude Opus 4.1/4",        "input": 15.0,  "output": 75.0,   "cache_read": 1.50,  "cache_write": 18.75  },

--- a/src-tauri/src/providers/pricing.rs
+++ b/src-tauri/src/providers/pricing.rs
@@ -298,6 +298,25 @@ mod tests {
         assert!((p.cache_write_1h - 10.0).abs() < 0.001);
     }
 
+    // Regression guard: "opus-4-7" must match its own entry, not fall through
+    // to the "opus-4" substring and get billed at Opus 4.1 rates ($15/$75).
+    #[test]
+    fn claude_opus_47_not_billed_as_41() {
+        let p = get_claude_pricing("claude-opus-4-7-20260416");
+        assert!((p.input - 5.0).abs() < 0.001, "Opus 4.7 input must be $5/MTok, got ${}", p.input);
+        assert!((p.output - 25.0).abs() < 0.001, "Opus 4.7 output must be $25/MTok, got ${}", p.output);
+        assert!((p.cache_read - 0.50).abs() < 0.001);
+        assert!((p.cache_write_5m - 6.25).abs() < 0.001);
+        assert!((p.cache_write_1h - 10.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn opencode_opus_47_not_billed_as_41() {
+        let p = get_opencode_pricing("anthropic/claude-opus-4-7-20260416");
+        assert!((p.input - 5.0).abs() < 0.001, "Opencode Opus 4.7 input must be $5/MTok, got ${}", p.input);
+        assert!((p.output - 25.0).abs() < 0.001);
+    }
+
     #[test]
     fn claude_sonnet_pricing() {
         let p = get_claude_pricing("claude-sonnet-4-6-20260320");


### PR DESCRIPTION
## Summary
- Opus 4.7 (released 2026-04-16) is missing from `pricing.json`
- `find_pricing()` uses substring matching (`model.contains(pattern)`), so `"opus-4-7"` matches the `"opus-4"` entry (Opus 4.1/4) before reaching the generic `"opus"` fallback
- This causes all Opus 4.7 usage to be charged at **3x the actual cost** ($15/$75 instead of $5/$25 per MTok)

## Fix
- Added `opus-4-7` entry in both `claude` and `opencode` sections of `pricing.json`, before the `opus-4` catch-all

## Test
- `"opus-4-7".contains("opus-4-7")` now matches before `"opus-4"`
- Pricing: $5/$25/$0.50/$6.25/$10.0 per MTok (same as Opus 4.6, per [Anthropic pricing](https://docs.anthropic.com/en/docs/about-claude/pricing))