### PR TITLE
feat: add Claude Fable 5 and Mythos 5 pricing

### DIFF
--- a/src-tauri/pricing.json
+++ b/src-tauri/pricing.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.4.0",
-  "last_updated": "2026-05-29",
+  "version": "1.5.0",
+  "last_updated": "2026-06-10",
   "sources": {
     "claude": "https://platform.claude.com/docs/en/about-claude/pricing",
     "codex": "https://developers.openai.com/api/docs/pricing"
@@ -8,6 +8,10 @@
   "claude": {
     "default": "sonnet",
     "models": [
+      { "match": "fable-5",   "label": "Fable 5",              "input": 10.0, "output": 50.0,  "cache_read": 1.00, "cache_write": 12.5,  "cache_write_1h": 20.0  },
+      { "match": "fable",     "label": "Fable 5",              "input": 10.0, "output": 50.0,  "cache_read": 1.00, "cache_write": 12.5,  "cache_write_1h": 20.0  },
+      { "match": "mythos-5",  "label": "Mythos 5",             "input": 10.0, "output": 50.0,  "cache_read": 1.00, "cache_write": 12.5,  "cache_write_1h": 20.0  },
+      { "match": "mythos",    "label": "Mythos 5",             "input": 10.0, "output": 50.0,  "cache_read": 1.00, "cache_write": 12.5,  "cache_write_1h": 20.0  },
       { "match": "opus-4-8",  "label": "Opus 4.8/4.7/4.6/4.5", "input": 5.0,  "output": 25.0,  "cache_read": 0.50, "cache_write": 6.25,  "cache_write_1h": 10.0  },
       { "match": "opus-4-7",  "label": "Opus 4.8/4.7/4.6/4.5", "input": 5.0,  "output": 25.0,  "cache_read": 0.50, "cache_write": 6.25,  "cache_write_1h": 10.0  },
       { "match": "opus-4-6",  "label": "Opus 4.8/4.7/4.6/4.5", "input": 5.0,  "output": 25.0,  "cache_read": 0.50, "cache_write": 6.25,  "cache_write_1h": 10.0  },
@@ -46,6 +50,10 @@
   "opencode": {
     "default": "sonnet",
     "models": [
+      { "match": "fable-5",           "label": "Claude Fable 5",               "input": 10.0,  "output": 50.0,   "cache_read": 1.00,  "cache_write": 12.5   },
+      { "match": "fable",             "label": "Claude Fable 5",               "input": 10.0,  "output": 50.0,   "cache_read": 1.00,  "cache_write": 12.5   },
+      { "match": "mythos-5",          "label": "Claude Mythos 5",              "input": 10.0,  "output": 50.0,   "cache_read": 1.00,  "cache_write": 12.5   },
+      { "match": "mythos",            "label": "Claude Mythos 5",              "input": 10.0,  "output": 50.0,   "cache_read": 1.00,  "cache_write": 12.5   },
       { "match": "opus-4-8",          "label": "Claude Opus 4.8/4.7/4.6/4.5", "input": 5.0,   "output": 25.0,   "cache_read": 0.50,  "cache_write": 6.25   },
       { "match": "opus-4-7",          "label": "Claude Opus 4.8/4.7/4.6/4.5", "input": 5.0,   "output": 25.0,   "cache_read": 0.50,  "cache_write": 6.25   },
       { "match": "opus-4-6",          "label": "Claude Opus 4.8/4.7/4.6/4.5", "input": 5.0,   "output": 25.0,   "cache_read": 0.50,  "cache_write": 6.25   },

--- a/src-tauri/src/providers/pricing.rs
+++ b/src-tauri/src/providers/pricing.rs
@@ -183,7 +183,7 @@ pub fn get_opencode_pricing(model: &str) -> OpenCodePricing {
     }
 
     // Fallback: try claude pricing first (for claude-* models), then codex
-    if model.contains("claude") || model.contains("sonnet") || model.contains("opus") || model.contains("haiku") {
+    if model.contains("claude") || model.contains("fable") || model.contains("mythos") || model.contains("sonnet") || model.contains("opus") || model.contains("haiku") {
         let entry = find_pricing(&cfg.claude, model);
         OpenCodePricing {
             input: entry.input,
@@ -336,6 +336,39 @@ mod tests {
         let p = get_opencode_pricing("anthropic/claude-opus-4-8-20260528");
         assert!((p.input - 5.0).abs() < 0.001, "Opencode Opus 4.8 input must be $5/MTok, got ${}", p.input);
         assert!((p.output - 25.0).abs() < 0.001);
+    }
+
+    // Regression guard: "claude-fable-5" must resolve to its own Fable entry
+    // ($10/$50), not fall through to the "sonnet" default and get under-billed
+    // at Sonnet rates ($3/$15). Fable 5 is the top tier above Opus.
+    #[test]
+    fn claude_fable_5_not_billed_as_sonnet() {
+        let p = get_claude_pricing("claude-fable-5");
+        assert!((p.input - 10.0).abs() < 0.001, "Fable 5 input must be $10/MTok, got ${}", p.input);
+        assert!((p.output - 50.0).abs() < 0.001, "Fable 5 output must be $50/MTok, got ${}", p.output);
+        assert!((p.cache_read - 1.00).abs() < 0.001);
+        assert!((p.cache_write_5m - 12.5).abs() < 0.001);
+        assert!((p.cache_write_1h - 20.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn opencode_fable_5_not_billed_as_sonnet() {
+        let p = get_opencode_pricing("anthropic/claude-fable-5");
+        assert!((p.input - 10.0).abs() < 0.001, "Opencode Fable 5 input must be $10/MTok, got ${}", p.input);
+        assert!((p.output - 50.0).abs() < 0.001);
+    }
+
+    // Regression guard: "claude-mythos-5" (Project Glasswing, limited availability)
+    // shares Fable 5 pricing ($10/$50) and must not fall through to the "sonnet"
+    // default ($3/$15).
+    #[test]
+    fn claude_mythos_5_not_billed_as_sonnet() {
+        let p = get_claude_pricing("claude-mythos-5");
+        assert!((p.input - 10.0).abs() < 0.001, "Mythos 5 input must be $10/MTok, got ${}", p.input);
+        assert!((p.output - 50.0).abs() < 0.001, "Mythos 5 output must be $50/MTok, got ${}", p.output);
+        assert!((p.cache_read - 1.00).abs() < 0.001);
+        assert!((p.cache_write_5m - 12.5).abs() < 0.001);
+        assert!((p.cache_write_1h - 20.0).abs() < 0.001);
     }
 
     #[test]


### PR DESCRIPTION
## 요약

신규 최상위 티어 모델(Opus 상위) 단가를 추가합니다.

| Model | Model ID | Input | Output |
|---|---|---|---|
| Claude Fable 5 | `claude-fable-5` | $10/MTok | $50/MTok |
| Claude Mythos 5 | `claude-mythos-5` (Project Glasswing) | $10/MTok | $50/MTok |

두 모델은 단가가 동일하며, Anthropic 공식 **Pricing** 페이지와 **Models overview**로 교차 검증했습니다.

## 단가 상세 (per MTok)

| 항목 | 값 |
|---|---|
| Base Input | $10 |
| Output | $50 |
| 5m Cache Write | $12.50 |
| 1h Cache Write | $20 |
| Cache Read | $1 |

(Opus $5/$25의 정확히 2배)

## 변경 내용

- `pricing.json` `claude` / `opencode` 섹션에 Fable 5, Mythos 5 추가
- 각 모델: 정확 매칭(`-5`) + bare-name 폴백(`fable` / `mythos`) — dated snapshot / preview / 미래 변형이 default Sonnet($3/$15)으로 **저청구**되는 것 방지
- opencode provider-detection fallback에 `fable` / `mythos` 추가
- 회귀 가드 테스트 3개 추가 ($10/$50 고정)
- `pricing.json` v1.4.0 → v1.5.0

## 검증

- 공식 문서 직접 대조: 단가 5종 × 모델 2종 전부 일치
- `cargo test --lib`: 63/63 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)