### PR TITLE
fix(usage): show Claude usage placeholder instead of hiding the card

### DIFF
--- a/src/components/UsageAlertBar.tsx
+++ b/src/components/UsageAlertBar.tsx
@@ -149,6 +149,76 @@ function UsageRow({
   );
 }
 
+function RefreshButton({
+  refreshing,
+  cooldown,
+  onRefresh,
+}: {
+  refreshing: boolean;
+  cooldown: number;
+  onRefresh: () => void;
+}) {
+  const t = useI18n();
+  const disabled = refreshing || cooldown > 0;
+
+  return (
+    <button
+      onClick={onRefresh}
+      disabled={disabled}
+      title={
+        refreshing
+          ? t("usageAlert.refreshing")
+          : cooldown > 0
+          ? `${t("usageAlert.refresh")} (${cooldown}s)`
+          : t("usageAlert.refresh")
+      }
+      aria-label={t("usageAlert.refresh")}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: 18,
+        height: 18,
+        padding: 0,
+        background: "transparent",
+        border: "none",
+        borderRadius: 3,
+        color: "var(--text-muted)",
+        cursor: disabled ? "default" : "pointer",
+        opacity: disabled ? 0.4 : 0.8,
+        transition: "opacity 0.2s ease, color 0.2s ease",
+      }}
+      onMouseEnter={(e) => {
+        if (!disabled) {
+          e.currentTarget.style.color = "var(--text-primary)";
+        }
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.color = "var(--text-muted)";
+      }}
+    >
+      <svg
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{
+          animation: refreshing ? "miniProfileSpin 0.8s linear infinite" : "none",
+        }}
+      >
+        <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+        <path d="M21 3v5h-5" />
+        <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+        <path d="M3 21v-5h5" />
+      </svg>
+    </button>
+  );
+}
+
 function ProviderHeader({
   label,
   stale,
@@ -399,6 +469,10 @@ export function UsageAlertBar() {
   // cached stats / rate limits still have data.
   const hasCodexData = showCodex && (hasCodexRateLimits || hasCodexSummary);
 
+  // Claude-only, tracking never enabled: show the standalone enable card. When
+  // Codex is also on, the same enable affordance is rendered inline further
+  // down via showClaudePrompt → ClaudeTrackingPrompt, so this branch is
+  // deliberately gated on !showCodex to avoid a duplicate prompt.
   if (showClaude && !prefs.usage_tracking_enabled && !showCodex) {
     return (
       <div style={{
@@ -451,7 +525,14 @@ export function UsageAlertBar() {
 
   const hasClaudeData = showClaude && (!!five_hour || !!seven_day || !!extra_usage);
   const showClaudePrompt = showClaude && !prefs.usage_tracking_enabled;
-  if (!hasClaudeData && !showClaudePrompt && !hasCodexData) return null;
+  // Tracking is enabled (often auto-migrated for existing users) but no usage
+  // payload is cached yet — credentials missing, first poll pending, or the
+  // OAuth fetch failed. Surface an explicit "unavailable" state instead of
+  // silently dropping the whole card, which otherwise looks like Claude usage
+  // vanished when the user merely toggled Codex off.
+  const showClaudeUnavailable =
+    showClaude && prefs.usage_tracking_enabled && !hasClaudeData;
+  if (!hasClaudeData && !showClaudePrompt && !showClaudeUnavailable && !hasCodexData) return null;
 
   return (
     <div style={{
@@ -481,60 +562,11 @@ export function UsageAlertBar() {
             label={t("usageAlert.claude")}
             stale={is_stale}
             refreshButton={(
-              <button
-                onClick={handleRefresh}
-                disabled={refreshing || cooldown > 0}
-                title={
-                  refreshing
-                    ? t("usageAlert.refreshing")
-                    : cooldown > 0
-                    ? `${t("usageAlert.refresh")} (${cooldown}s)`
-                    : t("usageAlert.refresh")
-                }
-                aria-label={t("usageAlert.refresh")}
-                style={{
-                  display: "inline-flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  width: 18,
-                  height: 18,
-                  padding: 0,
-                  background: "transparent",
-                  border: "none",
-                  borderRadius: 3,
-                  color: "var(--text-muted)",
-                  cursor: refreshing || cooldown > 0 ? "default" : "pointer",
-                  opacity: refreshing || cooldown > 0 ? 0.4 : 0.8,
-                  transition: "opacity 0.2s ease, color 0.2s ease",
-                }}
-                onMouseEnter={(e) => {
-                  if (!refreshing && cooldown === 0) {
-                    e.currentTarget.style.color = "var(--text-primary)";
-                  }
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.color = "var(--text-muted)";
-                }}
-              >
-                <svg
-                  width="12"
-                  height="12"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  style={{
-                    animation: refreshing ? "miniProfileSpin 0.8s linear infinite" : "none",
-                  }}
-                >
-                  <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
-                  <path d="M21 3v5h-5" />
-                  <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
-                  <path d="M3 21v-5h5" />
-                </svg>
-              </button>
+              <RefreshButton
+                refreshing={refreshing}
+                cooldown={cooldown}
+                onRefresh={handleRefresh}
+              />
             )}
           />
           {five_hour && (
@@ -568,7 +600,29 @@ export function UsageAlertBar() {
         />
       )}
 
-      {(hasClaudeData || showClaudePrompt) && hasCodexData && (
+      {showClaudeUnavailable && (
+        <div>
+          <ProviderHeader
+            label={t("usageAlert.claude")}
+            refreshButton={(
+              <RefreshButton
+                refreshing={refreshing}
+                cooldown={cooldown}
+                onRefresh={handleRefresh}
+              />
+            )}
+          />
+          <div style={{
+            fontSize: 10,
+            color: "var(--text-secondary)",
+            lineHeight: 1.4,
+          }}>
+            {t("usageAlert.claudeUnavailable")}
+          </div>
+        </div>
+      )}
+
+      {(hasClaudeData || showClaudePrompt || showClaudeUnavailable) && hasCodexData && (
         <div style={{
           height: 1,
           background: "rgba(255,255,255,0.08)",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -237,6 +237,7 @@
   "usageAlert.resetsNow": "Wird zurückgesetzt...",
   "usageAlert.refresh": "Aktualisieren",
   "usageAlert.refreshing": "Wird aktualisiert...",
+  "usageAlert.claudeUnavailable": "Claude-Nutzung kann nicht geladen werden. Prüfe, ob du bei Claude Code angemeldet bist, oder klicke auf Aktualisieren.",
 
   "usageTracking.title": "Claude Nutzungsverfolgung",
   "usageTracking.description": "Überwachen Sie Ihre Claude Code Sitzungs- und Wochenlimits in Echtzeit. Dies erfordert Zugriff auf Ihre Claude Code Anmeldedaten.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -243,6 +243,7 @@
   "usageAlert.resetsNow": "Resetting...",
   "usageAlert.refresh": "Refresh",
   "usageAlert.refreshing": "Refreshing...",
+  "usageAlert.claudeUnavailable": "Unable to load Claude usage. Check that you're signed in to Claude Code, or press refresh.",
 
   "usageTracking.title": "Claude Usage Tracking",
   "usageTracking.description": "Monitor your Claude Code session and weekly usage limits in real-time. This requires access to your Claude Code login credentials.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -237,6 +237,7 @@
   "usageAlert.resetsNow": "Reiniciando...",
   "usageAlert.refresh": "Actualizar",
   "usageAlert.refreshing": "Actualizando...",
+  "usageAlert.claudeUnavailable": "No se puede cargar el uso de Claude. Comprueba que has iniciado sesión en Claude Code o pulsa Actualizar.",
 
   "usageTracking.title": "Seguimiento de uso de Claude",
   "usageTracking.description": "Monitorea tus límites de sesión y semanales de Claude Code en tiempo real. Requiere acceso a tus credenciales de inicio de sesión de Claude Code.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -237,6 +237,7 @@
   "usageAlert.resetsNow": "Réinitialisation...",
   "usageAlert.refresh": "Actualiser",
   "usageAlert.refreshing": "Actualisation...",
+  "usageAlert.claudeUnavailable": "Impossible de charger l'utilisation de Claude. Vérifiez que vous êtes connecté à Claude Code, ou appuyez sur Actualiser.",
 
   "usageTracking.title": "Suivi d'utilisation Claude",
   "usageTracking.description": "Surveillez vos limites de session et hebdomadaires de Claude Code en temps réel. Nécessite l'accès à vos identifiants de connexion Claude Code.",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -237,6 +237,7 @@
   "usageAlert.resetsNow": "Reset in corso...",
   "usageAlert.refresh": "Aggiorna",
   "usageAlert.refreshing": "Aggiornamento...",
+  "usageAlert.claudeUnavailable": "Impossibile caricare l'utilizzo di Claude. Verifica di aver effettuato l'accesso a Claude Code o premi Aggiorna.",
 
   "usageTracking.title": "Monitoraggio utilizzo Claude",
   "usageTracking.description": "Monitora i limiti di sessione e settimanali di Claude Code in tempo reale. Richiede l'accesso alle credenziali di Claude Code.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -237,6 +237,7 @@
   "usageAlert.resetsNow": "リセット中...",
   "usageAlert.refresh": "更新",
   "usageAlert.refreshing": "更新中...",
+  "usageAlert.claudeUnavailable": "Claude の使用量を読み込めません。Claude Code にログインしているか確認するか、更新を押してください。",
 
   "usageTracking.title": "Claude 使用量トラッキング",
   "usageTracking.description": "Claude Codeのセッションおよび週間使用制限をリアルタイムで監視します。Claude Codeのログイン認証情報へのアクセスが必要です。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -243,6 +243,7 @@
   "usageAlert.resetsNow": "리셋 중...",
   "usageAlert.refresh": "새로고침",
   "usageAlert.refreshing": "새로고침 중...",
+  "usageAlert.claudeUnavailable": "Claude 사용량을 불러올 수 없습니다. Claude Code 로그인 상태를 확인하거나 새로고침을 눌러주세요.",
 
   "usageTracking.title": "Claude 사용량 추적",
   "usageTracking.description": "Claude Code 세션 및 주간 사용 한도를 실시간으로 모니터링합니다. Claude Code 로그인 자격 증명에 대한 접근이 필요합니다.",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -237,6 +237,7 @@
   "usageAlert.resetsNow": "Sıfırlanıyor...",
   "usageAlert.refresh": "Yenile",
   "usageAlert.refreshing": "Yenileniyor...",
+  "usageAlert.claudeUnavailable": "Claude kullanımı yüklenemiyor. Claude Code'da oturum açtığınızdan emin olun veya yenile'ye basın.",
 
   "usageTracking.title": "Claude Kullanım Takibi",
   "usageTracking.description": "Claude Code oturum ve haftalık kullanım limitlerinizi gerçek zamanlı izleyin. Bu, Claude Code giriş kimlik bilgilerinize erişim gerektirir.",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -237,6 +237,7 @@
   "usageAlert.resetsNow": "重置中...",
   "usageAlert.refresh": "刷新",
   "usageAlert.refreshing": "刷新中...",
+  "usageAlert.claudeUnavailable": "无法加载 Claude 使用量。请确认已登录 Claude Code，或点击刷新。",
 
   "usageTracking.title": "Claude 用量追踪",
   "usageTracking.description": "实时监控 Claude Code 会话和每周使用限额。需要访问 Claude Code 登录凭据。",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -237,6 +237,7 @@
   "usageAlert.resetsNow": "重置中...",
   "usageAlert.refresh": "重新整理",
   "usageAlert.refreshing": "重新整理中...",
+  "usageAlert.claudeUnavailable": "無法載入 Claude 使用量。請確認已登入 Claude Code，或點擊重新整理。",
 
   "usageTracking.title": "Claude 用量追蹤",
   "usageTracking.description": "即時監控 Claude Code 工作階段和每週使用限額。需要存取 Claude Code 登入憑證。",


### PR DESCRIPTION
## 문제

소스 드롭다운에서 **Codex를 끄면 사용량 카드가 통째로 사라지는** 제보 (제보자: mack-erel, Mac 사용).

직전 PR #149에서 "Codex 게이지가 토글을 무시하고 노출되던" 버그를 고쳤는데, 그 부작용으로 이번 증상이 드러났다.

## 원인

- `get_oauth_usage()`는 **캐시만** 읽고 네트워크를 타지 않는다. 캐시가 비면 `null` 반환 → 프론트의 `usage`가 비어 `hasClaudeData=false`.
- 캐시가 비는 경우: OAuth 자격증명 없음 / 첫 폴링(최대 5분) 전 / fetch 실패(401·429 등).
- 기존 사용자는 migration으로 `usage_tracking_enabled=true`가 강제되어 **활성화 프롬프트(`showClaudePrompt`)도 안 뜬다**.
- 결과: `!hasClaudeData && !showClaudePrompt && !hasCodexData` → 카드 전체 `return null`.
- PR #149 이전엔 Codex 캐시 데이터가 `hasCodexData=true`를 만들어 카드가 떠 있었으나, Codex를 끄면 `hasCodexData=false`가 되어 빈 화면이 됨.

## 수정

`showClaudeUnavailable = showClaude && usage_tracking_enabled && !hasClaudeData` 상태를 추가해, 카드를 숨기는 대신 **Claude 헤더 + 새로고침 버튼 + "불러올 수 없음" 안내**를 렌더링한다. 새로고침을 누르면 `refresh_oauth_usage`가 실행되고 데이터가 채워지면 정상 게이지로 자동 전환된다.

부수 정리:
- 중복되던 새로고침 버튼 JSX(~55행 × 2)를 `RefreshButton` 컴포넌트로 추출 — 새 블록에 빠져 있던 hover 효과도 함께 복원.
- `usageAlert.claudeUnavailable` i18n 키를 10개 locale 전부에 추가.

## 동작 매트릭스

| 상태 | 결과 |
|------|------|
| Claude ON + OAuth 데이터 있음 | 게이지 표시 |
| Claude ON + tracking enabled + OAuth 데이터 **없음** | **"불러올 수 없음" + 새로고침** (이전: 카드 사라짐) |
| Claude ON + tracking 미활성 | 활성화 프롬프트 |
| Claude OFF + Codex ON | Codex 게이지만 (PR #149 유지) |
| 둘 다 OFF | 숨김 |

## 검증

- ✅ `tsc --noEmit` 통과
- ✅ `npm run build` 통과
- ✅ `feature-dev:code-reviewer` 리뷰: critical 0건, 지적된 hover 누락·중복은 RefreshButton 추출로 해소

🤖 Generated with [Claude Code](https://claude.com/claude-code)