### PR TITLE
fix(translate): guard kiro-cli against argv flag smuggling

### DIFF
--- a/src-tauri/src/ai_translate.rs
+++ b/src-tauri/src/ai_translate.rs
@@ -211,7 +211,10 @@ fn run_kiro_once(key: &str, prompt: &str) -> Result<String, String> {
 
     let cli = resolve_kiro_cli();
     let mut child = Command::new(&cli)
-        .args(["chat", "--no-interactive", prompt])
+        // `--` is an end-of-options sentinel: everything after it is treated as a
+        // positional argument, never a flag. The prompt embeds untrusted chat text, so
+        // without this a message starting with `-`/`--` could smuggle CLI flags into kiro-cli.
+        .args(["chat", "--no-interactive", "--", prompt])
         .env("KIRO_API_KEY", key)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())


### PR DESCRIPTION
## 개요

PR #143에서 추가된 Kiro CLI 번역 프로바이더의 **argument injection (argv flag smuggling)** 취약점을 수정합니다. 자동 보안 리뷰에서 HIGH로 플래그된 항목입니다.

## 문제

`call_kiro`는 번역 프롬프트를 `kiro-cli chat --no-interactive "<프롬프트>"`의 argv에 직접 전달합니다. 이 프롬프트에는 **채팅 상대방이 보낸 메시지**(untrusted 입력)가 포함됩니다.

셸을 경유하지 않으므로 셸 인젝션은 없지만, 메시지가 `-` 또는 `--something`으로 시작하면 `kiro-cli`가 이를 **CLI 플래그로 오인**할 수 있습니다(flag smuggling). 지원 플래그에 따라 설정 변경·파일 쓰기 등으로 악용될 여지가 있습니다.

> 실제 호출 경로상 프롬프트는 항상 `Translate...`/`What language...` 영문 지시문으로 시작하지만, 이는 암묵적 가정입니다. defense-in-depth 차원의 명시적 방어입니다.

## 수정

`--` end-of-options 센티넬을 추가해 그 뒤 인자를 모두 positional로 강제합니다.

```rust
.args(["chat", "--no-interactive", "--", prompt])
```

## 테스트

- `cargo test ai_translate` — 기존 JSON 추출기 테스트 3개 전부 통과, 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)