### PR TITLE
feat(usage): add manual refresh button to recover stale usage widget

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -718,6 +718,21 @@ pub fn get_oauth_usage() -> Option<crate::oauth_usage::OAuthUsage> {
 }
 
 #[tauri::command]
+pub async fn refresh_oauth_usage(app: tauri::AppHandle) -> Option<crate::oauth_usage::OAuthUsage> {
+    // Throttle: if cache is fresh within 30 seconds, return it without hitting the API.
+    // Mirrors the frontend cooldown so rapid manual clicks cannot hammer the OAuth endpoint
+    // even if the UI gate is bypassed.
+    if crate::oauth_usage::is_cache_fresh(30) {
+        return crate::oauth_usage::get_cached_usage();
+    }
+    let result = crate::oauth_usage::fetch_and_cache_usage().await;
+    if result.is_some() {
+        let _ = app.emit("usage-updated", ());
+    }
+    result
+}
+
+#[tauri::command]
 pub fn get_pricing_table() -> pricing::PricingTable {
     pricing::get_pricing_table()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -845,6 +845,7 @@ pub fn run() {
             commands::save_png_to_file,
             commands::get_pricing_table,
             commands::get_oauth_usage,
+            commands::refresh_oauth_usage,
             commands::enable_usage_tracking,
             commands::get_ai_keys,
             commands::test_webhook,

--- a/src/components/UsageAlertBar.tsx
+++ b/src/components/UsageAlertBar.tsx
@@ -1,8 +1,10 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useOAuthUsage } from "../hooks/useOAuthUsage";
 import { useSettings } from "../contexts/SettingsContext";
 import { useI18n } from "../i18n/I18nContext";
+
+const REFRESH_COOLDOWN_SECONDS = 30;
 
 function getBarColor(percent: number): string {
   if (percent >= 90) return "#ef4444";
@@ -92,9 +94,40 @@ function UsageRow({
 
 export function UsageAlertBar() {
   const { prefs, refreshPrefs } = useSettings();
-  const { usage } = useOAuthUsage();
+  const { usage, refreshing, refresh } = useOAuthUsage();
   const t = useI18n();
   const [enabling, setEnabling] = useState(false);
+  const [cooldown, setCooldown] = useState(0);
+  const cooldownTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (cooldownTimerRef.current !== null) {
+        window.clearInterval(cooldownTimerRef.current);
+      }
+    };
+  }, []);
+
+  const handleRefresh = async () => {
+    if (refreshing || cooldown > 0) return;
+    setCooldown(REFRESH_COOLDOWN_SECONDS);
+    if (cooldownTimerRef.current !== null) {
+      window.clearInterval(cooldownTimerRef.current);
+    }
+    cooldownTimerRef.current = window.setInterval(() => {
+      setCooldown((prev) => {
+        if (prev <= 1) {
+          if (cooldownTimerRef.current !== null) {
+            window.clearInterval(cooldownTimerRef.current);
+            cooldownTimerRef.current = null;
+          }
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+    await refresh();
+  };
 
   if (!prefs.usage_tracking_enabled) {
     return (
@@ -179,15 +212,71 @@ export function UsageAlertBar() {
         }}>
           {t("usageAlert.title")}
         </span>
-        {is_stale && (
-          <span style={{
-            fontSize: 9,
-            fontWeight: 600,
-            color: "var(--text-muted)",
-          }}>
-            {t("usageAlert.stale")}
-          </span>
-        )}
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          {is_stale && (
+            <span style={{
+              fontSize: 9,
+              fontWeight: 600,
+              color: "var(--text-muted)",
+            }}>
+              {t("usageAlert.stale")}
+            </span>
+          )}
+          <button
+            onClick={handleRefresh}
+            disabled={refreshing || cooldown > 0}
+            title={
+              refreshing
+                ? t("usageAlert.refreshing")
+                : cooldown > 0
+                ? `${t("usageAlert.refresh")} (${cooldown}s)`
+                : t("usageAlert.refresh")
+            }
+            aria-label={t("usageAlert.refresh")}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: 18,
+              height: 18,
+              padding: 0,
+              background: "transparent",
+              border: "none",
+              borderRadius: 3,
+              color: "var(--text-muted)",
+              cursor: refreshing || cooldown > 0 ? "default" : "pointer",
+              opacity: refreshing || cooldown > 0 ? 0.4 : 0.8,
+              transition: "opacity 0.2s ease, color 0.2s ease",
+            }}
+            onMouseEnter={(e) => {
+              if (!refreshing && cooldown === 0) {
+                e.currentTarget.style.color = "var(--text-primary)";
+              }
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.color = "var(--text-muted)";
+            }}
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              style={{
+                animation: refreshing ? "miniProfileSpin 0.8s linear infinite" : "none",
+              }}
+            >
+              <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+              <path d="M21 3v5h-5" />
+              <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+              <path d="M3 21v-5h5" />
+            </svg>
+          </button>
+        </div>
       </div>
 
       {/* Session (5h) */}

--- a/src/hooks/useOAuthUsage.ts
+++ b/src/hooks/useOAuthUsage.ts
@@ -6,6 +6,7 @@ import type { OAuthUsage } from "../lib/types";
 export function useOAuthUsage() {
   const [usage, setUsage] = useState<OAuthUsage | null>(null);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const requestIdRef = useRef(0);
 
   const fetchUsage = useCallback(async () => {
@@ -18,6 +19,23 @@ export function useOAuthUsage() {
       // Ignore errors silently
     } finally {
       if (requestId === requestIdRef.current) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  const refresh = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+    setRefreshing(true);
+    try {
+      const data = await invoke<OAuthUsage | null>("refresh_oauth_usage");
+      if (requestId !== requestIdRef.current) return;
+      setUsage(data);
+    } catch {
+      // Ignore errors silently
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setRefreshing(false);
         setLoading(false);
       }
     }
@@ -36,5 +54,5 @@ export function useOAuthUsage() {
     };
   }, [fetchUsage]);
 
-  return { usage, loading };
+  return { usage, loading, refreshing, refresh };
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -231,6 +231,8 @@
   "usageAlert.stale": "Aktualisierung...",
   "usageAlert.resetsIn": "Zurücksetzen in {{time}}",
   "usageAlert.resetsNow": "Wird zurückgesetzt...",
+  "usageAlert.refresh": "Aktualisieren",
+  "usageAlert.refreshing": "Wird aktualisiert...",
 
   "usageTracking.title": "Claude Nutzungsverfolgung",
   "usageTracking.description": "Überwachen Sie Ihre Claude Code Sitzungs- und Wochenlimits in Echtzeit. Dies erfordert Zugriff auf Ihre Claude Code Anmeldedaten.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -237,6 +237,8 @@
   "usageAlert.stale": "Updating...",
   "usageAlert.resetsIn": "Resets in {{time}}",
   "usageAlert.resetsNow": "Resetting...",
+  "usageAlert.refresh": "Refresh",
+  "usageAlert.refreshing": "Refreshing...",
 
   "usageTracking.title": "Claude Usage Tracking",
   "usageTracking.description": "Monitor your Claude Code session and weekly usage limits in real-time. This requires access to your Claude Code login credentials.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -231,6 +231,8 @@
   "usageAlert.stale": "Actualizando...",
   "usageAlert.resetsIn": "Se reinicia en {{time}}",
   "usageAlert.resetsNow": "Reiniciando...",
+  "usageAlert.refresh": "Actualizar",
+  "usageAlert.refreshing": "Actualizando...",
 
   "usageTracking.title": "Seguimiento de uso de Claude",
   "usageTracking.description": "Monitorea tus límites de sesión y semanales de Claude Code en tiempo real. Requiere acceso a tus credenciales de inicio de sesión de Claude Code.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -231,6 +231,8 @@
   "usageAlert.stale": "Mise à jour...",
   "usageAlert.resetsIn": "Réinitialisation dans {{time}}",
   "usageAlert.resetsNow": "Réinitialisation...",
+  "usageAlert.refresh": "Actualiser",
+  "usageAlert.refreshing": "Actualisation...",
 
   "usageTracking.title": "Suivi d'utilisation Claude",
   "usageTracking.description": "Surveillez vos limites de session et hebdomadaires de Claude Code en temps réel. Nécessite l'accès à vos identifiants de connexion Claude Code.",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -231,6 +231,8 @@
   "usageAlert.stale": "Aggiornamento...",
   "usageAlert.resetsIn": "Reset tra {{time}}",
   "usageAlert.resetsNow": "Reset in corso...",
+  "usageAlert.refresh": "Aggiorna",
+  "usageAlert.refreshing": "Aggiornamento...",
 
   "usageTracking.title": "Monitoraggio utilizzo Claude",
   "usageTracking.description": "Monitora i limiti di sessione e settimanali di Claude Code in tempo reale. Richiede l'accesso alle credenziali di Claude Code.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -231,6 +231,8 @@
   "usageAlert.stale": "更新中...",
   "usageAlert.resetsIn": "{{time}}後にリセット",
   "usageAlert.resetsNow": "リセット中...",
+  "usageAlert.refresh": "更新",
+  "usageAlert.refreshing": "更新中...",
 
   "usageTracking.title": "Claude 使用量トラッキング",
   "usageTracking.description": "Claude Codeのセッションおよび週間使用制限をリアルタイムで監視します。Claude Codeのログイン認証情報へのアクセスが必要です。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -237,6 +237,8 @@
   "usageAlert.stale": "업데이트 중...",
   "usageAlert.resetsIn": "{{time}} 후 리셋",
   "usageAlert.resetsNow": "리셋 중...",
+  "usageAlert.refresh": "새로고침",
+  "usageAlert.refreshing": "새로고침 중...",
 
   "usageTracking.title": "Claude 사용량 추적",
   "usageTracking.description": "Claude Code 세션 및 주간 사용 한도를 실시간으로 모니터링합니다. Claude Code 로그인 자격 증명에 대한 접근이 필요합니다.",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -231,6 +231,8 @@
   "usageAlert.stale": "Güncelleniyor...",
   "usageAlert.resetsIn": "{{time}} içinde sıfırlanıyor",
   "usageAlert.resetsNow": "Sıfırlanıyor...",
+  "usageAlert.refresh": "Yenile",
+  "usageAlert.refreshing": "Yenileniyor...",
 
   "usageTracking.title": "Claude Kullanım Takibi",
   "usageTracking.description": "Claude Code oturum ve haftalık kullanım limitlerinizi gerçek zamanlı izleyin. Bu, Claude Code giriş kimlik bilgilerinize erişim gerektirir.",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -231,6 +231,8 @@
   "usageAlert.stale": "更新中...",
   "usageAlert.resetsIn": "{{time}}后重置",
   "usageAlert.resetsNow": "重置中...",
+  "usageAlert.refresh": "刷新",
+  "usageAlert.refreshing": "刷新中...",
 
   "usageTracking.title": "Claude 用量追踪",
   "usageTracking.description": "实时监控 Claude Code 会话和每周使用限额。需要访问 Claude Code 登录凭据。",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -231,6 +231,8 @@
   "usageAlert.stale": "更新中...",
   "usageAlert.resetsIn": "{{time}}後重置",
   "usageAlert.resetsNow": "重置中...",
+  "usageAlert.refresh": "重新整理",
+  "usageAlert.refreshing": "重新整理中...",
 
   "usageTracking.title": "Claude 用量追蹤",
   "usageTracking.description": "即時監控 Claude Code 工作階段和每週使用限額。需要存取 Claude Code 登入憑證。",


### PR DESCRIPTION
## Summary
- 사용량 위젯이 멈춰있을 때 앱을 종료/재시작 없이 복구할 수 있도록 사용량 헤더에 새로고침 아이콘 버튼 추가
- 연타 방지를 위한 3중 가드: 프론트 30초 쿨다운(남은 초 tooltip 표시), 백엔드 30초 캐시 throttle, 기존 in-flight fetch 락 재사용
- 10개 로케일 모두에 \`usageAlert.refresh\` / \`usageAlert.refreshing\` 키 추가
- 회전 애니메이션은 기존 \`miniProfileSpin\` keyframe 재사용

## Test plan
- [ ] 사용량 위젯 우측 상단의 ↻ 버튼 클릭 시 즉시 데이터가 갱신되는지 확인
- [ ] 클릭 직후 30초간 버튼이 비활성화되고 tooltip에 남은 초가 표시되는지 확인
- [ ] 빠르게 여러 번 눌러도 백엔드 API에 한 번만 호출되는지 확인 (네트워크 탭 또는 로그)
- [ ] 새로고침 진행 중에는 아이콘이 회전하는지 확인
- [ ] 사용량 추적이 비활성화되어 있을 때는 버튼이 노출되지 않는지 확인
- [ ] 한국어/영어 외 다른 언어에서도 버튼 라벨이 올바르게 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)