### PR TITLE
fix(usage): hide Codex gauges when source is toggled off

### DIFF
--- a/src/components/UsageAlertBar.tsx
+++ b/src/components/UsageAlertBar.tsx
@@ -394,7 +394,10 @@ export function UsageAlertBar() {
   const codexRateLimits = codexStats?.rate_limits ?? null;
   const hasCodexRateLimits = !!(codexRateLimits?.primary || codexRateLimits?.secondary);
   const hasCodexSummary = codexWeek.tokens > 0 || codexWeek.cost > 0 || codexWeek.messages > 0;
-  const hasCodexData = hasCodexRateLimits || hasCodexSummary;
+  // Codex usage must only surface when the source is actually enabled in the
+  // selector. Gate on showCodex so disabling Codex hides its gauges even when
+  // cached stats / rate limits still have data.
+  const hasCodexData = showCodex && (hasCodexRateLimits || hasCodexSummary);
 
   if (showClaude && !prefs.usage_tracking_enabled && !showCodex) {
     return (


### PR DESCRIPTION
## 문제

소스 선택 드롭다운에서 Codex를 꺼도("2개 중 1개 사용") **사용량 섹션에 Codex 게이지(세션/주간)가 계속 노출**된다는 제보. (제보자: mack-erel)

## 원인

`UsageAlertBar`에서 `showCodex = prefs.include_codex` 변수를 선언만 하고 Codex 블록 렌더링 조건에서는 사용하지 않았다. Codex 섹션이 `hasCodexData`(rate limit 또는 캐시된 사용량 존재 여부)만 보고 렌더링되어, 토글을 꺼도 캐시 데이터가 남아 있으면 게이지가 표시됐다.

- Claude 쪽: `hasClaudeData = showClaude && (...)` → 토글 존중 ✅
- Codex 쪽: `hasCodexData = hasCodexRateLimits || hasCodexSummary` → 토글 무시 ❌

`feat: add Codex usage limit tracking`에서 들어온 회귀.

## 수정

```diff
- const hasCodexData = hasCodexRateLimits || hasCodexSummary;
+ const hasCodexData = showCodex && (hasCodexRateLimits || hasCodexSummary);
```

`hasCodexData`에 `showCodex` 게이트를 추가해, 이 변수에 의존하는 모든 분기(빈 데이터 early-return, 구분선, Codex 블록)가 토글 상태를 일관되게 존중하도록 했다.

## 검증

- ✅ `tsc --noEmit` 통과
- ✅ `npm run build` 통과
- ✅ 메인 통계(`useCombinedStats`)는 이미 `includeCodex`를 올바르게 처리 중 — 버그는 `UsageAlertBar` 한 곳에만 국한됨을 교차 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)