### PR TITLE
fix: add Opus 4.7 pricing entry to prevent 3x overcharge (#129)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "ai-token-monitor"
-version = "0.19.3"
+version = "0.19.6"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/pricing.json
+++ b/src-tauri/pricing.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.2.0",
-  "last_updated": "2026-03-31",
+  "version": "1.2.1",
+  "last_updated": "2026-04-21",
   "sources": {
     "claude": "https://docs.anthropic.com/en/docs/about-claude/pricing",
     "codex": "https://developers.openai.com/api/docs/pricing"
@@ -8,11 +8,12 @@
   "claude": {
     "default": "sonnet",
     "models": [
+      { "match": "opus-4-7",  "label": "Opus 4.7",      "input": 5.0,  "output": 25.0,  "cache_read": 0.50, "cache_write": 6.25,  "cache_write_1h": 10.0  },
       { "match": "opus-4-6",  "label": "Opus 4.6/4.5",  "input": 5.0,  "output": 25.0,  "cache_read": 0.50, "cache_write": 6.25,  "cache_write_1h": 10.0  },
       { "match": "opus-4-5",  "label": "Opus 4.6/4.5",  "input": 5.0,  "output": 25.0,  "cache_read": 0.50, "cache_write": 6.25,  "cache_write_1h": 10.0  },
       { "match": "opus-4-1",  "label": "Opus 4.1/4",    "input": 15.0, "output": 75.0,  "cache_read": 1.50, "cache_write": 18.75, "cache_write_1h": 30.0  },
       { "match": "opus-4",    "label": "Opus 4.1/4",    "input": 15.0, "output": 75.0,  "cache_read": 1.50, "cache_write": 18.75, "cache_write_1h": 30.0  },
-      { "match": "opus",      "label": "Opus 4.6/4.5",  "input": 5.0,  "output": 25.0,  "cache_read": 0.50, "cache_write": 6.25,  "cache_write_1h": 10.0  },
+      { "match": "opus",      "label": "Opus 4.7",      "input": 5.0,  "output": 25.0,  "cache_read": 0.50, "cache_write": 6.25,  "cache_write_1h": 10.0  },
       { "match": "sonnet-4-6","label": "Sonnet 4.x",    "input": 3.0,  "output": 15.0,  "cache_read": 0.30, "cache_write": 3.75,  "cache_write_1h": 6.0   },
       { "match": "sonnet-4-5","label": "Sonnet 4.x",    "input": 3.0,  "output": 15.0,  "cache_read": 0.30, "cache_write": 3.75,  "cache_write_1h": 6.0   },
       { "match": "sonnet-4",  "label": "Sonnet 4.x",    "input": 3.0,  "output": 15.0,  "cache_read": 0.30, "cache_write": 3.75,  "cache_write_1h": 6.0   },
@@ -41,11 +42,12 @@
   "opencode": {
     "default": "sonnet",
     "models": [
+      { "match": "opus-4-7",          "label": "Claude Opus 4.7",          "input": 5.0,   "output": 25.0,   "cache_read": 0.50,  "cache_write": 6.25   },
       { "match": "opus-4-6",          "label": "Claude Opus 4.6/4.5",      "input": 5.0,   "output": 25.0,   "cache_read": 0.50,  "cache_write": 6.25   },
       { "match": "opus-4-5",          "label": "Claude Opus 4.6/4.5",      "input": 5.0,   "output": 25.0,   "cache_read": 0.50,  "cache_write": 6.25   },
       { "match": "opus-4-1",          "label": "Claude Opus 4.1/4",        "input": 15.0,  "output": 75.0,   "cache_read": 1.50,  "cache_write": 18.75  },
       { "match": "opus-4",            "label": "Claude Opus 4.1/4",        "input": 15.0,  "output": 75.0,   "cache_read": 1.50,  "cache_write": 18.75  },
-      { "match": "opus",              "label": "Claude Opus 4.6/4.5",      "input": 5.0,   "output": 25.0,   "cache_read": 0.50,  "cache_write": 6.25   },
+      { "match": "opus",              "label": "Claude Opus 4.7",          "input": 5.0,   "output": 25.0,   "cache_read": 0.50,  "cache_write": 6.25   },
       { "match": "sonnet-4-6",        "label": "Claude Sonnet 4.x",        "input": 3.0,   "output": 15.0,   "cache_read": 0.30,  "cache_write": 3.75   },
       { "match": "sonnet-4-5",        "label": "Claude Sonnet 4.x",        "input": 3.0,   "output": 15.0,   "cache_read": 0.30,  "cache_write": 3.75   },
       { "match": "sonnet-4",          "label": "Claude Sonnet 4.x",        "input": 3.0,   "output": 15.0,   "cache_read": 0.30,  "cache_write": 3.75   },

--- a/src-tauri/src/providers/pricing.rs
+++ b/src-tauri/src/providers/pricing.rs
@@ -299,6 +299,23 @@ mod tests {
     }
 
     #[test]
+    fn claude_opus_4_7_pricing_not_shadowed_by_opus_4() {
+        let p = get_claude_pricing("claude-opus-4-7-20260416");
+        assert!((p.input - 5.0).abs() < 0.001, "input was {}", p.input);
+        assert!((p.output - 25.0).abs() < 0.001, "output was {}", p.output);
+        assert!((p.cache_read - 0.50).abs() < 0.001);
+        assert!((p.cache_write_5m - 6.25).abs() < 0.001);
+        assert!((p.cache_write_1h - 10.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn claude_opus_4_1_still_priced_correctly() {
+        let p = get_claude_pricing("claude-opus-4-1-20250805");
+        assert!((p.input - 15.0).abs() < 0.001);
+        assert!((p.output - 75.0).abs() < 0.001);
+    }
+
+    #[test]
     fn claude_sonnet_pricing() {
         let p = get_claude_pricing("claude-sonnet-4-6-20260320");
         assert!((p.input - 3.0).abs() < 0.001);


### PR DESCRIPTION
## Summary
- Opus 4.7 (출시일 2026-04-16)가 `pricing.json`에 누락되어 `find_pricing()`의 substring 매칭이 `opus-4-7` → `opus-4` 항목에 먼저 걸리면서 **Opus 4.1/4 단가(3배)로 과금**되던 문제를 수정
- `claude`/`opencode` 두 섹션 모두에 `opus-4-7` 엔트리를 `opus-4-6` 위에 추가하고, 일반 `opus` 폴백 라벨도 `Opus 4.7`로 갱신
- Opus 4.7이 Opus 4.x 항목에 가려지지 않는지, 그리고 Opus 4.1이 여전히 정상 가격으로 매칭되는지 확인하는 회귀 테스트 2건 추가

## 가격 (Anthropic 공식, MTok 기준)
| 토큰 유형   | Opus 4.7 | (이전) Opus 4.1/4 매칭 |
|-------------|----------|------------------------|
| Input       | \$5      | \$15                   |
| Output      | \$25     | \$75                   |
| Cache Read  | \$0.50   | \$1.50                 |
| Cache Write (5m) | \$6.25 | \$18.75          |
| Cache Write (1h) | \$10   | \$30             |

## Test plan
- [x] `cargo test --lib providers::pricing` 10건 전부 통과
- [x] 신규 `claude_opus_4_7_pricing_not_shadowed_by_opus_4` 테스트 추가 및 통과
- [x] 신규 `claude_opus_4_1_still_priced_correctly` 회귀 테스트 통과
- [ ] 앱 실행 후 Opus 4.7 사용 세션 비용이 이전 대비 1/3 수준으로 표시되는지 육안 확인

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)