### PR TITLE
fix(usage): stop refresh spinner from getting stuck after polling race

### DIFF
--- a/src/hooks/useOAuthUsage.ts
+++ b/src/hooks/useOAuthUsage.ts
@@ -13,14 +13,13 @@ export function useOAuthUsage() {
     const requestId = ++requestIdRef.current;
     try {
       const data = await invoke<OAuthUsage | null>("get_oauth_usage");
-      if (requestId !== requestIdRef.current) return;
-      setUsage(data);
+      if (requestId === requestIdRef.current) {
+        setUsage(data);
+      }
     } catch {
       // Ignore errors silently
     } finally {
-      if (requestId === requestIdRef.current) {
-        setLoading(false);
-      }
+      setLoading(false);
     }
   }, []);
 
@@ -29,15 +28,19 @@ export function useOAuthUsage() {
     setRefreshing(true);
     try {
       const data = await invoke<OAuthUsage | null>("refresh_oauth_usage");
-      if (requestId !== requestIdRef.current) return;
-      setUsage(data);
+      // Only adopt the result if no newer request has started; otherwise keep
+      // the more recent data. The spinner state is reset unconditionally below.
+      if (requestId === requestIdRef.current) {
+        setUsage(data);
+      }
     } catch {
       // Ignore errors silently
     } finally {
-      if (requestId === requestIdRef.current) {
-        setRefreshing(false);
-        setLoading(false);
-      }
+      // Always clear the spinner — never tie it to requestId, otherwise a
+      // concurrent fetchUsage() (e.g. from a "usage-updated" event fired by
+      // this very refresh) bumps requestIdRef and strands refreshing=true.
+      setRefreshing(false);
+      setLoading(false);
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- 사용량 위젯 새로고침 버튼이 가끔 무한 회전 상태로 멈추는 버그 수정
- 원인: \`refresh()\` 내부에서 \`setRefreshing(false)\`가 \`requestId === requestIdRef.current\` 조건 안에 있었는데, 백엔드 \`usage-updated\` 이벤트(특히 \`refresh_oauth_usage\` 자체가 emit하는 이벤트)가 도착하면 listener가 \`fetchUsage()\`를 호출하며 \`requestIdRef\`를 증가시킴 → 원래 \`refresh()\`의 finally에서 조건이 false가 되어 spinner가 영원히 안 꺼짐
- 수정: \`requestId\` 비교는 \`setUsage()\`(stale data 방지 목적)에만 적용. \`setRefreshing(false)\` / \`setLoading(false)\`는 finally에서 항상 호출
- \`fetchUsage()\`도 동일한 패턴이라 \`loading\`이 끼는 잠재 버그 함께 수정

## Test plan
- [ ] 사용량 위젯 새로고침 클릭 후 회전 애니메이션이 fetch 완료 시 즉시 멈추는지 확인
- [ ] 백엔드 5분 폴링과 새로고침이 겹치는 타이밍에도 회전이 멈추는지 확인 (스파이더 클릭 후 5분 폴링이 동시에 발생하도록)
- [ ] 회전이 멈춘 뒤 30초 쿨다운이 끝나면 다시 클릭 가능한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)