### PR TITLE
fix: add GPT-5.5 / 5.5-pro / 5.4-pro pricing

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "ai-token-monitor"
-version = "0.19.3"
+version = "0.19.8"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/pricing.json
+++ b/src-tauri/pricing.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.2.0",
-  "last_updated": "2026-03-31",
+  "version": "1.3.0",
+  "last_updated": "2026-04-27",
   "sources": {
     "claude": "https://docs.anthropic.com/en/docs/about-claude/pricing",
     "codex": "https://developers.openai.com/api/docs/pricing"
@@ -26,6 +26,9 @@
   "codex": {
     "default": "gpt-5.4",
     "models": [
+      { "match": "gpt-5.5-pro",       "label": "gpt-5.5-pro",       "input": 30.00,"output": 180.00,"cached_input": 0.0   },
+      { "match": "gpt-5.5",           "label": "gpt-5.5",           "input": 5.00, "output": 30.00, "cached_input": 0.50  },
+      { "match": "gpt-5.4-pro",       "label": "gpt-5.4-pro",       "input": 30.00,"output": 180.00,"cached_input": 0.0   },
       { "match": "gpt-5.4-nano",      "label": "gpt-5.4-nano",      "input": 0.20, "output": 1.25,  "cached_input": 0.02  },
       { "match": "gpt-5.4-mini",      "label": "gpt-5.4-mini",      "input": 0.75, "output": 4.50,  "cached_input": 0.075 },
       { "match": "gpt-5.4",           "label": "gpt-5.4",           "input": 2.50, "output": 15.00, "cached_input": 0.25  },
@@ -54,6 +57,9 @@
       { "match": "sonnet",            "label": "Claude Sonnet 4.x",        "input": 3.0,   "output": 15.0,   "cache_read": 0.30,  "cache_write": 3.75   },
       { "match": "haiku-4-5",         "label": "Claude Haiku 4.5",         "input": 1.0,   "output": 5.0,    "cache_read": 0.10,  "cache_write": 1.25   },
       { "match": "haiku",             "label": "Claude Haiku 4.5",         "input": 1.0,   "output": 5.0,    "cache_read": 0.10,  "cache_write": 1.25   },
+      { "match": "gpt-5.5-pro",       "label": "GPT-5.5 Pro",              "input": 30.00, "output": 180.0,  "cache_read": 0.0,   "cache_write": 0.0    },
+      { "match": "gpt-5.5",           "label": "GPT-5.5",                  "input": 5.00,  "output": 30.0,   "cache_read": 0.50,  "cache_write": 0.0    },
+      { "match": "gpt-5.4-pro",       "label": "GPT-5.4 Pro",              "input": 30.00, "output": 180.0,  "cache_read": 0.0,   "cache_write": 0.0    },
       { "match": "gpt-5.4",           "label": "GPT-5.4",                  "input": 2.50,  "output": 15.0,   "cache_read": 0.25,  "cache_write": 0.0    },
       { "match": "gpt-5.3",           "label": "GPT-5.3",                  "input": 1.75,  "output": 14.0,   "cache_read": 0.175, "cache_write": 0.0    },
       { "match": "gpt-5.2",           "label": "GPT-5.2",                  "input": 1.25,  "output": 10.0,   "cache_read": 0.125, "cache_write": 0.0    },

--- a/src-tauri/src/providers/pricing.rs
+++ b/src-tauri/src/providers/pricing.rs
@@ -358,4 +358,37 @@ mod tests {
         let p = get_codex_pricing("some-future-model");
         assert!((p.input - 2.50).abs() < 0.001);
     }
+
+    // Regression guard: "gpt-5.5" must match its own entry, not fall through
+    // to the default ("gpt-5.4") and get billed at GPT-5.4 rates ($2.50/$15).
+    #[test]
+    fn codex_gpt55_not_billed_as_gpt54() {
+        let p = get_codex_pricing("gpt-5.5");
+        assert!((p.input - 5.00).abs() < 0.001, "GPT-5.5 input must be $5/MTok, got ${}", p.input);
+        assert!((p.output - 30.00).abs() < 0.001, "GPT-5.5 output must be $30/MTok, got ${}", p.output);
+        assert!((p.cached_input - 0.50).abs() < 0.001);
+    }
+
+    #[test]
+    fn codex_gpt55_pro_not_billed_as_gpt54() {
+        let p = get_codex_pricing("gpt-5.5-pro");
+        assert!((p.input - 30.00).abs() < 0.001, "GPT-5.5 Pro input must be $30/MTok, got ${}", p.input);
+        assert!((p.output - 180.00).abs() < 0.001, "GPT-5.5 Pro output must be $180/MTok, got ${}", p.output);
+    }
+
+    #[test]
+    fn opencode_gpt55_not_billed_as_gpt54() {
+        let p = get_opencode_pricing("openai/gpt-5.5");
+        assert!((p.input - 5.00).abs() < 0.001, "Opencode GPT-5.5 input must be $5/MTok, got ${}", p.input);
+        assert!((p.output - 30.00).abs() < 0.001);
+    }
+
+    // Regression guard: dated snapshot IDs (e.g. gpt-5.5-2026-04-23) must
+    // resolve to the gpt-5.5 entry, not the gpt-5.4 default fallback.
+    #[test]
+    fn codex_gpt55_dated_snapshot_resolves_correctly() {
+        let p = get_codex_pricing("gpt-5.5-2026-04-23");
+        assert!((p.input - 5.00).abs() < 0.001, "GPT-5.5 dated snapshot must match gpt-5.5, got input ${}", p.input);
+        assert!((p.output - 30.00).abs() < 0.001);
+    }
 }


### PR DESCRIPTION
## Summary
- GPT-5.5 (released 2026-04-23) was missing from `pricing.json`, causing **2x undercharge** for GPT-5.5 and **12x undercharge** for GPT-5.5 Pro
- `find_pricing()` uses substring matching and falls back to codex `default: \"gpt-5.4\"` on no match, so `\"gpt-5.5\"` was billed at GPT-5.4 rates ($2.50/$15 instead of $5.00/$30)
- This is the mirror image of #129/#130 (Opus 4.7) — same root cause, different model

## Pricing Verified Against OpenAI Official Page

| Model | Input | Cached | Output |
|-------|-------|--------|--------|
| gpt-5.5 | $5.00 | $0.50 | $30.00 |
| gpt-5.5-pro | $30.00 | — | $180.00 |
| gpt-5.4-pro | $30.00 | — | $180.00 |

Cross-verified with: OpenAI docs, OpenRouter, apidog, letsdatascience, buildfastwithai. All sources agree.

## Changes
- `pricing.json`: add `gpt-5.5-pro`, `gpt-5.5`, `gpt-5.4-pro` entries to **both** `codex` and `opencode` sections, ordered before `gpt-5.4` to prevent substring shadowing
- `pricing.json`: bump `version` 1.2.0 → 1.3.0, `last_updated` → 2026-04-27
- `pricing.rs`: add 4 regression tests guarding against fall-through to `gpt-5.4` default, including dated snapshot ID `gpt-5.5-2026-04-23`

## Test
- \`cargo test --quiet pricing\` → **16 passed; 0 failed** (12 existing + 4 new)
- Full test suite: **52 passed**

## Not Included (Separate Issue)
Long context pricing (>272K input tokens — 2x input, 1.5x output) is not modeled. This affects gpt-5.5, gpt-5.5-pro, gpt-5.4, gpt-5.4-pro and several Anthropic models too. Should be tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)