### PR TITLE
feat: Kiro CLI를 API 키 기반 번역 프로바이더로 추가

### DIFF
--- a/src-tauri/src/ai_translate.rs
+++ b/src-tauri/src/ai_translate.rs
@@ -128,8 +128,231 @@ async fn call_model(keys: &crate::providers::types::AiKeys, model: &str, prompt:
     } else if model.starts_with("claude") {
         let key = keys.anthropic.as_deref().ok_or("Anthropic API key not set")?;
         call_anthropic(key, model, prompt).await
+    } else if model.starts_with("kiro") {
+        let key = keys.kiro.as_deref().ok_or("Kiro API key not set")?;
+        call_kiro(key, prompt).await
     } else {
         Err(format!("Unknown model provider for model: {}", model))
+    }
+}
+
+/// Translate via the local `kiro-cli` binary, authenticating with the user-provided
+/// API key (injected as `KIRO_API_KEY`) rather than any cached `kiro-cli login` session.
+///
+/// `kiro-cli chat --no-interactive` decorates stdout with ANSI codes, a `> ` prompt
+/// marker and a `Credits: … Time: …` footer, so we ask the model to wrap its answer in a
+/// compact JSON object (`{"t":"…"}`) and extract it via balanced-brace matching — the
+/// footer/ANSI chrome carries no braces, so this isolates the answer reliably.
+async fn call_kiro(key: &str, prompt: &str) -> Result<String, String> {
+    let key = key.to_string();
+    let kiro_prompt = format!(
+        "{}\n\nIMPORTANT: Respond with ONLY a compact single-line JSON object of the form \
+         {{\"t\":\"<your answer here>\"}} and nothing else — no markdown fences, no explanation.",
+        prompt
+    );
+    tauri::async_runtime::spawn_blocking(move || run_kiro_blocking(&key, &kiro_prompt))
+        .await
+        .map_err(|e| format!("Kiro task join failed: {}", e))?
+}
+
+/// Resolve the `kiro-cli` binary. GUI apps inherit a minimal PATH, so probe common
+/// install locations first and fall back to the bare name (PATH lookup).
+fn resolve_kiro_cli() -> std::path::PathBuf {
+    let bin = if cfg!(target_os = "windows") { "kiro-cli.exe" } else { "kiro-cli" };
+    if let Some(home) = dirs::home_dir() {
+        for rel in [".local/bin", ".kiro/bin"] {
+            let c = home.join(rel).join(bin);
+            if c.exists() {
+                return c;
+            }
+        }
+    }
+    if !cfg!(target_os = "windows") {
+        for p in ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin"] {
+            let c = std::path::Path::new(p).join(bin);
+            if c.exists() {
+                return c;
+            }
+        }
+    }
+    std::path::PathBuf::from(bin)
+}
+
+const KIRO_MAX_ATTEMPTS: u32 = 3;
+
+/// Run `kiro-cli` up to a few times; the chat output occasionally lacks parseable JSON.
+fn run_kiro_blocking(key: &str, prompt: &str) -> Result<String, String> {
+    let mut last_err = String::new();
+    for attempt in 1..=KIRO_MAX_ATTEMPTS {
+        match run_kiro_once(key, prompt) {
+            Ok(s) => return Ok(s),
+            // Auth failures are deterministic — don't waste retries on a bad/expired key.
+            Err(e) if e.starts_with("AUTH:") => {
+                return Err(e.trim_start_matches("AUTH:").to_string());
+            }
+            Err(e) => {
+                last_err = e;
+                if attempt < KIRO_MAX_ATTEMPTS {
+                    std::thread::sleep(std::time::Duration::from_millis(500 * attempt as u64));
+                }
+            }
+        }
+    }
+    Err(format!(
+        "Kiro CLI failed after {} attempts: {}",
+        KIRO_MAX_ATTEMPTS, last_err
+    ))
+}
+
+fn run_kiro_once(key: &str, prompt: &str) -> Result<String, String> {
+    use std::io::Read;
+    use std::process::{Command, Stdio};
+    use std::time::{Duration, Instant};
+
+    let cli = resolve_kiro_cli();
+    let mut child = Command::new(&cli)
+        .args(["chat", "--no-interactive", prompt])
+        .env("KIRO_API_KEY", key)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("spawn failed ({}): {}", cli.display(), e))?;
+
+    // Drain pipes on dedicated threads so a large output can't deadlock the child.
+    let mut out_h = child.stdout.take();
+    let mut err_h = child.stderr.take();
+    let out_t = std::thread::spawn(move || {
+        let mut s = String::new();
+        if let Some(ref mut h) = out_h {
+            let _ = h.read_to_string(&mut s);
+        }
+        s
+    });
+    let err_t = std::thread::spawn(move || {
+        let mut s = String::new();
+        if let Some(ref mut h) = err_h {
+            let _ = h.read_to_string(&mut s);
+        }
+        s
+    });
+
+    let start = Instant::now();
+    let timeout = Duration::from_secs(60);
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(st)) => break st,
+            Ok(None) if start.elapsed() < timeout => {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err("Kiro CLI timed out".to_string());
+            }
+            Err(e) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!("Kiro CLI wait error: {}", e));
+            }
+        }
+    };
+
+    let stdout = out_t.join().unwrap_or_default();
+    let stderr = err_t.join().unwrap_or_default();
+
+    if !status.success() {
+        return Err(format!(
+            "Kiro CLI exit {}: {}",
+            status.code().unwrap_or(-1),
+            stderr.trim()
+        ));
+    }
+
+    let combined = format!("{}\n{}", stdout, stderr);
+
+    // kiro-cli exits 0 even on auth failure, printing an "Authentication failed" notice
+    // instead of a reply. Detect it so we surface a clear error and skip retries.
+    if combined.contains("Authentication failed") || combined.contains("invalid or expired") {
+        return Err("AUTH:Kiro authentication failed — check your API key".to_string());
+    }
+
+    let value = extract_json_object(&combined).ok_or("Kiro CLI returned no parseable JSON")?;
+    value
+        .get("t")
+        .and_then(|v| v.as_str())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "Kiro CLI JSON missing non-empty 't' field".to_string())
+}
+
+/// Extract the first balanced, string-aware JSON object from arbitrary text.
+/// ASCII delimiters (`{` `}` `"` `\`) never collide with UTF-8 continuation bytes
+/// (all >= 0x80), so byte indexing stays on char boundaries for the `{ … }` slice.
+fn extract_json_object(text: &str) -> Option<Value> {
+    let bytes = text.as_bytes();
+    for i in 0..bytes.len() {
+        if bytes[i] != b'{' {
+            continue;
+        }
+        let mut depth: i32 = 0;
+        let mut in_str = false;
+        let mut esc = false;
+        let mut j = i;
+        while j < bytes.len() {
+            let c = bytes[j];
+            if esc {
+                esc = false;
+            } else if in_str {
+                if c == b'\\' {
+                    esc = true;
+                } else if c == b'"' {
+                    in_str = false;
+                }
+            } else if c == b'"' {
+                in_str = true;
+            } else if c == b'{' {
+                depth += 1;
+            } else if c == b'}' {
+                depth -= 1;
+                if depth == 0 {
+                    if let Ok(v) = serde_json::from_str::<Value>(&text[i..=j]) {
+                        return Some(v);
+                    }
+                    break; // wrong start point — try next '{'
+                }
+            }
+            j += 1;
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_json_from_kiro_chrome() {
+        // Real `kiro-cli chat --no-interactive` output: ANSI + "> " marker + JSON + Credits footer.
+        let raw = "\n\u{1b}[38;5;252m\u{1b}[0m\u{1b}[?25l\u{1b}[38;5;141m> \u{1b}[0m{\"t\":\"안녕하세요 세계\"}\u{1b}[0m\u{1b}[0m\n\u{1b}[38;5;8m\n ▸ Credits: 0.03 • Time: 2s\n\n\u{1b}[0m";
+        let v = extract_json_object(raw).expect("should find JSON object");
+        assert_eq!(v.get("t").and_then(|x| x.as_str()), Some("안녕하세요 세계"));
+    }
+
+    #[test]
+    fn extracts_json_with_braces_inside_string() {
+        let raw = "noise > {\"t\":\"use {curly} braces\"} ▸ Credits: 0.01";
+        let v = extract_json_object(raw).expect("should find JSON object");
+        assert_eq!(
+            v.get("t").and_then(|x| x.as_str()),
+            Some("use {curly} braces")
+        );
+    }
+
+    #[test]
+    fn returns_none_without_json() {
+        assert!(extract_json_object("just some ▸ Credits: 0.01 text").is_none());
     }
 }
 

--- a/src-tauri/src/providers/types.rs
+++ b/src-tauri/src/providers/types.rs
@@ -156,6 +156,8 @@ pub struct AiKeys {
     #[serde(default)]
     pub anthropic: Option<String>,
     #[serde(default)]
+    pub kiro: Option<String>,
+    #[serde(default)]
     pub webhook_discord_url: Option<String>,
     #[serde(default)]
     pub webhook_slack_url: Option<String>,
@@ -170,6 +172,7 @@ impl AiKeys {
         self.gemini.is_some()
             || self.openai.is_some()
             || self.anthropic.is_some()
+            || self.kiro.is_some()
             || self.webhook_discord_url.is_some()
             || self.webhook_slack_url.is_some()
             || self.webhook_telegram_bot_token.is_some()

--- a/src/components/ChatRoom.tsx
+++ b/src/components/ChatRoom.tsx
@@ -137,7 +137,7 @@ function ChatContent({ userId, activated, visible }: { userId: string; activated
   } = useChat(userId, activated, visible);
   const langName = LANGUAGE_NAMES[prefs.language] ?? prefs.language;
   const { translations, translating, translate, translateReply: invokeTranslateReply } = useTranslate(langName);
-  const hasAiKey = !!(prefs.ai_keys?.gemini || prefs.ai_keys?.openai || prefs.ai_keys?.anthropic);
+  const hasAiKey = !!(prefs.ai_keys?.gemini || prefs.ai_keys?.openai || prefs.ai_keys?.anthropic || prefs.ai_keys?.kiro);
   const hasAiModel = !!prefs.ai_model;
   const myNickname = useMemo(() => getCachedProfile(userId)?.nickname ?? null, [userId, messages.length]);
   const { typingUsers, sendTyping, stopTyping } = useTypingIndicator(userId, myNickname, activated);

--- a/src/components/SettingsOverlay.tsx
+++ b/src/components/SettingsOverlay.tsx
@@ -987,6 +987,13 @@ const AI_PROVIDERS: AiProvider[] = [
       { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
     ],
   },
+  {
+    id: "kiro",
+    i18nKey: "settings.aiKeyKiro",
+    models: [
+      { id: "kiro", label: "Kiro CLI" },
+    ],
+  },
 ];
 
 function AiTranslationSection({
@@ -995,9 +1002,9 @@ function AiTranslationSection({
   onKeysChange,
   onModelChange,
 }: {
-  aiKeys?: { gemini?: string; openai?: string; anthropic?: string };
+  aiKeys?: { gemini?: string; openai?: string; anthropic?: string; kiro?: string };
   aiModel?: string;
-  onKeysChange: (keys: { gemini?: string; openai?: string; anthropic?: string }) => void;
+  onKeysChange: (keys: { gemini?: string; openai?: string; anthropic?: string; kiro?: string }) => void;
   onModelChange: (model: string | undefined) => void;
 }) {
   const t = useI18n();

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -47,16 +47,28 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const skipNextPersist = useRef(true);
 
   useEffect(() => {
-    invoke<UserPreferences>("get_preferences").then((p) => {
-      setPrefs(p);
-      // Skip the persist effect triggered by the initial load from disk.
-      skipNextPersist.current = true;
-      prevConfigDirsRef.current = JSON.stringify(p.config_dirs);
-      prevCodexDirsRef.current = JSON.stringify(p.codex_dirs);
-      setReady(true);
-    }).catch(() => {
-      setReady(true);
-    });
+    (async () => {
+      try {
+        const p = await invoke<UserPreferences>("get_preferences");
+        // AI keys live in a separate encrypted file and are intentionally NOT returned
+        // by get_preferences. Load them on their own and merge, so translation stays
+        // enabled across app restarts (otherwise prefs.ai_keys is always empty on launch).
+        let merged = p;
+        try {
+          const keys = await invoke<UserPreferences["ai_keys"] | null>("get_ai_keys");
+          if (keys) merged = { ...p, ai_keys: keys };
+        } catch {
+          /* keys are optional — ignore load failures */
+        }
+        setPrefs(merged);
+        // Skip the persist effect triggered by the initial load from disk.
+        skipNextPersist.current = true;
+        prevConfigDirsRef.current = JSON.stringify(merged.config_dirs);
+        prevCodexDirsRef.current = JSON.stringify(merged.codex_dirs);
+      } finally {
+        setReady(true);
+      }
+    })();
   }, []);
 
   // Apply theme to document

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -285,6 +285,7 @@
   "settings.aiKeyGemini": "Gemini API Key",
   "settings.aiKeyOpenAI": "OpenAI API Key",
   "settings.aiKeyAnthropic": "Anthropic API Key",
+  "settings.aiKeyKiro": "Kiro API Key (requires kiro-cli)",
   "settings.aiModel": "AI Model",
   "settings.aiDescription": "Translate chat messages using AI",
   "settings.aiFeatures": "• Click translate button on any message to read in your language\n• Auto-translate your replies to match the other person's language\n• Add an API key from any provider below to get started",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -285,6 +285,7 @@
   "settings.aiKeyGemini": "Gemini API 키",
   "settings.aiKeyOpenAI": "OpenAI API 키",
   "settings.aiKeyAnthropic": "Anthropic API 키",
+  "settings.aiKeyKiro": "Kiro API 키 (kiro-cli 필요)",
   "settings.aiModel": "AI 모델",
   "settings.aiDescription": "AI를 활용하여 채팅 메시지를 번역합니다",
   "settings.aiFeatures": "• 메시지의 번역 버튼을 눌러 내 언어로 확인\n• 답글 작성 시 상대방 언어로 자동 번역하여 전송\n• 아래 제공업체 중 하나의 API 키를 추가하면 사용할 수 있습니다",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -102,6 +102,7 @@ export interface UserPreferences {
     gemini?: string;
     openai?: string;
     anthropic?: string;
+    kiro?: string;
     webhook_discord_url?: string;
     webhook_slack_url?: string;
     webhook_telegram_bot_token?: string;


### PR DESCRIPTION
## 개요

채팅 번역 프로바이더에 **Kiro CLI**를 추가합니다 (기존 Gemini / OpenAI / Anthropic에 이어 네 번째). 다른 프로바이더와 달리 로컬에 설치된 `kiro-cli` 바이너리를 서브프로세스로 실행하며, 사용자가 입력한 API 키를 `KIRO_API_KEY` 환경변수로 주입해 인증합니다. `kiro-cli login` 세션은 필요하지 않으며 사용하지도 않습니다.

## 배경

이미 Kiro 구독 / `kiro-cli`를 사용 중인 사용자가, 다른 클라우드 API 키를 따로 발급받지 않고도 채팅 메시지를 번역할 수 있습니다.

## 동작 방식

- 모델 id가 `kiro`로 시작하면 `call_kiro`로 라우팅되어 `kiro-cli chat --no-interactive "<프롬프트>"`를 `KIRO_API_KEY`를 주입한 채 실행합니다.
- `kiro-cli chat`의 stdout에는 ANSI 코드, `> ` 프롬프트 마커, `Credits: … Time: …` 푸터가 섞여 나옵니다. 그래서 모델에게 응답을 `{"t":"…"}` 형태의 compact JSON으로 요청하고, 균형 괄호 + 문자열 인지 매칭으로 해당 객체만 추출합니다 (푸터·ANSI에는 중괄호가 없음). 타임아웃과 제한된 재시도를 포함합니다.
- `kiro-cli`는 인증 실패 시에도 exit code 0을 반환하므로, 출력 텍스트에서 인증 실패 메시지를 감지해 재시도 없이 명확한 에러로 처리합니다.

## 함께 수정한 기존 버그

- 채팅 번역 가드가 `gemini/openai/anthropic`만 확인하고 있어, 새 프로바이더 키가 무시되었습니다 — 이제 `kiro`도 포함합니다.
- `ai_keys`는 별도 암호화 파일에 저장되어 `get_preferences`에서 의도적으로 제외되는데, 프론트엔드가 `get_ai_keys`를 한 번도 호출하지 않아 매 실행 시 `prefs.ai_keys`가 비어 있었습니다 — **모든 프로바이더**에서 앱 재시작 후 번역이 비활성화되던 문제입니다. 이제 시작 시 키를 불러옵니다.

## 테스트

- TypeScript: `tsc --noEmit` 통과
- Rust: JSON 추출기 단위 테스트 추가 (`cargo test --lib ai_translate`)
- End-to-end: 실제 키로 `kiro-cli`에 대해 검증 — 번역, 답장 언어 감지, 그리고 키 강제 인증(잘못된 키는 login 세션으로 폴백하지 않고 실패) 확인

## 참고

- 로컬에 `kiro-cli`가 설치되어 있어야 합니다. 키는 다른 프로바이더와 동일하게 기존 AES-256-GCM 암호화 키 파일에 저장됩니다.
- en/ko UI 라벨을 추가했으며, 그 외 언어는 en으로 폴백합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
