### PR TITLE
fix(profile): allow adding links when metadata fetch is blocked

### DIFF
--- a/src-tauri/src/url_metadata.rs
+++ b/src-tauri/src/url_metadata.rs
@@ -10,7 +10,7 @@ fn client() -> &'static Client {
     HTTP_CLIENT.get_or_init(|| {
         Client::builder()
             .timeout(Duration::from_secs(8))
-            .user_agent("Mozilla/5.0 (compatible; AITokenMonitor/1.0)")
+            .user_agent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
             .redirect(reqwest::redirect::Policy::limited(5))
             .build()
             .unwrap_or_default()
@@ -49,21 +49,24 @@ pub async fn fetch_url_metadata(url: String) -> Result<UrlMetadata, String> {
         return Err("Only HTTP/HTTPS URLs are supported".to_string());
     }
 
-    let response = client()
-        .get(&url)
-        .send()
-        .await
-        .map_err(|e| format!("Failed to fetch URL: {}", e))?;
+    // Metadata is decorative — never let a blocked or failing fetch prevent
+    // adding a valid link (e.g. LinkedIn returns 999/403 to non-browser clients).
+    let fallback = || UrlMetadata {
+        url: url.clone(),
+        title: None,
+        favicon_url: extract_origin(&url).map(|origin| format!("{}/favicon.ico", origin)),
+    };
 
-    if !response.status().is_success() {
-        return Err(format!("HTTP {}", response.status()));
-    }
+    let response = match client().get(&url).send().await {
+        Ok(resp) if resp.status().is_success() => resp,
+        _ => return Ok(fallback()),
+    };
 
     let final_url = response.url().to_string();
-    let body = response
-        .text()
-        .await
-        .map_err(|e| format!("Failed to read response: {}", e))?;
+    let body = match response.text().await {
+        Ok(body) => body,
+        Err(_) => return Ok(fallback()),
+    };
 
     let document = Html::parse_document(&body);
 


### PR DESCRIPTION
## Summary
Fixes a user report: LinkedIn URLs could not be added as profile links.

- `fetch_url_metadata` failed hard on any non-2xx response or request error, and the frontend treats that as "cannot add link" — LinkedIn blocks non-browser clients (HTTP 999/403/authwall), so such links were impossible to add
- Metadata is decorative, so it is now best-effort: on fetch failure the command returns the original URL with `title: None` (UI already falls back to hostname) and an `origin/favicon.ico` favicon
- User-Agent switched from `Mozilla/5.0 (compatible; AITokenMonitor/1.0)` to a real browser string to improve title extraction success overall
- Hard errors remain only for genuinely invalid URLs (parse failure / non-HTTP scheme), preserving the bad-input UX

## Verification
- `cargo check` clean, all 97 existing Rust tests pass
- Frontend fallbacks confirmed: hostname display title (`MiniProfile.tsx`), favicon error state

🤖 Generated with [Claude Code](https://claude.com/claude-code)