### PR TITLE
fix(usage): stop showing a false Claude-usage error for Codex-only users

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -718,6 +718,11 @@ pub fn get_oauth_usage() -> Option<crate::oauth_usage::OAuthUsage> {
 }
 
 #[tauri::command]
+pub fn get_oauth_usage_status() -> crate::oauth_usage::OAuthUsageStatus {
+    crate::oauth_usage::get_usage_status()
+}
+
+#[tauri::command]
 pub async fn refresh_oauth_usage(app: tauri::AppHandle) -> Option<crate::oauth_usage::OAuthUsage> {
     // Throttle: if cache is fresh within 30 seconds, return it without hitting the API.
     // Mirrors the frontend cooldown so rapid manual clicks cannot hammer the OAuth endpoint

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -845,6 +845,7 @@ pub fn run() {
             commands::save_png_to_file,
             commands::get_pricing_table,
             commands::get_oauth_usage,
+            commands::get_oauth_usage_status,
             commands::refresh_oauth_usage,
             commands::enable_usage_tracking,
             commands::get_ai_keys,

--- a/src-tauri/src/oauth_usage.rs
+++ b/src-tauri/src/oauth_usage.rs
@@ -113,6 +113,36 @@ pub fn get_cached_usage() -> Option<OAuthUsage> {
     })
 }
 
+/// Coarse status used by the UI to decide whether the Claude usage card should
+/// show data, stay hidden, or surface an actionable message — without leaking
+/// credential objects out of this module.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OAuthUsageStatus {
+    /// Usage is cached and renderable.
+    Available,
+    /// No cached usage and no OAuth credentials on disk/keychain — the user has
+    /// not signed into Claude Code. This is the normal state for Codex-only
+    /// users and must NOT be shown as an error.
+    NoCredentials,
+    /// Credentials exist but no usage is cached yet — first poll pending or the
+    /// fetch failed (network / 401 / 429). Worth offering a refresh.
+    Unavailable,
+}
+
+/// Classify the current OAuth usage state for the UI. Reads the in-memory cache
+/// and, only when empty, probes for credentials (read-only keychain access — no
+/// prompt, since the polling loop already reads the same entry).
+pub fn get_usage_status() -> OAuthUsageStatus {
+    if get_cached_usage().is_some() {
+        return OAuthUsageStatus::Available;
+    }
+    if read_oauth_credentials().is_none() {
+        return OAuthUsageStatus::NoCredentials;
+    }
+    OAuthUsageStatus::Unavailable
+}
+
 /// Check if cache was fetched within the given number of seconds.
 pub fn is_cache_fresh(max_age_secs: u64) -> bool {
     if let Ok(cache) = OAUTH_CACHE.lock() {

--- a/src/components/UsageAlertBar.tsx
+++ b/src/components/UsageAlertBar.tsx
@@ -406,7 +406,7 @@ function ClaudeTrackingPrompt({
 
 export function UsageAlertBar() {
   const { prefs, refreshPrefs } = useSettings();
-  const { usage, refreshing, refresh } = useOAuthUsage();
+  const { usage, status: oauthStatus, refreshing, refresh } = useOAuthUsage();
   const { stats: codexStats } = useTokenStats("codex");
   const todayStr = useToday();
   const t = useI18n();
@@ -525,13 +525,16 @@ export function UsageAlertBar() {
 
   const hasClaudeData = showClaude && (!!five_hour || !!seven_day || !!extra_usage);
   const showClaudePrompt = showClaude && !prefs.usage_tracking_enabled;
-  // Tracking is enabled (often auto-migrated for existing users) but no usage
-  // payload is cached yet — credentials missing, first poll pending, or the
-  // OAuth fetch failed. Surface an explicit "unavailable" state instead of
-  // silently dropping the whole card, which otherwise looks like Claude usage
-  // vanished when the user merely toggled Codex off.
+  // Only surface the "unavailable" message when the backend reports that OAuth
+  // credentials exist but no usage is cached yet (first poll pending or a failed
+  // fetch). The "no_credentials" status — the normal state for Codex-only users
+  // who never signed into Claude Code — stays hidden so we don't show a
+  // permanent false error. Until the status resolves, render nothing.
   const showClaudeUnavailable =
-    showClaude && prefs.usage_tracking_enabled && !hasClaudeData;
+    showClaude &&
+    prefs.usage_tracking_enabled &&
+    !hasClaudeData &&
+    oauthStatus === "unavailable";
   if (!hasClaudeData && !showClaudePrompt && !showClaudeUnavailable && !hasCodexData) return null;
 
   return (

--- a/src/hooks/useOAuthUsage.ts
+++ b/src/hooks/useOAuthUsage.ts
@@ -1,10 +1,11 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import type { OAuthUsage } from "../lib/types";
+import type { OAuthUsage, OAuthUsageStatus } from "../lib/types";
 
 export function useOAuthUsage() {
   const [usage, setUsage] = useState<OAuthUsage | null>(null);
+  const [status, setStatus] = useState<OAuthUsageStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const requestIdRef = useRef(0);
@@ -12,9 +13,13 @@ export function useOAuthUsage() {
   const fetchUsage = useCallback(async () => {
     const requestId = ++requestIdRef.current;
     try {
-      const data = await invoke<OAuthUsage | null>("get_oauth_usage");
+      const [data, nextStatus] = await Promise.all([
+        invoke<OAuthUsage | null>("get_oauth_usage"),
+        invoke<OAuthUsageStatus>("get_oauth_usage_status").catch(() => null),
+      ]);
       if (requestId === requestIdRef.current) {
         setUsage(data);
+        if (nextStatus) setStatus(nextStatus);
       }
     } catch {
       // Ignore errors silently
@@ -27,11 +32,18 @@ export function useOAuthUsage() {
     const requestId = ++requestIdRef.current;
     setRefreshing(true);
     try {
+      // Status must be read AFTER the refresh completes — refresh_oauth_usage is
+      // an async network call that writes the cache only once it resolves, while
+      // get_oauth_usage_status is a synchronous cache read. Running them in
+      // parallel would let the status read see the pre-refresh (empty) cache and
+      // report "unavailable" even on a successful refresh.
       const data = await invoke<OAuthUsage | null>("refresh_oauth_usage");
+      const nextStatus = await invoke<OAuthUsageStatus>("get_oauth_usage_status").catch(() => null);
       // Only adopt the result if no newer request has started; otherwise keep
       // the more recent data. The spinner state is reset unconditionally below.
       if (requestId === requestIdRef.current) {
         setUsage(data);
+        if (nextStatus) setStatus(nextStatus);
       }
     } catch {
       // Ignore errors silently
@@ -57,5 +69,5 @@ export function useOAuthUsage() {
     };
   }, [fetchUsage]);
 
-  return { usage, loading, refreshing, refresh };
+  return { usage, status, loading, refreshing, refresh };
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -237,7 +237,7 @@
   "usageAlert.resetsNow": "Wird zurückgesetzt...",
   "usageAlert.refresh": "Aktualisieren",
   "usageAlert.refreshing": "Wird aktualisiert...",
-  "usageAlert.claudeUnavailable": "Claude-Nutzung kann nicht geladen werden. Prüfe, ob du bei Claude Code angemeldet bist, oder klicke auf Aktualisieren.",
+  "usageAlert.claudeUnavailable": "Claude-Nutzung ist vorübergehend nicht verfügbar. Klicke gleich auf Aktualisieren.",
 
   "usageTracking.title": "Claude Nutzungsverfolgung",
   "usageTracking.description": "Überwachen Sie Ihre Claude Code Sitzungs- und Wochenlimits in Echtzeit. Dies erfordert Zugriff auf Ihre Claude Code Anmeldedaten.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -243,7 +243,7 @@
   "usageAlert.resetsNow": "Resetting...",
   "usageAlert.refresh": "Refresh",
   "usageAlert.refreshing": "Refreshing...",
-  "usageAlert.claudeUnavailable": "Unable to load Claude usage. Check that you're signed in to Claude Code, or press refresh.",
+  "usageAlert.claudeUnavailable": "Claude usage is temporarily unavailable. Press refresh in a moment.",
 
   "usageTracking.title": "Claude Usage Tracking",
   "usageTracking.description": "Monitor your Claude Code session and weekly usage limits in real-time. This requires access to your Claude Code login credentials.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -237,7 +237,7 @@
   "usageAlert.resetsNow": "Reiniciando...",
   "usageAlert.refresh": "Actualizar",
   "usageAlert.refreshing": "Actualizando...",
-  "usageAlert.claudeUnavailable": "No se puede cargar el uso de Claude. Comprueba que has iniciado sesión en Claude Code o pulsa Actualizar.",
+  "usageAlert.claudeUnavailable": "El uso de Claude no está disponible temporalmente. Pulsa Actualizar en un momento.",
 
   "usageTracking.title": "Seguimiento de uso de Claude",
   "usageTracking.description": "Monitorea tus límites de sesión y semanales de Claude Code en tiempo real. Requiere acceso a tus credenciales de inicio de sesión de Claude Code.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -237,7 +237,7 @@
   "usageAlert.resetsNow": "Réinitialisation...",
   "usageAlert.refresh": "Actualiser",
   "usageAlert.refreshing": "Actualisation...",
-  "usageAlert.claudeUnavailable": "Impossible de charger l'utilisation de Claude. Vérifiez que vous êtes connecté à Claude Code, ou appuyez sur Actualiser.",
+  "usageAlert.claudeUnavailable": "L'utilisation de Claude est temporairement indisponible. Appuyez sur Actualiser dans un instant.",
 
   "usageTracking.title": "Suivi d'utilisation Claude",
   "usageTracking.description": "Surveillez vos limites de session et hebdomadaires de Claude Code en temps réel. Nécessite l'accès à vos identifiants de connexion Claude Code.",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -237,7 +237,7 @@
   "usageAlert.resetsNow": "Reset in corso...",
   "usageAlert.refresh": "Aggiorna",
   "usageAlert.refreshing": "Aggiornamento...",
-  "usageAlert.claudeUnavailable": "Impossibile caricare l'utilizzo di Claude. Verifica di aver effettuato l'accesso a Claude Code o premi Aggiorna.",
+  "usageAlert.claudeUnavailable": "L'utilizzo di Claude è temporaneamente non disponibile. Premi Aggiorna tra poco.",
 
   "usageTracking.title": "Monitoraggio utilizzo Claude",
   "usageTracking.description": "Monitora i limiti di sessione e settimanali di Claude Code in tempo reale. Richiede l'accesso alle credenziali di Claude Code.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -237,7 +237,7 @@
   "usageAlert.resetsNow": "リセット中...",
   "usageAlert.refresh": "更新",
   "usageAlert.refreshing": "更新中...",
-  "usageAlert.claudeUnavailable": "Claude の使用量を読み込めません。Claude Code にログインしているか確認するか、更新を押してください。",
+  "usageAlert.claudeUnavailable": "Claude の使用量を一時的に読み込めません。しばらくしてから更新を押してください。",
 
   "usageTracking.title": "Claude 使用量トラッキング",
   "usageTracking.description": "Claude Codeのセッションおよび週間使用制限をリアルタイムで監視します。Claude Codeのログイン認証情報へのアクセスが必要です。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -243,7 +243,7 @@
   "usageAlert.resetsNow": "리셋 중...",
   "usageAlert.refresh": "새로고침",
   "usageAlert.refreshing": "새로고침 중...",
-  "usageAlert.claudeUnavailable": "Claude 사용량을 불러올 수 없습니다. Claude Code 로그인 상태를 확인하거나 새로고침을 눌러주세요.",
+  "usageAlert.claudeUnavailable": "Claude 사용량을 일시적으로 불러올 수 없습니다. 잠시 후 새로고침을 눌러주세요.",
 
   "usageTracking.title": "Claude 사용량 추적",
   "usageTracking.description": "Claude Code 세션 및 주간 사용 한도를 실시간으로 모니터링합니다. Claude Code 로그인 자격 증명에 대한 접근이 필요합니다.",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -237,7 +237,7 @@
   "usageAlert.resetsNow": "Sıfırlanıyor...",
   "usageAlert.refresh": "Yenile",
   "usageAlert.refreshing": "Yenileniyor...",
-  "usageAlert.claudeUnavailable": "Claude kullanımı yüklenemiyor. Claude Code'da oturum açtığınızdan emin olun veya yenile'ye basın.",
+  "usageAlert.claudeUnavailable": "Claude kullanımı geçici olarak kullanılamıyor. Birazdan yenile'ye basın.",
 
   "usageTracking.title": "Claude Kullanım Takibi",
   "usageTracking.description": "Claude Code oturum ve haftalık kullanım limitlerinizi gerçek zamanlı izleyin. Bu, Claude Code giriş kimlik bilgilerinize erişim gerektirir.",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -237,7 +237,7 @@
   "usageAlert.resetsNow": "重置中...",
   "usageAlert.refresh": "刷新",
   "usageAlert.refreshing": "刷新中...",
-  "usageAlert.claudeUnavailable": "无法加载 Claude 使用量。请确认已登录 Claude Code，或点击刷新。",
+  "usageAlert.claudeUnavailable": "暂时无法加载 Claude 使用量。请稍后点击刷新。",
 
   "usageTracking.title": "Claude 用量追踪",
   "usageTracking.description": "实时监控 Claude Code 会话和每周使用限额。需要访问 Claude Code 登录凭据。",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -237,7 +237,7 @@
   "usageAlert.resetsNow": "重置中...",
   "usageAlert.refresh": "重新整理",
   "usageAlert.refreshing": "重新整理中...",
-  "usageAlert.claudeUnavailable": "無法載入 Claude 使用量。請確認已登入 Claude Code，或點擊重新整理。",
+  "usageAlert.claudeUnavailable": "暫時無法載入 Claude 使用量。請稍後點擊重新整理。",
 
   "usageTracking.title": "Claude 用量追蹤",
   "usageTracking.description": "即時監控 Claude Code 工作階段和每週使用限額。需要存取 Claude Code 登入憑證。",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -152,3 +152,11 @@ export interface OAuthUsage {
   fetched_at: string;
   is_stale: boolean;
 }
+
+// Mirrors the Rust OAuthUsageStatus enum (serde rename_all = "snake_case").
+// "available": usage is cached and renderable.
+// "no_credentials": user has not signed into Claude Code — normal for
+//   Codex-only users; must not be surfaced as an error.
+// "unavailable": credentials exist but no usage cached yet (first poll pending
+//   or a failed fetch) — worth offering a refresh.
+export type OAuthUsageStatus = "available" | "no_credentials" | "unavailable";


### PR DESCRIPTION
## 문제 (v0.19.22 회귀)

v0.19.22(PR #150)에서 도입한 `showClaudeUnavailable = showClaude && usage_tracking_enabled && !hasClaudeData`가 너무 광범위하게 true가 됐다.

- `include_claude` 기본값 **true**
- `usage_tracking_enabled`는 모든 기존 사용자에게 migration으로 **강제 true**

→ **Codex만 쓰거나 Claude Code에 로그인한 적 없는 사용자**가 매 세션 *"Claude 사용량을 불러올 수 없습니다"* 오류 블록을 영구적으로 보게 됨. healthy 사용자도 cold-start 시 깜빡임 발생.

(워크플로우 코드리뷰 `/code-review high`에서 CONFIRMED로 검출)

## 수정

"자격증명 없음"(= Claude 미로그인, Codex-only 사용자의 정상 상태)과 "자격증명 있으나 데이터 미수신"(첫 폴링 대기 또는 fetch 실패)을 구분한다.

**백엔드** (`oauth_usage.rs` / `commands.rs` / `lib.rs`):
- `OAuthUsageStatus { available, no_credentials, unavailable }` enum + `get_usage_status()` 추가
- `get_oauth_usage_status` Tauri command로 노출
- 캐시를 읽고, 비었을 때만 자격증명을 **read-only**로 확인(keychain 프롬프트 없음 — polling이 이미 동일 항목을 읽음)

**프론트** (`useOAuthUsage.ts` / `UsageAlertBar.tsx` / `types.ts`):
- `useOAuthUsage`가 status도 조회
- `showClaudeUnavailable`에 `oauthStatus === "unavailable"` 조건 추가 → `no_credentials`면 **숨김**
- `refresh()`에서 status를 `refresh_oauth_usage` 완료 **이후 순차** 조회(병렬 시 갱신 전 캐시를 읽어 잘못된 unavailable 보고하는 레이스 방지)

**i18n**: `claudeUnavailable` 메시지에서 "로그인 확인" 문구 제거(그 케이스는 이제 카드 숨김으로 처리) → "일시적 불가, 새로고침" (10 locale)

## 동작 매트릭스

| 상태 | status | 결과 |
|------|--------|------|
| Claude 데이터 있음(stale 포함) | available | 게이지 표시 |
| Claude ON + 자격증명 **없음**(Codex-only/미로그인) | no_credentials | **숨김** (거짓 오류 제거) |
| Claude ON + 자격증명 있으나 데이터 없음 | unavailable | "일시적 불가 + 새로고침" |
| status 미해결(cold-start, 1 IPC 라운드트립) | null | 숨김 (깜빡임 없음) |

## 검증

- ✅ `cargo check` / `cargo test --lib oauth` (6 passed)
- ✅ `tsc --noEmit` / `npm run build`
- ✅ `feature-dev:code-reviewer`: critical 0건. 지적된 refresh 레이스(Issue 1)는 순차 조회로 수정. 로그인 후 5분 폴링 갱신 갭(Issue 2)은 기존 동작과 동일한 pre-existing 갭이라 범위 제외

🤖 Generated with [Claude Code](https://claude.com/claude-code)