### PR TITLE
fix(usage): find Claude OAuth credentials across multiple keychain accounts

### DIFF
--- a/src-tauri/src/oauth_usage.rs
+++ b/src-tauri/src/oauth_usage.rs
@@ -271,23 +271,36 @@ fn read_oauth_credentials_macos() -> Option<OAuthCredentials> {
 
 #[cfg(target_os = "macos")]
 fn read_oauth_credentials_keychain() -> Option<OAuthCredentials> {
-    let account = whoami::username();
+    // A single service ("Claude Code-credentials") can hold MORE THAN ONE item
+    // under different accounts. Observed in the wild: one item with acct="unknown"
+    // that only carries `mcpOAuth` (no `claudeAiOauth`), and another under the OS
+    // username that carries the real `claudeAiOauth` token — or vice versa. Which
+    // item `security` returns for a given `-a` is not reliable across machines, so
+    // we try several account candidates AND fall back to an account-less lookup,
+    // accepting only an item that actually yields claudeAiOauth credentials. This
+    // is why some macOS users saw "unavailable" while others worked: the lookup
+    // happened to land on the mcpOAuth-only item.
+    let username = whoami::username();
+    let account_candidates: [Option<&str>; 3] = [Some("unknown"), Some(&username), None];
 
-    // Try legacy name first (avoids `security dump-keychain` discovery)
     let legacy = "Claude Code-credentials";
-    if let Some(credentials) = read_keychain_credentials(legacy, &account) {
-        return Some(credentials);
+    for account in account_candidates {
+        if let Some(credentials) = read_keychain_credentials(legacy, account) {
+            return Some(credentials);
+        }
     }
 
     // Claude Code v2.1.52+ uses "Claude Code-credentials-{hash}" service name.
-    // Only run discovery if legacy name didn't work.
+    // Only run discovery if the legacy name didn't yield usable credentials.
     let service_names = find_keychain_service_names();
     for service in &service_names {
         if service == legacy {
-            continue; // Already tried
+            continue; // Already tried above
         }
-        if let Some(credentials) = read_keychain_credentials(service, &account) {
-            return Some(credentials);
+        for account in account_candidates {
+            if let Some(credentials) = read_keychain_credentials(service, account) {
+                return Some(credentials);
+            }
         }
     }
     None
@@ -296,12 +309,18 @@ fn read_oauth_credentials_keychain() -> Option<OAuthCredentials> {
 /// Read a password from macOS Keychain via `/usr/bin/security` CLI.
 /// Claude Code stores credentials using the same `security` binary,
 /// so it's always in the keychain item's ACL — no permission prompts.
+/// When `account` is None the `-a` filter is omitted so `security` returns the
+/// first matching item for the service regardless of its account field.
 #[cfg(target_os = "macos")]
-fn read_keychain_credentials(service: &str, account: &str) -> Option<OAuthCredentials> {
-    let output = Command::new("/usr/bin/security")
-        .args(["find-generic-password", "-s", service, "-a", account, "-w"])
-        .output()
-        .ok()?;
+fn read_keychain_credentials(service: &str, account: Option<&str>) -> Option<OAuthCredentials> {
+    let mut args = vec!["find-generic-password", "-s", service];
+    if let Some(account) = account {
+        args.push("-a");
+        args.push(account);
+    }
+    args.push("-w");
+
+    let output = Command::new("/usr/bin/security").args(&args).output().ok()?;
 
     if !output.status.success() {
         return None;
@@ -674,5 +693,20 @@ mod tests {
         let credentials = extract_credentials_from_keychain_data(payload).expect("credentials");
 
         assert_eq!(credentials.access_token, "access-token");
+    }
+
+    #[test]
+    fn rejects_keychain_item_without_claude_oauth() {
+        // A "Claude Code-credentials" keychain item can hold only `mcpOAuth`
+        // (no `claudeAiOauth`). Extraction must return None so the lookup keeps
+        // trying other account candidates / service names instead of accepting
+        // a tokenless item and reporting "unavailable".
+        let value = serde_json::json!({
+            "mcpOAuth": {
+                "notion|abc": { "serverName": "notion" }
+            }
+        });
+
+        assert!(extract_oauth_credentials(&value).is_none());
     }
 }


### PR DESCRIPTION
## 문제

macOS 일부 사용자만 Claude 사용량이 *"일시적으로 불러올 수 없습니다"*(`unavailable` 상태)로 표시. 같은 macOS인데 개발자 본인은 정상, 제보자(kimeloo, macOS 26.5.1, Claude Code 로그인됨)는 실패. Windows는 정상.

## 근본 원인 (본인 환경에서 직접 재현해 확정)

macOS keychain의 `Claude Code-credentials` service에 **account가 다른 항목이 2개** 존재할 수 있다:
- `acct="unknown"` → `mcpOAuth`만 (Claude 사용량 토큰 `claudeAiOauth` **없음**)
- `acct={OS username}` → `claudeAiOauth` **있음** (실제 토큰)

— 또는 그 반대.

기존 코드는 keychain CLI를 `-a {whoami}` 단일 account로 조회했는데, **같은 service에 항목이 여럿일 때 어느 것이 반환될지가 머신마다 비결정적**이다. 직접 재현 결과 account 인자에 따라 토큰 유무가 갈렸다(본인은 username 항목에 토큰이 있어 운 좋게 성공, unknown/무지정은 토큰 없는 항목 반환).

토큰이 `unknown` account에 저장된 사용자는 lookup이 tokenless 항목에 막혀 자격증명 추출 실패 → fetch 실패 → `unavailable`.

## 수정 (`oauth_usage.rs`)

- `read_oauth_credentials_keychain()`이 account 후보 `[Some("unknown"), Some(whoami), None]`를 순서대로 시도. 각 service name(legacy + hash discovery)에 대해 반복.
- `read_keychain_credentials(service, account: Option<&str>)` — `None`이면 account 필터를 생략(account 무관 조회).
- `extract_oauth_credentials`가 `claudeAiOauth` 없으면 `None`을 반환하므로, `mcpOAuth`만 있는 항목은 자동 skip되고 다음 후보로 진행.
- 회귀 테스트 `rejects_keychain_item_without_claude_oauth` 추가.

## 검증

- ✅ `cargo check` / `cargo test --lib oauth` (7 passed, 신규 포함)
- ✅ 본인 환경 시뮬레이션: `unknown`(skip) → `soul`(토큰 채택) 정상 동작 확인
- ✅ `feature-dev:code-reviewer`: **critical 0, 블로킹 없음, "ready to ship"**. account 순회·`Option<&str>` 수명·discovery 상호작용 모두 safe 확인. 지적된 2건은 pre-existing 한계(keychain CLI 단일 반환 특성, SERVICE_NAMES_CACHE double-lock)로 이 PR이 도입한 게 아니며 오히려 discovery 호출 빈도가 줄어듦.

> clippy의 pre-existing Mutex deadlock 에러(claude_code.rs/codex.rs/kimi.rs)는 이 변경과 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
