### PR TITLE
fix(usage): tolerate null resets_at in OAuth usage response

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,31 +83,35 @@ fn check_and_fire_alerts(app_handle: &tauri::AppHandle) {
     //   - It doesn't change on minor timestamp drift within the same window
     let mut windows_to_check: Vec<(&str, f64, String, Option<String>)> = Vec::new();
 
-    // Truncate resets_at to hour to avoid spurious resets from second-level drift
-    fn stable_window_id(name: &str, resets_at: &str) -> String {
-        // Take first 13 chars of ISO timestamp (e.g. "2026-04-03T11") for hour-level stability
-        let truncated = &resets_at[..resets_at.len().min(13)];
-        format!("{}:{}", name, truncated)
+    // Truncate resets_at to hour to avoid spurious resets from second-level drift.
+    // resets_at is optional — a window with no scheduled reset still needs a
+    // stable id, so fall back to a fixed marker instead of the timestamp.
+    fn stable_window_id(name: &str, resets_at: Option<&str>) -> String {
+        match resets_at {
+            // Take first 13 chars of ISO timestamp (e.g. "2026-04-03T11") for hour-level stability
+            Some(ts) => format!("{}:{}", name, &ts[..ts.len().min(13)]),
+            None => format!("{}:none", name),
+        }
     }
 
     if monitored.five_hour {
         if let Some(w) = &usage.five_hour {
-            windows_to_check.push(("Session (5h)", w.utilization, stable_window_id("5h", &w.resets_at), Some(w.resets_at.clone())));
+            windows_to_check.push(("Session (5h)", w.utilization, stable_window_id("5h", w.resets_at.as_deref()), w.resets_at.clone()));
         }
     }
     if monitored.seven_day {
         if let Some(w) = &usage.seven_day {
-            windows_to_check.push(("Weekly", w.utilization, stable_window_id("7d", &w.resets_at), Some(w.resets_at.clone())));
+            windows_to_check.push(("Weekly", w.utilization, stable_window_id("7d", w.resets_at.as_deref()), w.resets_at.clone()));
         }
     }
     if monitored.seven_day_sonnet {
         if let Some(w) = &usage.seven_day_sonnet {
-            windows_to_check.push(("Weekly Sonnet", w.utilization, stable_window_id("7d-sonnet", &w.resets_at), Some(w.resets_at.clone())));
+            windows_to_check.push(("Weekly Sonnet", w.utilization, stable_window_id("7d-sonnet", w.resets_at.as_deref()), w.resets_at.clone()));
         }
     }
     if monitored.seven_day_opus {
         if let Some(w) = &usage.seven_day_opus {
-            windows_to_check.push(("Weekly Opus", w.utilization, stable_window_id("7d-opus", &w.resets_at), Some(w.resets_at.clone())));
+            windows_to_check.push(("Weekly Opus", w.utilization, stable_window_id("7d-opus", w.resets_at.as_deref()), w.resets_at.clone()));
         }
     }
     if monitored.extra_usage {

--- a/src-tauri/src/oauth_usage.rs
+++ b/src-tauri/src/oauth_usage.rs
@@ -10,7 +10,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UsageWindow {
     pub utilization: f64,
-    pub resets_at: String,
+    // The API returns `null` for `resets_at` on windows that have no scheduled
+    // reset (e.g. a scoped weekly window at 0% utilization). It must stay
+    // optional — a non-optional String here makes serde fail the ENTIRE response
+    // parse, which empties the cache and surfaces a false "unavailable" error.
+    pub resets_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -549,7 +553,17 @@ struct ApiResponse {
 #[derive(Debug, Deserialize)]
 struct ApiUsageWindow {
     utilization: f64,
-    resets_at: String,
+    #[serde(default)]
+    resets_at: Option<String>,
+}
+
+impl From<ApiUsageWindow> for UsageWindow {
+    fn from(w: ApiUsageWindow) -> Self {
+        UsageWindow {
+            utilization: w.utilization,
+            resets_at: w.resets_at,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -604,22 +618,10 @@ async fn fetch_usage_from_api(token: &str) -> Result<OAuthUsage, FetchUsageError
         .map_err(|e| FetchUsageError::Parse(e.to_string()))?;
 
     Ok(OAuthUsage {
-        five_hour: api.five_hour.map(|w| UsageWindow {
-            utilization: w.utilization,
-            resets_at: w.resets_at,
-        }),
-        seven_day: api.seven_day.map(|w| UsageWindow {
-            utilization: w.utilization,
-            resets_at: w.resets_at,
-        }),
-        seven_day_sonnet: api.seven_day_sonnet.map(|w| UsageWindow {
-            utilization: w.utilization,
-            resets_at: w.resets_at,
-        }),
-        seven_day_opus: api.seven_day_opus.map(|w| UsageWindow {
-            utilization: w.utilization,
-            resets_at: w.resets_at,
-        }),
+        five_hour: api.five_hour.map(UsageWindow::from),
+        seven_day: api.seven_day.map(UsageWindow::from),
+        seven_day_sonnet: api.seven_day_sonnet.map(UsageWindow::from),
+        seven_day_opus: api.seven_day_opus.map(UsageWindow::from),
         extra_usage: api.extra_usage.and_then(|e| {
             let monthly_limit = e.monthly_limit?;
             let used_credits = e.used_credits?;
@@ -693,6 +695,33 @@ mod tests {
         let credentials = extract_credentials_from_keychain_data(payload).expect("credentials");
 
         assert_eq!(credentials.access_token, "access-token");
+    }
+
+    #[test]
+    fn parses_api_response_with_null_resets_at() {
+        // Real api.anthropic.com/api/oauth/usage payload shape: a scoped weekly
+        // window (e.g. Sonnet) at 0% utilization reports `resets_at: null`. A
+        // non-optional String field made serde fail the ENTIRE parse here, which
+        // emptied the cache and surfaced a false "unavailable" error in the UI.
+        let body = r#"{
+            "five_hour": {"utilization": 63.0, "resets_at": "2026-06-29T04:50:00Z", "limit_dollars": null},
+            "seven_day": {"utilization": 8.0, "resets_at": "2026-07-03T18:00:00Z"},
+            "seven_day_oauth_apps": null,
+            "seven_day_opus": null,
+            "seven_day_sonnet": {"utilization": 0.0, "resets_at": null},
+            "extra_usage": {"is_enabled": false, "monthly_limit": null, "used_credits": null, "utilization": null}
+        }"#;
+
+        let api: ApiResponse = serde_json::from_str(body).expect("response should parse");
+
+        let sonnet = api.seven_day_sonnet.expect("seven_day_sonnet present");
+        assert_eq!(sonnet.utilization, 0.0);
+        assert_eq!(sonnet.resets_at, None);
+        assert_eq!(
+            api.five_hour.unwrap().resets_at.as_deref(),
+            Some("2026-06-29T04:50:00Z")
+        );
+        assert!(api.seven_day_opus.is_none());
     }
 
     #[test]

--- a/src/components/UsageAlertBar.tsx
+++ b/src/components/UsageAlertBar.tsx
@@ -18,8 +18,12 @@ function getBarColor(percent: number): string {
   return "#22c55e";
 }
 
-function formatResetTime(resetsAt: string, t: (key: string, params?: Record<string, string>) => string): string {
+function formatResetTime(resetsAt: string | null | undefined, t: (key: string, params?: Record<string, string>) => string): string {
+  // The API omits resets_at (null) for windows with no scheduled reset. Bail
+  // before the diff math so we render a clean blank instead of "NaNd NaNh".
+  if (!resetsAt) return "";
   const reset = new Date(resetsAt);
+  if (Number.isNaN(reset.getTime())) return "";
   const now = new Date();
   const diffMs = reset.getTime() - now.getTime();
   if (diffMs <= 0) return t("usageAlert.resetsNow");

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -133,7 +133,8 @@ export interface MonitoredWindows {
 
 export interface UsageWindow {
   utilization: number;
-  resets_at: string;
+  // null when the window has no scheduled reset (e.g. a scoped weekly window at 0%)
+  resets_at: string | null;
 }
 
 export interface ExtraUsage {


### PR DESCRIPTION
## Problem

The Claude usage card surfaced **"Claude 사용량을 일시적으로 불러올 수 없습니다"** (`Unavailable` state) for some users even though OAuth credentials were valid and `https://api.anthropic.com/api/oauth/usage` returned **HTTP 200** with usage data.

## Root cause

The live API response carries `resets_at: null` for windows that have no scheduled reset — e.g. a scoped weekly **Sonnet** window at 0% utilization:

```json
"seven_day_sonnet": { "utilization": 0.0, "resets_at": null }
```

`ApiUsageWindow.resets_at` was a non-optional `String`, so serde failed the **entire** `response.json::<ApiResponse>()` parse on that single `null`. The fetch returned a `Parse` error, the cache stayed empty, and `get_usage_status()` reported `Unavailable` — even though `seven_day_sonnet`/`seven_day_opus` aren't even rendered in the card.

This explains the intermittency: it only breaks once a window's `resets_at` comes back `null`.

## Fix

Make `resets_at` optional end-to-end:

- **`oauth_usage.rs`** — `UsageWindow` / `ApiUsageWindow` use `Option<String>`; add a regression test built from the real null payload.
- **`lib.rs`** — `stable_window_id` accepts the optional timestamp (falls back to a `:none` marker so reset-detection stays stable).
- **`types.ts`** — `resets_at: string | null`.
- **`UsageAlertBar.tsx`** — `formatResetTime` returns `""` on null / invalid date, so an absent timestamp renders blank instead of `NaNd NaNh`.

## Verification

- `curl` against the live endpoint confirmed the `resets_at: null` payload (HTTP 200).
- New regression test parses that exact payload; full backend suite (86 tests) passes; `tsc` passes.
- Ran the app via `tauri dev` — usage now parses and caches:
  `5h=Some(68.0) 7d=Some(8.0) sonnet=Some((0.0, None))`, card renders instead of the error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)