### PR TITLE
fix(usage): unstick Claude usage refresh during 429 back-off window

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -756,11 +756,25 @@ pub async fn refresh_oauth_usage(app: tauri::AppHandle) -> Option<crate::oauth_u
     if crate::oauth_usage::is_cache_fresh(30) {
         return crate::oauth_usage::get_cached_usage();
     }
+    // If we're inside a 429 back-off window, fetch_and_cache_usage() will
+    // short-circuit and hand back the same stale cache. Don't emit
+    // "usage-updated" in that case — the data hasn't changed and re-emitting
+    // makes the refresh button look like it silently did nothing.
+    let rate_limited_before = crate::oauth_usage::rate_limit_remaining_secs().is_some();
     let result = crate::oauth_usage::fetch_and_cache_usage().await;
-    if result.is_some() {
+    let rate_limited_after = crate::oauth_usage::rate_limit_remaining_secs().is_some();
+    if result.is_some() && !rate_limited_before && !rate_limited_after {
         let _ = app.emit("usage-updated", ());
     }
     result
+}
+
+/// Seconds remaining before the Claude usage API can be polled again after a
+/// 429, or `None` when refresh is unthrottled. Lets the UI explain an inert
+/// refresh button.
+#[tauri::command]
+pub fn get_oauth_rate_limit_remaining() -> Option<u64> {
+    crate::oauth_usage::rate_limit_remaining_secs()
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -894,6 +894,7 @@ pub fn run() {
             commands::get_pricing_table,
             commands::get_oauth_usage,
             commands::get_oauth_usage_status,
+            commands::get_oauth_rate_limit_remaining,
             commands::refresh_oauth_usage,
             commands::enable_usage_tracking,
             commands::get_ai_keys,

--- a/src-tauri/src/oauth_usage.rs
+++ b/src-tauri/src/oauth_usage.rs
@@ -130,8 +130,10 @@ pub fn get_cached_usage() -> Option<OAuthUsage> {
     let cache = OAUTH_CACHE.lock().ok()?;
     cache.as_ref().map(|entry| {
         let mut usage = entry.usage.clone();
-        // Mark as stale if older than 10 minutes
-        if entry.fetched_at.elapsed().as_secs() > 600 {
+        // Mark as stale if older than 15 minutes. Kept comfortably above the
+        // 5-minute poll interval (lib.rs) so a single failed/slow poll does not
+        // immediately flip the badge to "stale".
+        if entry.fetched_at.elapsed().as_secs() > 900 {
             usage.is_stale = true;
         }
         usage
@@ -166,6 +168,20 @@ pub fn get_usage_status() -> OAuthUsageStatus {
         return OAuthUsageStatus::NoCredentials;
     }
     OAuthUsageStatus::Unavailable
+}
+
+/// Seconds remaining in the current 429 rate-limit back-off window, if any.
+/// The UI uses this to explain why a manual refresh currently does nothing
+/// instead of leaving the button looking inert. Returns `None` when we are
+/// free to hit the API again.
+pub fn rate_limit_remaining_secs() -> Option<u64> {
+    let until = (*RATE_LIMIT_UNTIL.lock().ok()?)?;
+    let now = Instant::now();
+    if until > now {
+        Some((until - now).as_secs().max(1))
+    } else {
+        None
+    }
 }
 
 /// Check if cache was fetched within the given number of seconds.
@@ -690,7 +706,8 @@ async fn fetch_usage_from_api(token: &str) -> Result<OAuthUsage, FetchUsageError
             .get("retry-after")
             .and_then(|v| v.to_str().ok())
             .and_then(|v| v.parse::<u64>().ok())
-            .unwrap_or(300); // default 5 min if header missing
+            .unwrap_or(60); // default 1 min if header missing — a missing header
+                            // should not lock manual refresh out for 5 minutes.
         if let Ok(mut guard) = RATE_LIMIT_UNTIL.lock() {
             *guard = Some(Instant::now() + std::time::Duration::from_secs(retry_after_secs));
         }
@@ -894,5 +911,23 @@ mod tests {
         });
 
         assert!(extract_oauth_credentials(&value).is_none());
+    }
+
+    #[test]
+    fn rate_limit_remaining_reports_window_then_clears() {
+        // Future window → remaining seconds are reported so the UI can explain
+        // why refresh is throttled.
+        *RATE_LIMIT_UNTIL.lock().unwrap() = Some(Instant::now() + Duration::from_secs(45));
+        let remaining = rate_limit_remaining_secs().expect("should be within window");
+        assert!((1..=45).contains(&remaining), "got {remaining}");
+
+        // Past window → None, so the UI drops back to the normal stale badge.
+        *RATE_LIMIT_UNTIL.lock().unwrap() =
+            Some(Instant::now() - Duration::from_secs(1));
+        assert_eq!(rate_limit_remaining_secs(), None);
+
+        // No window set → None.
+        *RATE_LIMIT_UNTIL.lock().unwrap() = None;
+        assert_eq!(rate_limit_remaining_secs(), None);
     }
 }

--- a/src/components/UsageAlertBar.tsx
+++ b/src/components/UsageAlertBar.tsx
@@ -226,13 +226,19 @@ function RefreshButton({
 function ProviderHeader({
   label,
   stale,
+  rateLimitRemaining,
   refreshButton,
 }: {
   label: string;
   stale?: boolean;
+  rateLimitRemaining?: number | null;
   refreshButton?: ReactNode;
 }) {
   const t = useI18n();
+  // When inside a 429 back-off window, refresh genuinely can't hit the API yet.
+  // Say so explicitly instead of leaving the bare "stale" badge, which makes the
+  // refresh button look broken.
+  const throttled = rateLimitRemaining != null && rateLimitRemaining > 0;
 
   return (
     <div style={{
@@ -249,7 +255,18 @@ function ProviderHeader({
         {label}
       </span>
       <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-        {stale && (
+        {throttled ? (
+          <span
+            title={t("usageAlert.rateLimitedTooltip")}
+            style={{
+              fontSize: 9,
+              fontWeight: 600,
+              color: "var(--text-muted)",
+            }}
+          >
+            {t("usageAlert.rateLimited", { seconds: Math.ceil(rateLimitRemaining!) })}
+          </span>
+        ) : stale && (
           <span style={{
             fontSize: 9,
             fontWeight: 600,
@@ -410,7 +427,7 @@ function ClaudeTrackingPrompt({
 
 export function UsageAlertBar() {
   const { prefs, refreshPrefs } = useSettings();
-  const { usage, status: oauthStatus, refreshing, refresh } = useOAuthUsage();
+  const { usage, status: oauthStatus, refreshing, rateLimitRemaining, refresh } = useOAuthUsage();
   const { stats: codexStats } = useTokenStats("codex");
   const todayStr = useToday();
   const t = useI18n();
@@ -575,6 +592,7 @@ export function UsageAlertBar() {
           <ProviderHeader
             label={t("usageAlert.claude")}
             stale={is_stale}
+            rateLimitRemaining={rateLimitRemaining}
             refreshButton={(
               <RefreshButton
                 refreshing={refreshing}

--- a/src/hooks/useOAuthUsage.ts
+++ b/src/hooks/useOAuthUsage.ts
@@ -8,18 +8,23 @@ export function useOAuthUsage() {
   const [status, setStatus] = useState<OAuthUsageStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+  // Seconds remaining in a 429 back-off window, or null when refresh is
+  // unthrottled. Surfaced so the badge can explain an inert refresh button.
+  const [rateLimitRemaining, setRateLimitRemaining] = useState<number | null>(null);
   const requestIdRef = useRef(0);
 
   const fetchUsage = useCallback(async () => {
     const requestId = ++requestIdRef.current;
     try {
-      const [data, nextStatus] = await Promise.all([
+      const [data, nextStatus, rateLimit] = await Promise.all([
         invoke<OAuthUsage | null>("get_oauth_usage"),
         invoke<OAuthUsageStatus>("get_oauth_usage_status").catch(() => null),
+        invoke<number | null>("get_oauth_rate_limit_remaining").catch(() => null),
       ]);
       if (requestId === requestIdRef.current) {
         setUsage(data);
         if (nextStatus) setStatus(nextStatus);
+        setRateLimitRemaining(rateLimit ?? null);
       }
     } catch {
       // Ignore errors silently
@@ -39,11 +44,13 @@ export function useOAuthUsage() {
       // report "unavailable" even on a successful refresh.
       const data = await invoke<OAuthUsage | null>("refresh_oauth_usage");
       const nextStatus = await invoke<OAuthUsageStatus>("get_oauth_usage_status").catch(() => null);
+      const rateLimit = await invoke<number | null>("get_oauth_rate_limit_remaining").catch(() => null);
       // Only adopt the result if no newer request has started; otherwise keep
       // the more recent data. The spinner state is reset unconditionally below.
       if (requestId === requestIdRef.current) {
         setUsage(data);
         if (nextStatus) setStatus(nextStatus);
+        setRateLimitRemaining(rateLimit ?? null);
       }
     } catch {
       // Ignore errors silently
@@ -69,5 +76,5 @@ export function useOAuthUsage() {
     };
   }, [fetchUsage]);
 
-  return { usage, status, loading, refreshing, refresh };
+  return { usage, status, loading, refreshing, rateLimitRemaining, refresh };
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -214,6 +214,8 @@
   "usageAlert.last7Days": "Letzte 7 Tage",
   "usageAlert.extraUsage": "Zusätzliche Nutzung",
   "usageAlert.stale": "Veraltete Daten",
+  "usageAlert.rateLimited": "Neuer Versuch in {{seconds}}s",
+  "usageAlert.rateLimitedTooltip": "Zu viele Anfragen — automatischer Wiederholungsversuch in Kürze. Die Daten werden automatisch aktualisiert.",
   "usageAlert.resetsIn": "Zurücksetzen in {{time}}",
   "usageAlert.resetsNow": "Wird zurückgesetzt...",
   "usageAlert.refresh": "Aktualisieren",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -220,6 +220,8 @@
   "usageAlert.last7Days": "Last 7 days",
   "usageAlert.extraUsage": "Extra Usage",
   "usageAlert.stale": "Stale data",
+  "usageAlert.rateLimited": "Retrying in {{seconds}}s",
+  "usageAlert.rateLimitedTooltip": "Too many requests — auto-retrying shortly. Data will update automatically.",
   "usageAlert.resetsIn": "Resets in {{time}}",
   "usageAlert.resetsNow": "Resetting...",
   "usageAlert.refresh": "Refresh",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -214,6 +214,8 @@
   "usageAlert.last7Days": "Últimos 7 días",
   "usageAlert.extraUsage": "Uso adicional",
   "usageAlert.stale": "Datos obsoletos",
+  "usageAlert.rateLimited": "Reintentando en {{seconds}}s",
+  "usageAlert.rateLimitedTooltip": "Demasiadas solicitudes: se reintentará automáticamente en breve. Los datos se actualizarán solos.",
   "usageAlert.resetsIn": "Se reinicia en {{time}}",
   "usageAlert.resetsNow": "Reiniciando...",
   "usageAlert.refresh": "Actualizar",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -214,6 +214,8 @@
   "usageAlert.last7Days": "7 derniers jours",
   "usageAlert.extraUsage": "Utilisation supplémentaire",
   "usageAlert.stale": "Données obsolètes",
+  "usageAlert.rateLimited": "Nouvelle tentative dans {{seconds}}s",
+  "usageAlert.rateLimitedTooltip": "Trop de requêtes — nouvelle tentative automatique sous peu. Les données se mettront à jour automatiquement.",
   "usageAlert.resetsIn": "Réinitialisation dans {{time}}",
   "usageAlert.resetsNow": "Réinitialisation...",
   "usageAlert.refresh": "Actualiser",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -214,6 +214,8 @@
   "usageAlert.last7Days": "Ultimi 7 giorni",
   "usageAlert.extraUsage": "Utilizzo extra",
   "usageAlert.stale": "Dati non aggiornati",
+  "usageAlert.rateLimited": "Nuovo tentativo tra {{seconds}}s",
+  "usageAlert.rateLimitedTooltip": "Troppe richieste — nuovo tentativo automatico a breve. I dati si aggiorneranno automaticamente.",
   "usageAlert.resetsIn": "Reset tra {{time}}",
   "usageAlert.resetsNow": "Reset in corso...",
   "usageAlert.refresh": "Aggiorna",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -214,6 +214,8 @@
   "usageAlert.last7Days": "直近7日",
   "usageAlert.extraUsage": "追加使用量",
   "usageAlert.stale": "古いデータ",
+  "usageAlert.rateLimited": "{{seconds}}秒後に再試行",
+  "usageAlert.rateLimitedTooltip": "リクエストが多いため、まもなく自動で再試行します。データは自動的に更新されます。",
   "usageAlert.resetsIn": "{{time}}後にリセット",
   "usageAlert.resetsNow": "リセット中...",
   "usageAlert.refresh": "更新",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -220,6 +220,8 @@
   "usageAlert.last7Days": "최근 7일",
   "usageAlert.extraUsage": "추가 사용량",
   "usageAlert.stale": "오래된 데이터",
+  "usageAlert.rateLimited": "{{seconds}}초 후 재시도",
+  "usageAlert.rateLimitedTooltip": "요청이 많아 잠시 후 자동으로 다시 시도합니다. 데이터가 곧 갱신됩니다.",
   "usageAlert.resetsIn": "{{time}} 후 리셋",
   "usageAlert.resetsNow": "리셋 중...",
   "usageAlert.refresh": "새로고침",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -214,6 +214,8 @@
   "usageAlert.last7Days": "Son 7 gün",
   "usageAlert.extraUsage": "Ek Kullanım",
   "usageAlert.stale": "Eski veri",
+  "usageAlert.rateLimited": "{{seconds}} sn sonra yeniden",
+  "usageAlert.rateLimitedTooltip": "Çok fazla istek — kısa süre içinde otomatik olarak yeniden denenecek. Veriler otomatik güncellenecek.",
   "usageAlert.resetsIn": "{{time}} içinde sıfırlanıyor",
   "usageAlert.resetsNow": "Sıfırlanıyor...",
   "usageAlert.refresh": "Yenile",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -214,6 +214,8 @@
   "usageAlert.last7Days": "最近 7 天",
   "usageAlert.extraUsage": "额外用量",
   "usageAlert.stale": "旧数据",
+  "usageAlert.rateLimited": "{{seconds}}秒后重试",
+  "usageAlert.rateLimitedTooltip": "请求过多，稍后将自动重试。数据会自动更新。",
   "usageAlert.resetsIn": "{{time}}后重置",
   "usageAlert.resetsNow": "重置中...",
   "usageAlert.refresh": "刷新",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -214,6 +214,8 @@
   "usageAlert.last7Days": "最近 7 天",
   "usageAlert.extraUsage": "額外用量",
   "usageAlert.stale": "舊資料",
+  "usageAlert.rateLimited": "{{seconds}}秒後重試",
+  "usageAlert.rateLimitedTooltip": "請求過多，稍後將自動重試。資料會自動更新。",
   "usageAlert.resetsIn": "{{time}}後重置",
   "usageAlert.resetsNow": "重置中...",
   "usageAlert.refresh": "重新整理",


### PR DESCRIPTION
## 문제

Claude 사용량 패널이 "오래된 데이터" 배지를 띄운 채, 새로고침 버튼을 눌러도 아무 반응이 없는 먹통 상태가 되는 경우가 있었습니다.

## 원인

- API가 429를 반환하면 `RATE_LIMIT_UNTIL` back-off 창이 설정되는데, `retry-after` 헤더가 없으면 **기본 5분**이 걸림.
- 그 창 동안 폴링·수동 새로고침 모두 API를 호출하지 않고 캐시를 그대로 반환하며 `fetched_at`을 갱신하지 않음 → 10분 초과 시 stale 배지.
- 수동 새로고침 시 데이터는 안 바뀌었는데 `usage-updated`를 emit → UI가 같은 화면을 다시 그려 **버튼이 먹통처럼 보임**.
- 프론트엔드에 rate-limit 안내가 전혀 없어 사용자가 이유를 알 수 없었음.

## 수정

**Backend**
- 429 기본 retry-after `300s → 60s`
- stale 임계값 `10min → 15min` (5분 폴링 주기와 여유 확보)
- rate-limit 창 안에서는 `refresh_oauth_usage`가 `usage-updated`를 emit하지 않음
- `get_oauth_rate_limit_remaining` 커맨드 + `rate_limit_remaining_secs()` 헬퍼 신설

**Frontend**
- rate-limit 창일 때 "오래된 데이터" 대신 **"N초 후 재시도"** 배지 + 툴팁 표시 (10개 로케일)

## 검증

- `cargo test --lib oauth_usage` — 10 passed (rate_limit 신규 테스트 포함)
- `npx tsc --noEmit` / `npm run build` 성공
- `cargo check` 성공 (신규 경고 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)