### PR TITLE
perf: byte-offset incremental JSONL parsing + leaderboard keep-mounted + badge rank fix

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -439,10 +439,13 @@ fn start_file_watcher(app_handle: tauri::AppHandle) {
             }
         }
 
-        // Adaptive debounce: escalate during burst activity
+        // Adaptive debounce: escalate during burst activity. Long-running agent
+        // sessions append to their JSONL every few seconds, so a short burst window
+        // just re-parses the same hot files over and over — 30s keeps the tray at
+        // most half a minute stale while cutting parse cycles by 3x.
         let mut recent_triggers: Vec<std::time::Instant> = Vec::new();
         let base_debounce = std::time::Duration::from_secs(2);
-        let burst_debounce = std::time::Duration::from_secs(10);
+        let burst_debounce = std::time::Duration::from_secs(30);
 
         loop {
             match rx.recv_timeout(std::time::Duration::from_secs(60)) {
@@ -477,9 +480,10 @@ fn start_file_watcher(app_handle: tauri::AppHandle) {
                     providers::kimi::invalidate_stats_cache();
                     providers::glm::invalidate_stats_cache();
                     providers::gjc::invalidate_stats_cache();
-                    let _ = app_handle.emit("stats-updated", ());
-                    // Re-parse in background so the tray reflects new data even when the
-                    // popup is closed (get_all_stats is only called by the frontend).
+                    // Re-parse in background, then notify the frontend. Emitting only
+                    // after the parse completes means the frontend's get_*_stats calls
+                    // hit the warm cache instead of racing this thread and parsing the
+                    // same files a second time.
                     let app_for_refresh = app_handle.clone();
                     thread::spawn(move || {
                         let prefs = commands::get_preferences();
@@ -501,6 +505,7 @@ fn start_file_watcher(app_handle: tauri::AppHandle) {
                             let _ = providers::gjc::GjcProvider::new(prefs.gjc_dirs.clone()).fetch_stats();
                         }
                         update_tray_title(&app_for_refresh);
+                        let _ = app_for_refresh.emit("stats-updated", ());
                     });
                 }
                 Err(mpsc::RecvTimeoutError::Timeout) => {

--- a/src-tauri/src/providers/claude_code.rs
+++ b/src-tauri/src/providers/claude_code.rs
@@ -13,14 +13,42 @@ use serde::{Deserialize, Serialize};
 use super::traits::TokenProvider;
 use super::types::{ActivityCategory, AllStats, AnalyticsData, DailyUsage, McpServerUsage, ModelUsage, ProjectUsage, ToolCount};
 
-/// Unified incremental cache: stats + per-file metadata for mtime-based change detection.
+/// Per-file parse state: identity metadata plus how far the file has been parsed.
+/// `parsed_offset` is the byte position just past the last complete line consumed,
+/// so append-only JSONL growth can resume from there instead of re-reading the file.
+#[derive(Clone, PartialEq)]
+struct FileParseState {
+    mtime: SystemTime,
+    size: u64,
+    parsed_offset: u64,
+}
+
+impl FileParseState {
+    fn matches(&self, mtime: SystemTime, size: u64) -> bool {
+        self.mtime == mtime && self.size == size
+    }
+}
+
+/// Unified incremental cache: stats + per-file parse state for change detection.
 struct IncrementalCache {
     stats: AllStats,
     computed_at: Instant,
     /// All parsed entries keyed by dedup key (message_id:request_id)
     entries: HashMap<String, SessionEntry>,
-    /// File metadata for change detection: path → (modified_time, size)
-    file_meta: HashMap<PathBuf, (SystemTime, u64)>,
+    /// Parse state per file: path → (mtime, size, parsed byte offset)
+    file_states: HashMap<PathBuf, FileParseState>,
+}
+
+/// True when every current file is present in the cached states with identical
+/// (mtime, size) — i.e. nothing changed since the last parse.
+fn file_states_match(
+    states: &HashMap<PathBuf, FileParseState>,
+    current: &HashMap<PathBuf, (SystemTime, u64)>,
+) -> bool {
+    states.len() == current.len()
+        && current.iter().all(|(path, (mtime, size))| {
+            states.get(path).map_or(false, |st| st.matches(*mtime, *size))
+        })
 }
 
 static STATS_CACHE: Mutex<Option<IncrementalCache>> = Mutex::new(None);
@@ -179,61 +207,159 @@ impl ClaudeCodeProvider {
         meta
     }
 
-    /// Parse a single JSONL file and return its entries keyed by dedup key.
-    fn parse_single_file(path: &PathBuf) -> HashMap<String, SessionEntry> {
+    /// Parse a JSONL file starting at byte `start_offset`, returning its entries keyed by
+    /// dedup key plus the byte offset just past the last complete line consumed.
+    ///
+    /// A trailing line without a newline (a writer mid-flush) is left unconsumed so the
+    /// next parse re-reads it once the writer completes it. Active session files only
+    /// ever grow, so resuming from the previous offset skips the (potentially hundreds
+    /// of MB) already-parsed prefix.
+    ///
+    /// Returns None when the file can't be opened/seeked — callers must NOT record a
+    /// parse state in that case, so the next cycle retries instead of treating the
+    /// file as consumed.
+    fn parse_file_from(path: &PathBuf, start_offset: u64) -> Option<(HashMap<String, SessionEntry>, u64)> {
+        use std::io::{Seek, SeekFrom};
+
         let mut entries = HashMap::new();
-        if let Ok(file) = fs::File::open(path) {
-            let reader = BufReader::with_capacity(64 * 1024, file);
-            for line in reader.lines().map_while(Result::ok) {
-                if let Some(entry) = parse_session_line(&line) {
-                    let key = format!("{}:{}", entry.message_id, entry.request_id);
-                    entries.insert(key, entry);
+        let mut offset = start_offset;
+        let mut file = fs::File::open(path).ok()?;
+        if start_offset > 0 {
+            file.seek(SeekFrom::Start(start_offset)).ok()?;
+        }
+        let mut reader = BufReader::with_capacity(64 * 1024, file);
+        let mut buf: Vec<u8> = Vec::with_capacity(8 * 1024);
+        loop {
+            buf.clear();
+            match reader.read_until(b'\n', &mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if buf.last() != Some(&b'\n') {
+                        // Partial trailing line — leave it for the next parse.
+                        break;
+                    }
+                    offset += n as u64;
+                    if let Ok(line) = std::str::from_utf8(&buf) {
+                        if let Some(entry) = parse_session_line(line) {
+                            let key = format!("{}:{}", entry.message_id, entry.request_id);
+                            entries.insert(key, entry);
+                        }
+                    }
                 }
+                Err(_) => break,
             }
         }
-        entries
+        Some((entries, offset))
+    }
+
+    /// Parse an entire JSONL file (offset 0), returning entries and its parse state.
+    /// None when the file is unreadable — the caller skips recording a state so the
+    /// next cycle retries.
+    fn parse_full_file(path: &PathBuf, mtime: SystemTime, size: u64) -> Option<(HashMap<String, SessionEntry>, FileParseState)> {
+        let (entries, parsed_offset) = Self::parse_file_from(path, 0)?;
+        Some((entries, FileParseState { mtime, size, parsed_offset }))
+    }
+
+    /// Byte offset just past the last newline in the file — the safe resume point for
+    /// a file whose content we skip parsing. JSONL files virtually always end with a
+    /// newline, so this is a single 1-byte read; a file that ends mid-line (writer
+    /// crashed without a trailing flush) is scanned backwards until the last newline,
+    /// so the incomplete line is re-read if the file is ever appended to again.
+    fn last_complete_line_offset(path: &PathBuf, size: u64) -> u64 {
+        use std::io::{Read, Seek, SeekFrom};
+
+        if size == 0 {
+            return 0;
+        }
+        let Ok(mut file) = fs::File::open(path) else {
+            return 0;
+        };
+
+        // Fast path: check only the final byte.
+        let mut last = [0u8; 1];
+        if file.seek(SeekFrom::Start(size - 1)).is_err() || file.read_exact(&mut last).is_err() {
+            return 0;
+        }
+        if last[0] == b'\n' {
+            return size;
+        }
+
+        // Rare path: scan backwards in chunks for the last newline.
+        const CHUNK: u64 = 64 * 1024;
+        let mut end = size;
+        let mut buf = vec![0u8; CHUNK as usize];
+        while end > 0 {
+            let start = end.saturating_sub(CHUNK);
+            let len = (end - start) as usize;
+            if file.seek(SeekFrom::Start(start)).is_err()
+                || file.read_exact(&mut buf[..len]).is_err()
+            {
+                return 0;
+            }
+            if let Some(pos) = buf[..len].iter().rposition(|&b| b == b'\n') {
+                return start + pos as u64 + 1;
+            }
+            end = start;
+        }
+        0
     }
 
     /// Incrementally parse only changed files, reusing cached entries for unchanged files.
+    /// Appended-to files resume from their previous byte offset; shrunk or rewritten
+    /// files are re-parsed from the start.
     fn parse_incremental(
         current_meta: &HashMap<PathBuf, (SystemTime, u64)>,
         cached_entries: &HashMap<String, SessionEntry>,
-        cached_meta: &HashMap<PathBuf, (SystemTime, u64)>,
-    ) -> HashMap<String, SessionEntry> {
-        let mut entries = cached_entries.clone();
-
-        let mut changed_files: Vec<&PathBuf> = Vec::new();
-        for (path, (mtime, size)) in current_meta {
-            match cached_meta.get(path) {
-                Some((cached_mtime, cached_size)) if cached_mtime == mtime && cached_size == size => {}
-                _ => { changed_files.push(path); }
-            }
-        }
-
+        cached_states: &HashMap<PathBuf, FileParseState>,
+    ) -> (HashMap<String, SessionEntry>, HashMap<PathBuf, FileParseState>) {
         // If files were deleted, do a full re-parse (can't selectively remove entries per file)
-        let has_deleted = cached_meta.keys().any(|p| !current_meta.contains_key(p));
+        let has_deleted = cached_states.keys().any(|p| !current_meta.contains_key(p));
         if has_deleted {
             let mut fresh = HashMap::new();
-            for path in current_meta.keys() {
-                fresh.extend(Self::parse_single_file(path));
+            let mut states = HashMap::new();
+            for (path, (mtime, size)) in current_meta {
+                let Some((file_entries, state)) = Self::parse_full_file(path, *mtime, *size) else {
+                    continue; // unreadable — no state recorded, retried next cycle
+                };
+                fresh.extend(file_entries);
+                states.insert(path.clone(), state);
             }
-            return fresh;
+            return (fresh, states);
         }
 
-        let changed_count = changed_files.len();
+        let mut entries = cached_entries.clone();
+        let mut states: HashMap<PathBuf, FileParseState> = HashMap::new();
+        let mut changed_count = 0usize;
+        let start = Instant::now();
+
+        for (path, (mtime, size)) in current_meta {
+            let resume_offset = match cached_states.get(path) {
+                Some(st) if st.matches(*mtime, *size) => {
+                    // Unchanged — keep the cached state as-is.
+                    states.insert(path.clone(), st.clone());
+                    continue;
+                }
+                // Grew (append-only session log): resume after the last complete line.
+                Some(st) if *size > st.size => st.parsed_offset,
+                // Shrunk or same-size rewrite: start over.
+                _ => 0,
+            };
+            let Some((file_entries, parsed_offset)) = Self::parse_file_from(path, resume_offset) else {
+                continue; // unreadable — no state recorded, retried next cycle
+            };
+            entries.extend(file_entries);
+            states.insert(path.clone(), FileParseState { mtime: *mtime, size: *size, parsed_offset });
+            changed_count += 1;
+        }
+
         if changed_count > 0 {
-            let start = Instant::now();
-            for path in &changed_files {
-                let file_entries = Self::parse_single_file(path);
-                entries.extend(file_entries);
-            }
             eprintln!(
                 "[PERF] Incremental parse: {} changed files in {:?} (total {} files)",
                 changed_count, start.elapsed(), current_meta.len()
             );
         }
 
-        entries
+        (entries, states)
     }
 
     /// Build AllStats from parsed entries, merging with disk cache for historical months.
@@ -799,9 +925,9 @@ impl ClaudeCodeProvider {
         let current_meta = self.collect_file_meta();
 
         // Check if any files actually changed since last computation
-        let entries = if let Ok(cache) = STATS_CACHE.lock() {
+        let (entries, file_states) = if let Ok(cache) = STATS_CACHE.lock() {
             if let Some(ref cached) = *cache {
-                if cached.file_meta == current_meta {
+                if file_states_match(&cached.file_states, &current_meta) {
                     // No files changed — refresh timestamp and return cached stats
                     drop(cache);
                     if let Ok(mut cache) = STATS_CACHE.lock() {
@@ -819,7 +945,7 @@ impl ClaudeCodeProvider {
                 }
 
                 // Incremental parse — only changed files
-                Self::parse_incremental(&current_meta, &cached.entries, &cached.file_meta)
+                Self::parse_incremental(&current_meta, &cached.entries, &cached.file_states)
             } else {
                 // First run — full parse
                 drop(cache);
@@ -840,24 +966,39 @@ impl ClaudeCodeProvider {
                 let prev_month = prev_month_str();
                 let only_current = has_historical && disk_cache.months.contains_key(&prev_month);
 
+                let mut file_states: HashMap<PathBuf, FileParseState> = HashMap::new();
+
                 if only_current {
                     // Fast path: disk cache is complete — only parse current-month files
-                    for (path, (_, _)) in &current_meta {
-                        if let Ok(metadata) = fs::metadata(path) {
-                            if let Ok(modified) = metadata.modified() {
-                                let modified_date: chrono::DateTime<chrono::Local> = modified.into();
-                                let file_month = modified_date.format("%Y-%m").to_string();
-                                if file_month < current_month {
-                                    continue;
-                                }
-                            }
+                    for (path, (mtime, size)) in &current_meta {
+                        let modified_date: chrono::DateTime<chrono::Local> = (*mtime).into();
+                        let file_month = modified_date.format("%Y-%m").to_string();
+                        if file_month < current_month {
+                            // Historical file covered by the disk cache — record where its
+                            // complete lines end (not the raw size: a file that stopped on
+                            // a partial line must not have that line skipped if it is ever
+                            // appended to again).
+                            let parsed_offset = Self::last_complete_line_offset(path, *size);
+                            file_states.insert(
+                                path.clone(),
+                                FileParseState { mtime: *mtime, size: *size, parsed_offset },
+                            );
+                            continue;
                         }
-                        entries.extend(Self::parse_single_file(path));
+                        let Some((file_entries, state)) = Self::parse_full_file(path, *mtime, *size) else {
+                            continue; // unreadable — no state recorded, retried next cycle
+                        };
+                        entries.extend(file_entries);
+                        file_states.insert(path.clone(), state);
                     }
                 } else {
                     // Full parse: either no cache yet, or the cache is missing some months
-                    for path in current_meta.keys() {
-                        entries.extend(Self::parse_single_file(path));
+                    for (path, (mtime, size)) in &current_meta {
+                        let Some((file_entries, state)) = Self::parse_full_file(path, *mtime, *size) else {
+                            continue; // unreadable — no state recorded, retried next cycle
+                        };
+                        entries.extend(file_entries);
+                        file_states.insert(path.clone(), state);
                     }
 
                     // Split off historical entries, persist any months missing from cache
@@ -891,7 +1032,7 @@ impl ClaudeCodeProvider {
                 }
 
                 eprintln!("[PERF] Full parse completed in {:?}", full_start.elapsed());
-                entries
+                (entries, file_states)
             }
         } else {
             return Err("Failed to acquire cache lock".to_string());
@@ -899,13 +1040,13 @@ impl ClaudeCodeProvider {
 
         let stats = self.build_stats(&entries);
 
-        // Update cache with entries + file metadata
+        // Update cache with entries + per-file parse state
         if let Ok(mut cache) = STATS_CACHE.lock() {
             *cache = Some(IncrementalCache {
                 stats: stats.clone(),
                 computed_at: Instant::now(),
                 entries,
-                file_meta: current_meta,
+                file_states,
             });
         }
 
@@ -1091,5 +1232,93 @@ mod tests {
         assert_eq!(entry.cwd, "/home/user/project");
         assert_eq!(entry.tool_names, vec!["Read", "Bash"]);
         assert_eq!(entry.bash_commands, vec!["git", "npm"]);
+    }
+
+    fn temp_jsonl(name: &str, content: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "atm-offset-test-{}-{}.jsonl",
+            std::process::id(),
+            name
+        ));
+        fs::write(&path, content).expect("write temp jsonl");
+        path
+    }
+
+    #[test]
+    fn parse_file_from_consumes_complete_lines_and_reports_offset() {
+        let content = format!("{}\n{}\n", sample_jsonl_line(), sample_jsonl_line_with_cache_ttl());
+        let path = temp_jsonl("complete", &content);
+
+        let (entries, offset) = ClaudeCodeProvider::parse_file_from(&path, 0).expect("parse");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(offset, content.len() as u64);
+
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn parse_file_from_leaves_partial_trailing_line_unconsumed() {
+        let complete = format!("{}\n", sample_jsonl_line());
+        let partial = &sample_jsonl_line_with_cache_ttl()[..40]; // no trailing newline
+        let path = temp_jsonl("partial", &format!("{}{}", complete, partial));
+
+        let (entries, offset) = ClaudeCodeProvider::parse_file_from(&path, 0).expect("parse");
+        assert_eq!(entries.len(), 1, "partial line must not produce an entry");
+        assert_eq!(offset, complete.len() as u64, "offset must stop before the partial line");
+
+        // Writer completes the partial line — resuming from the offset picks it up.
+        let full = format!("{}{}\n", complete, sample_jsonl_line_with_cache_ttl());
+        fs::write(&path, &full).expect("rewrite temp jsonl");
+        let (tail_entries, new_offset) = ClaudeCodeProvider::parse_file_from(&path, offset).expect("parse");
+        assert_eq!(tail_entries.len(), 1);
+        assert!(tail_entries.contains_key("msg-2:req-2"));
+        assert_eq!(new_offset, full.len() as u64);
+
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn last_complete_line_offset_handles_trailing_states() {
+        // Ends with newline → full size.
+        let complete = format!("{}\n", sample_jsonl_line());
+        let path = temp_jsonl("llo-complete", &complete);
+        assert_eq!(
+            ClaudeCodeProvider::last_complete_line_offset(&path, complete.len() as u64),
+            complete.len() as u64
+        );
+        let _ = fs::remove_file(&path);
+
+        // Ends mid-line → offset after the last newline.
+        let partial = format!("{}\n{{\"trunc", sample_jsonl_line());
+        let path = temp_jsonl("llo-partial", &partial);
+        assert_eq!(
+            ClaudeCodeProvider::last_complete_line_offset(&path, partial.len() as u64),
+            (sample_jsonl_line().len() + 1) as u64
+        );
+        let _ = fs::remove_file(&path);
+
+        // No newline at all → 0.
+        let path = temp_jsonl("llo-none", "{\"no-newline");
+        assert_eq!(ClaudeCodeProvider::last_complete_line_offset(&path, 12), 0);
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn parse_file_from_resumes_after_append_without_rereading_prefix() {
+        let first = format!("{}\n", sample_jsonl_line());
+        let path = temp_jsonl("append", &first);
+
+        let (entries, offset) = ClaudeCodeProvider::parse_file_from(&path, 0).expect("parse");
+        assert_eq!(entries.len(), 1);
+
+        // Append a second line and resume from the previous offset.
+        let appended = format!("{}{}\n", first, sample_jsonl_line_with_web_search());
+        fs::write(&path, &appended).expect("append temp jsonl");
+        let (tail_entries, new_offset) = ClaudeCodeProvider::parse_file_from(&path, offset).expect("parse");
+        assert_eq!(tail_entries.len(), 1, "only the appended line should be parsed");
+        assert!(tail_entries.contains_key("msg-3:req-3"));
+        assert_eq!(new_offset, appended.len() as u64);
+
+        let _ = fs::remove_file(&path);
     }
 }

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -21,13 +21,72 @@ fn expand_tilde(path: &str) -> PathBuf {
 
 // --- Cache infrastructure (mirrors claude_code.rs patterns) ---
 
+/// Bytes of pre-resume-point content kept to detect in-place rewrites. Codex entry
+/// keys are position-based (`path\nline_index`), so resuming mid-file after a rewrite
+/// would silently misnumber lines — the fingerprint downgrades that case to a full
+/// re-parse.
+const TAIL_FINGERPRINT_LEN: usize = 16;
+
+/// Per-file parse state: identity metadata, byte-offset resume point, and the
+/// in-file parser state (line counter, session id, active model, last snapshot)
+/// needed to continue an append-only rollout file mid-stream.
+#[derive(Clone, PartialEq)]
+struct FileParseState {
+    mtime: SystemTime,
+    size: u64,
+    /// Byte offset just past the last complete line consumed.
+    parsed_offset: u64,
+    /// Number of complete lines consumed so far (continues the position-based keys).
+    lines_consumed: u32,
+    session_id: String,
+    current_model: String,
+    prev_snapshot: Option<(u64, u64, u64, u64)>,
+    /// Up to TAIL_FINGERPRINT_LEN bytes immediately before `parsed_offset`.
+    tail_fingerprint: Vec<u8>,
+}
+
+impl FileParseState {
+    fn fresh(path: &Path) -> Self {
+        Self {
+            mtime: SystemTime::UNIX_EPOCH,
+            size: 0,
+            parsed_offset: 0,
+            lines_consumed: 0,
+            session_id: path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("codex-session")
+                .to_string(),
+            current_model: String::new(),
+            prev_snapshot: None,
+            tail_fingerprint: Vec::new(),
+        }
+    }
+
+    fn matches(&self, mtime: SystemTime, size: u64) -> bool {
+        self.mtime == mtime && self.size == size
+    }
+}
+
+/// True when every current file is present in the cached states with identical
+/// (mtime, size) — i.e. nothing changed since the last parse.
+fn file_states_match(
+    states: &HashMap<PathBuf, FileParseState>,
+    current: &HashMap<PathBuf, (SystemTime, u64)>,
+) -> bool {
+    states.len() == current.len()
+        && current.iter().all(|(path, (mtime, size))| {
+            states.get(path).map_or(false, |st| st.matches(*mtime, *size))
+        })
+}
+
 struct IncrementalCache {
     stats: AllStats,
     computed_at: Instant,
-    /// Per-file parsed entries keyed by dedup key (session_id:line_index)
+    /// Per-file parsed entries keyed by dedup key (`path\nline_index`)
     entries: HashMap<String, CodexEntry>,
-    /// File metadata for mtime-based change detection
-    file_meta: HashMap<PathBuf, (SystemTime, u64)>,
+    /// Parse state per file for change detection and append-resume
+    file_states: HashMap<PathBuf, FileParseState>,
 }
 
 static STATS_CACHE: Mutex<Option<IncrementalCache>> = Mutex::new(None);
@@ -250,164 +309,234 @@ impl CodexProvider {
         meta
     }
 
-    /// Parse a single JSONL file and return entries keyed by dedup key.
-    fn parse_single_file(path: &Path) -> HashMap<String, CodexEntry> {
-        let mut entries = HashMap::new();
-        let Ok(file) = fs::File::open(path) else {
-            return entries;
+    /// Parse a JSONL rollout file, resuming from `prior` parse state when given
+    /// (append-only growth), or from the start otherwise. Returns the parsed entries
+    /// and the updated state. A trailing line without a newline (writer mid-flush) is
+    /// left unconsumed so the next parse re-reads it once complete.
+    ///
+    /// The parser is stateful across a file (session_meta id, active model from
+    /// turn_context, previous token_count snapshot), so all of that lives in
+    /// FileParseState and carries over between resumes.
+    fn parse_file_from(
+        path: &Path,
+        prior: Option<&FileParseState>,
+        mtime: SystemTime,
+        size: u64,
+    ) -> (HashMap<String, CodexEntry>, FileParseState) {
+        use std::io::{Seek, SeekFrom};
+
+        let mut state = match prior {
+            Some(st) => st.clone(),
+            None => FileParseState::fresh(path),
         };
+
+        // On open/seek failure, return the state with its PRIOR (mtime, size) so the
+        // next cycle sees a mismatch and retries — recording the new identity here
+        // would make the unparsed bytes look "already consumed" forever.
+        let mut entries = HashMap::new();
+        let Ok(mut file) = fs::File::open(path) else {
+            return (entries, state);
+        };
+        if state.parsed_offset > 0 && file.seek(SeekFrom::Start(state.parsed_offset)).is_err() {
+            return (entries, state);
+        }
+        state.mtime = mtime;
+        state.size = size;
 
         // Keep the path date as a fallback only. A single session file can span midnight,
         // so per-event timestamps are more accurate for "today" stats.
         let path_date = extract_date_from_path(path);
 
-        let mut session_id = path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("codex-session")
-            .to_string();
-        let mut current_model = String::new();
-        let mut line_index: u32 = 0;
-        // Track previous snapshot for deduplication of identical consecutive token_count events
-        let mut prev_snapshot: Option<(u64, u64, u64, u64)> = None;
-
-        let reader = BufReader::with_capacity(64 * 1024, file);
-        for line in reader.lines().map_while(Result::ok) {
-            line_index += 1;
-
-            let Ok(value) = serde_json::from_str::<Value>(&line) else {
-                continue;
-            };
-
-            match value.get("type").and_then(|v| v.as_str()) {
-                Some("session_meta") => {
-                    if let Some(id) = value.pointer("/payload/id").and_then(|v| v.as_str()) {
-                        session_id = id.to_string();
+        let mut reader = BufReader::with_capacity(64 * 1024, file);
+        let mut buf: Vec<u8> = Vec::with_capacity(8 * 1024);
+        loop {
+            buf.clear();
+            match reader.read_until(b'\n', &mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if buf.last() != Some(&b'\n') {
+                        // Partial trailing line — leave it for the next parse.
+                        break;
                     }
-                }
-                Some("turn_context") => {
-                    if let Some(model) = value.pointer("/payload/model").and_then(|v| v.as_str()) {
-                        current_model = model.to_string();
-                    }
-                }
-                Some("event_msg") => {
-                    let payload_type = value.pointer("/payload/type").and_then(|v| v.as_str());
-                    match payload_type {
-                        Some("token_count") => {
-                            let Some(info) = value.pointer("/payload/info") else {
-                                continue;
-                            };
-                            if info.is_null() {
-                                continue;
+                    state.parsed_offset += n as u64;
+                    state.lines_consumed += 1;
+                    let fp_len = n.min(TAIL_FINGERPRINT_LEN);
+                    state.tail_fingerprint = buf[n - fp_len..n].to_vec();
+
+                    let Ok(line) = std::str::from_utf8(&buf) else {
+                        continue;
+                    };
+                    let Ok(value) = serde_json::from_str::<Value>(line) else {
+                        continue;
+                    };
+
+                    match value.get("type").and_then(|v| v.as_str()) {
+                        Some("session_meta") => {
+                            if let Some(id) = value.pointer("/payload/id").and_then(|v| v.as_str()) {
+                                state.session_id = id.to_string();
                             }
-
-                            let Some((input, output, cached, total)) = extract_token_usage(info)
-                            else {
-                                continue;
-                            };
-
-                            // Skip duplicate consecutive snapshots
-                            let snap = (input, output, cached, total);
-                            if prev_snapshot.as_ref() == Some(&snap) {
-                                continue;
+                        }
+                        Some("turn_context") => {
+                            if let Some(model) = value.pointer("/payload/model").and_then(|v| v.as_str()) {
+                                state.current_model = model.to_string();
                             }
-                            prev_snapshot = Some(snap);
+                        }
+                        Some("event_msg") => {
+                            let payload_type = value.pointer("/payload/type").and_then(|v| v.as_str());
+                            match payload_type {
+                                Some("token_count") => {
+                                    let Some(info) = value.pointer("/payload/info") else {
+                                        continue;
+                                    };
+                                    if info.is_null() {
+                                        continue;
+                                    }
 
-                            if input == 0 && output == 0 && cached == 0 && total == 0 {
-                                continue;
+                                    let Some((input, output, cached, total)) = extract_token_usage(info)
+                                    else {
+                                        continue;
+                                    };
+
+                                    // Skip duplicate consecutive snapshots
+                                    let snap = (input, output, cached, total);
+                                    if state.prev_snapshot.as_ref() == Some(&snap) {
+                                        continue;
+                                    }
+                                    state.prev_snapshot = Some(snap);
+
+                                    if input == 0 && output == 0 && cached == 0 && total == 0 {
+                                        continue;
+                                    }
+
+                                    let date = resolve_entry_date(path_date.as_deref(), &value);
+
+                                    let model = if state.current_model.is_empty() {
+                                        "codex".to_string()
+                                    } else {
+                                        state.current_model.clone()
+                                    };
+
+                                    let cumulative = extract_cumulative_usage(info);
+
+                                    // Key by source file (+ line) rather than session_id so a
+                                    // session_id appearing in multiple files never lets one file's
+                                    // re-parse clobber another file's cached entries. '\n' can't
+                                    // occur in a path, so it's a safe field separator.
+                                    let key = format!("{}\n{}", path.display(), state.lines_consumed);
+                                    entries.insert(
+                                        key,
+                                        CodexEntry {
+                                            date,
+                                            model,
+                                            session_id: state.session_id.clone(),
+                                            input_tokens: input,
+                                            output_tokens: output,
+                                            cached_tokens: cached,
+                                            total_tokens: total,
+                                            cumulative,
+                                        },
+                                    );
+                                }
+                                _ => {}
                             }
-
-                            let date = resolve_entry_date(path_date.as_deref(), &value);
-
-                            let model = if current_model.is_empty() {
-                                "codex".to_string()
-                            } else {
-                                current_model.clone()
-                            };
-
-                            let cumulative = extract_cumulative_usage(info);
-
-                            // Key by source file (+ line) rather than session_id so a
-                            // session_id appearing in multiple files never lets one file's
-                            // re-parse clobber another file's cached entries. '\n' can't
-                            // occur in a path, so it's a safe field separator.
-                            let key = format!("{}\n{}", path.display(), line_index);
-                            entries.insert(
-                                key,
-                                CodexEntry {
-                                    date,
-                                    model,
-                                    session_id: session_id.clone(),
-                                    input_tokens: input,
-                                    output_tokens: output,
-                                    cached_tokens: cached,
-                                    total_tokens: total,
-                                    cumulative,
-                                },
-                            );
                         }
                         _ => {}
                     }
                 }
-                _ => {}
+                Err(_) => break,
             }
         }
 
-        entries
+        (entries, state)
     }
 
-    /// Incrementally parse only changed files.
+    /// True when the bytes immediately before the cached resume point still match the
+    /// recorded fingerprint — i.e. the growth really is an append, not a rewrite that
+    /// happens to be larger.
+    fn tail_fingerprint_matches(path: &Path, st: &FileParseState) -> bool {
+        use std::io::{Read, Seek, SeekFrom};
+
+        if st.tail_fingerprint.is_empty() {
+            return st.parsed_offset == 0;
+        }
+        let fp_len = st.tail_fingerprint.len() as u64;
+        if st.parsed_offset < fp_len {
+            return false;
+        }
+        let Ok(mut file) = fs::File::open(path) else {
+            return false;
+        };
+        let mut buf = vec![0u8; fp_len as usize];
+        file.seek(SeekFrom::Start(st.parsed_offset - fp_len)).is_ok()
+            && file.read_exact(&mut buf).is_ok()
+            && buf == st.tail_fingerprint
+    }
+
+    /// Incrementally parse only changed files. Appended-to files resume from their
+    /// previous byte offset (verified by tail fingerprint); anything else — shrink,
+    /// same-size rewrite, or a grow whose pre-resume bytes changed — is purged and
+    /// re-parsed from the start.
     fn parse_incremental(
         current_meta: &HashMap<PathBuf, (SystemTime, u64)>,
         cached_entries: &HashMap<String, CodexEntry>,
-        cached_meta: &HashMap<PathBuf, (SystemTime, u64)>,
-    ) -> HashMap<String, CodexEntry> {
-        let mut entries = cached_entries.clone();
-
-        let mut changed_files: Vec<&PathBuf> = Vec::new();
-        for (path, (mtime, size)) in current_meta {
-            match cached_meta.get(path) {
-                Some((cached_mtime, cached_size))
-                    if cached_mtime == mtime && cached_size == size => {}
-                _ => {
-                    changed_files.push(path);
-                }
-            }
-        }
-
+        cached_states: &HashMap<PathBuf, FileParseState>,
+    ) -> (HashMap<String, CodexEntry>, HashMap<PathBuf, FileParseState>) {
         // If files were deleted, do a full re-parse
-        let has_deleted = cached_meta.keys().any(|p| !current_meta.contains_key(p));
+        let has_deleted = cached_states.keys().any(|p| !current_meta.contains_key(p));
         if has_deleted {
             let mut fresh = HashMap::new();
-            for path in current_meta.keys() {
-                fresh.extend(Self::parse_single_file(path));
+            let mut states = HashMap::new();
+            for (path, (mtime, size)) in current_meta {
+                let (file_entries, st) = Self::parse_file_from(path, None, *mtime, *size);
+                fresh.extend(file_entries);
+                states.insert(path.clone(), st);
             }
-            return fresh;
+            return (fresh, states);
         }
 
-        if !changed_files.is_empty() {
-            let start = Instant::now();
-            let count = changed_files.len();
-            for path in &changed_files {
-                // Drop every cached entry that came from this file before re-merging.
-                // Keys are `"<path>\n<line_index>"` (position-based within the file): a
-                // rewrite/compaction can move an event to a new line, so its old key would
-                // otherwise survive `extend` and double-count. Purging by path prefix
-                // removes only this file's stale entries — never another file's, even when
+        let mut entries = cached_entries.clone();
+        let mut states: HashMap<PathBuf, FileParseState> = HashMap::new();
+        let mut changed_count = 0usize;
+        let start = Instant::now();
+
+        for (path, (mtime, size)) in current_meta {
+            let prior = match cached_states.get(path) {
+                Some(st) if st.matches(*mtime, *size) => {
+                    states.insert(path.clone(), st.clone());
+                    continue;
+                }
+                // Append-only growth: existing `"<path>\n<line_index>"` keys stay
+                // valid, so no purge is needed — just parse the new tail.
+                Some(st) if *size > st.size && Self::tail_fingerprint_matches(path, st) => {
+                    Some(st.clone())
+                }
+                // Shrink, same-size rewrite, or fingerprint mismatch: a rewrite can
+                // move an event to a new line, so its old position-based key would
+                // otherwise survive `extend` and double-count. Purge by path prefix —
+                // this file's stale entries only, never another file's, even when
                 // they share a session_id.
-                let prefix = format!("{}\n", path.display());
-                entries.retain(|k, _| !k.starts_with(&prefix));
-                entries.extend(Self::parse_single_file(path));
-            }
+                _ => {
+                    let prefix = format!("{}\n", path.display());
+                    entries.retain(|k, _| !k.starts_with(&prefix));
+                    None
+                }
+            };
+            let (file_entries, st) = Self::parse_file_from(path, prior.as_ref(), *mtime, *size);
+            entries.extend(file_entries);
+            states.insert(path.clone(), st);
+            changed_count += 1;
+        }
+
+        if changed_count > 0 {
             eprintln!(
                 "[PERF][Codex] Incremental parse: {} changed files in {:?} (total {} files)",
-                count,
+                changed_count,
                 start.elapsed(),
                 current_meta.len()
             );
         }
 
-        entries
+        (entries, states)
     }
 
     /// Build AllStats from parsed entries.
@@ -545,9 +674,9 @@ impl CodexProvider {
         let start = Instant::now();
         let current_meta = self.collect_file_meta();
 
-        let entries = if let Ok(cache) = STATS_CACHE.lock() {
+        let (entries, file_states) = if let Ok(cache) = STATS_CACHE.lock() {
             if let Some(ref cached) = *cache {
-                if cached.file_meta == current_meta {
+                if file_states_match(&cached.file_states, &current_meta) {
                     drop(cache);
                     let rate_limits = self.resolve_rate_limits(&current_meta);
                     if let Ok(mut cache) = STATS_CACHE.lock() {
@@ -569,7 +698,7 @@ impl CodexProvider {
                 }
 
                 // Incremental parse
-                Self::parse_incremental(&current_meta, &cached.entries, &cached.file_meta)
+                Self::parse_incremental(&current_meta, &cached.entries, &cached.file_states)
             } else {
                 // First run — full parse
                 drop(cache);
@@ -579,14 +708,17 @@ impl CodexProvider {
                 );
                 let full_start = Instant::now();
                 let mut entries = HashMap::new();
-                for path in current_meta.keys() {
-                    entries.extend(Self::parse_single_file(path));
+                let mut file_states = HashMap::new();
+                for (path, (mtime, size)) in &current_meta {
+                    let (file_entries, st) = Self::parse_file_from(path, None, *mtime, *size);
+                    entries.extend(file_entries);
+                    file_states.insert(path.clone(), st);
                 }
                 eprintln!(
                     "[PERF][Codex] Full parse completed in {:?}",
                     full_start.elapsed()
                 );
-                entries
+                (entries, file_states)
             }
         } else {
             return Err("Failed to acquire cache lock".to_string());
@@ -600,7 +732,7 @@ impl CodexProvider {
                 stats: stats.clone(),
                 computed_at: Instant::now(),
                 entries,
-                file_meta: current_meta,
+                file_states,
             });
         }
 
@@ -1529,15 +1661,17 @@ mod tests {
         let ctx_line = r#"{"type":"turn_context","payload":{"model":"gpt-5.5"}}"#;
         let token_line = r#"{"timestamp":"2026-06-20T01:00:00.000Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1000,"cached_input_tokens":0,"output_tokens":500,"total_tokens":1500}}}}"#;
 
-        // Version 1: meta, ctx, token  → token at line 3 → key "sess-X:3"
+        // Version 1: meta, ctx, token  → token at line 3 → key "<path>\n3"
         fs::write(&path, format!("{}\n{}\n{}\n", meta_line, ctx_line, token_line)).unwrap();
         let v1_meta = file_meta_of(&path);
-        let cached_entries = CodexProvider::parse_single_file(&path);
+        let (cached_entries, v1_state) =
+            CodexProvider::parse_file_from(&path, None, v1_meta.0, v1_meta.1);
         assert_eq!(cached_entries.len(), 1, "v1 should have exactly one entry");
 
         // Version 2: session compacted — an extra preamble line shifts the token
-        // event down to line 4 → new key "sess-X:4" for the SAME usage. The byte
-        // length also changes, so the incremental path treats the file as changed.
+        // event down to line 4 → new key "<path>\n4" for the SAME usage. The file
+        // grew, but the bytes before the old resume point changed, so the tail
+        // fingerprint must reject the append-resume and force a purged re-parse.
         fs::write(
             &path,
             format!("{}\n{}\n{}\n{}\n", meta_line, ctx_line, "{}", token_line),
@@ -1546,13 +1680,13 @@ mod tests {
         let v2_meta = file_meta_of(&path);
         assert_ne!(v1_meta.1, v2_meta.1, "rewrite must change the byte length");
 
-        let mut cached_meta = HashMap::new();
-        cached_meta.insert(path.clone(), v1_meta);
+        let mut cached_states = HashMap::new();
+        cached_states.insert(path.clone(), v1_state);
         let mut current_meta = HashMap::new();
         current_meta.insert(path.clone(), v2_meta);
 
-        let merged =
-            CodexProvider::parse_incremental(&current_meta, &cached_entries, &cached_meta);
+        let (merged, _) =
+            CodexProvider::parse_incremental(&current_meta, &cached_entries, &cached_states);
         let stats = CodexProvider::build_stats(&merged);
         let total: u64 = stats.daily.iter().map(|d| d.input_tokens).sum();
 
@@ -1592,12 +1726,15 @@ mod tests {
         fs::write(&path_a, format!("{}\n{}\n{}\n", meta, ctx, tok(1000))).unwrap();
         fs::write(&path_b, format!("{}\n{}\n{}\n", meta, ctx, tok(2000))).unwrap();
 
-        // Initial full parse caches both files' entries.
-        let mut cached = CodexProvider::parse_single_file(&path_a);
-        cached.extend(CodexProvider::parse_single_file(&path_b));
-        let mut cached_meta = HashMap::new();
-        cached_meta.insert(path_a.clone(), file_meta_of(&path_a));
-        cached_meta.insert(path_b.clone(), file_meta_of(&path_b));
+        // Initial full parse caches both files' entries + states.
+        let a_meta = file_meta_of(&path_a);
+        let b_meta = file_meta_of(&path_b);
+        let (mut cached, a_state) = CodexProvider::parse_file_from(&path_a, None, a_meta.0, a_meta.1);
+        let (b_entries, b_state) = CodexProvider::parse_file_from(&path_b, None, b_meta.0, b_meta.1);
+        cached.extend(b_entries);
+        let mut cached_states = HashMap::new();
+        cached_states.insert(path_a.clone(), a_state);
+        cached_states.insert(path_b.clone(), b_state);
 
         // Only file A changes (a preamble line shifts its event + bumps byte length).
         fs::write(&path_a, format!("{}\n{}\n{}\n{}\n", meta, ctx, "{}", tok(1000))).unwrap();
@@ -1605,7 +1742,7 @@ mod tests {
         current_meta.insert(path_a.clone(), file_meta_of(&path_a));
         current_meta.insert(path_b.clone(), file_meta_of(&path_b));
 
-        let merged = CodexProvider::parse_incremental(&current_meta, &cached, &cached_meta);
+        let (merged, _) = CodexProvider::parse_incremental(&current_meta, &cached, &cached_states);
         let total: u64 = CodexProvider::build_stats(&merged)
             .daily
             .iter()
@@ -1625,6 +1762,67 @@ mod tests {
             m.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH),
             m.len(),
         )
+    }
+
+    /// Append-only growth must resume from the cached offset with carried parser
+    /// state: continued line numbering, the session_meta id from the prefix, and the
+    /// previous token_count snapshot (so a duplicate consecutive snapshot straddling
+    /// the resume boundary still dedups).
+    #[test]
+    fn incremental_append_resumes_with_carried_parser_state() {
+        let dir = std::env::temp_dir()
+            .join(format!("codex_test_append_resume_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("rollout-append.jsonl");
+
+        let meta = r#"{"type":"session_meta","payload":{"id":"sess-X"}}"#;
+        let ctx = r#"{"type":"turn_context","payload":{"model":"gpt-5.5"}}"#;
+        let tok = |inp: u64| {
+            format!(
+                r#"{{"timestamp":"2026-06-20T01:00:00.000Z","type":"event_msg","payload":{{"type":"token_count","info":{{"last_token_usage":{{"input_tokens":{},"cached_input_tokens":0,"output_tokens":0,"total_tokens":{}}}}}}}}}"#,
+                inp, inp
+            )
+        };
+
+        let v1 = format!("{}\n{}\n{}\n", meta, ctx, tok(1000));
+        fs::write(&path, &v1).unwrap();
+        let v1_meta = file_meta_of(&path);
+        let (cached_entries, v1_state) =
+            CodexProvider::parse_file_from(&path, None, v1_meta.0, v1_meta.1);
+        assert_eq!(cached_entries.len(), 1);
+
+        // Append: a verbatim duplicate of the last snapshot (must dedup via carried
+        // prev_snapshot) followed by a genuinely new turn.
+        let v2 = format!("{}{}\n{}\n", v1, tok(1000), tok(500));
+        fs::write(&path, &v2).unwrap();
+
+        let mut cached_states = HashMap::new();
+        cached_states.insert(path.clone(), v1_state);
+        let mut current_meta = HashMap::new();
+        current_meta.insert(path.clone(), file_meta_of(&path));
+
+        let (merged, states) =
+            CodexProvider::parse_incremental(&current_meta, &cached_entries, &cached_states);
+
+        let _ = fs::remove_dir_all(&dir);
+
+        assert_eq!(
+            merged.len(),
+            2,
+            "expected old entry + one new entry (duplicate snapshot must dedup)"
+        );
+        let total: u64 = merged.values().map(|e| e.input_tokens).sum();
+        assert_eq!(total, 1500, "1000 (cached) + 500 (appended)");
+        assert!(
+            merged.values().all(|e| e.session_id == "sess-X"),
+            "resumed tail must inherit session_meta id from the parsed prefix"
+        );
+        // New entry keeps position-based numbering: line 5 (line 4 was the dup).
+        assert!(merged.contains_key(&format!("{}\n5", path.display())));
+        let st = states.get(&path).expect("state for appended file");
+        assert_eq!(st.parsed_offset, v2.len() as u64);
+        assert_eq!(st.lines_consumed, 5);
     }
 
     fn replay_entry(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,6 +83,7 @@ function AppContent() {
   const [activeTab, setActiveTab] = useState<TabType>("overview");
   const [analyticsSubTab, setAnalyticsSubTab] = useState<AnalyticsSubTab>("usage");
   const [chatActivated, setChatActivated] = useState(false);
+  const [leaderboardActivated, setLeaderboardActivated] = useState(false);
   const todayStr = useToday();
   const { unreadCount } = useUnreadChat(activeTab === "chat", user?.id ?? null);
 
@@ -94,6 +95,7 @@ function AppContent() {
 
   useEffect(() => {
     if (activeTab === "chat") setChatActivated(true);
+    if (activeTab === "leaderboard") setLeaderboardActivated(true);
   }, [activeTab]);
 
   // Drive the unified chat realtime channel. Activation is gated only by
@@ -232,9 +234,13 @@ function AppContent() {
         )}
       </div>
 
-      {/* Leaderboard lazy-loads (network requests), keep conditional */}
-      {activeTab === "leaderboard" && (
-        <Leaderboard />
+      {/* Leaderboard: defers mount (and its network requests) until first visit,
+          then stays mounted behind a CSS toggle so the hooks' 30-min caches and
+          poll timers survive tab switches instead of refetching on every entry. */}
+      {leaderboardActivated && (
+        <div style={{ display: activeTab === "leaderboard" ? "contents" : "none" }}>
+          <Leaderboard />
+        </div>
       )}
 
       {/* Chat: always mounted but hidden via CSS; defers fetch until first visit */}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -17,6 +17,11 @@ extra_search_path = ["public", "extensions"]
 # for accidental or malicious requests.
 max_rows = 1000
 
+[functions.badge]
+# Badge SVGs are embedded in GitHub READMEs, which fetch without any auth header —
+# JWT verification must stay off or every embed 401s at the gateway.
+verify_jwt = false
+
 [api.tls]
 # Enable HTTPS endpoints locally using a self-signed certificate.
 enabled = false

--- a/supabase/migrations/20260707000000_add_get_badge_rank.sql
+++ b/supabase/migrations/20260707000000_add_get_badge_rank.sql
@@ -1,0 +1,55 @@
+-- Create the get_badge_rank() RPC that the badge edge function has been calling
+-- since launch but which never existed in any environment.
+--
+-- Impact of the missing function, per badge request (cache miss):
+--   1. a wasted failed RPC round-trip (`get_badge_rank` → undefined function), then
+--   2. a fallback call to get_leaderboard_entries() that aggregates the FULL
+--      leaderboard just to locate one user's index, and
+--   3. a correctness bug: get_leaderboard_entries() is capped at LIMIT 200, so any
+--      user ranked below 200 rendered as "Unranked".
+--
+-- This function computes a single user's rank directly. Ordering (total desc,
+-- user_id asc) and the leaderboard_hidden filter mirror get_leaderboard_entries()
+-- exactly so the badge rank always matches the in-app leaderboard position.
+-- Returns zero rows when the user has no data in range (the edge function treats
+-- that as "Unranked").
+
+create or replace function get_badge_rank(
+  p_user_id uuid,
+  p_provider text,
+  p_date_from date,
+  p_date_to date
+) returns table (
+  rank integer
+)
+language sql
+security definer
+set search_path = public
+as $$
+  with totals as (
+    select
+      s.user_id,
+      sum(s.total_tokens)::bigint as total_tokens
+    from daily_snapshots s
+    join profiles p on p.id = s.user_id
+    where s.provider = p_provider
+      and s.date >= p_date_from
+      and s.date <= p_date_to
+      and p.leaderboard_hidden = false
+    group by s.user_id
+  ),
+  ranked as (
+    select
+      t.user_id,
+      row_number() over (
+        order by t.total_tokens desc, t.user_id
+      )::integer as rank
+    from totals t
+  )
+  select r.rank
+  from ranked r
+  where r.user_id = p_user_id;
+$$;
+
+revoke all on function get_badge_rank(uuid, text, date, date) from public;
+grant execute on function get_badge_rank(uuid, text, date, date) to authenticated, service_role;


### PR DESCRIPTION
## 배경

"리더보드가 갑자기 느리다"는 증상을 조사한 결과, 서버(Supabase)는 정상(RPC 70~100ms, 캐시 히트율 1.00)이었고 원인은 **앱 자체의 CPU 기아**였습니다: `~/.claude/projects`가 5.2GB / 70K 파일로 커진 상태에서 대형 병렬 세션(단일 파일 최대 228MB, 합계 ~818MB)이 로그를 계속 append하면, 파일 단위 (mtime, size) 캐시 때문에 몇 KB 추가에도 해당 파일 **전체**를 ~10초마다 재파싱 — 앱 프로세스 CPU 71.6% 관측.

## 변경 사항

### 1. Byte-offset 증분 파싱 (claude_code + codex)
- 파일별 `FileParseState`(mtime, size, parsed_offset)를 캐시하고, append-only 성장 시 마지막 완전한 라인 뒤부터만 파싱
- 개행 미완성 트레일링 라인은 미소비 → 다음 사이클에 재시도 (유실 없음)
- codex는 파서가 파일 내 상태(session_id, 모델, 직전 token_count 스냅샷)를 가지므로 상태를 함께 carry, position 기반 dedup 키 정합 유지 + 16바이트 tail fingerprint로 "커졌지만 재작성" 케이스를 퍼지+전체 재파싱으로 강등
- open/seek 실패 시 state를 기록하지 않아 다음 사이클에 재시도 (무음 영구 스킵 방지)

### 2. 워처 이중 파싱 제거 + 디바운스 조정
- `stats-updated`를 백그라운드 재파싱 **완료 후** emit → 프런트는 warm cache만 읽음 (기존: 같은 파일을 두 번 파싱)
- 버스트 디바운스 10s → 30s

### 3. 리더보드 keep-mounted
- 탭 이탈 시 언마운트로 30분 캐시가 소실되던 것을 chat 탭과 같은 CSS 토글 방식으로 전환 → 재진입 즉시 표시

### 4. badge: get_badge_rank RPC 신설 + verify_jwt 해제
- badge 함수가 출시 때부터 존재하지 않는 RPC를 호출 → 요청마다 실패 후 전체 리더보드 폴백 + LIMIT 200 밖 "Unranked" 버그 → 전용 rank RPC 마이그레이션 추가 (프로덕션 적용 완료)
- README 임베드가 인증 헤더 없이 오는데 verify_jwt=true로 배포돼 전부 401 → config.toml에 false 명문화 (재배포 완료)

## 테스트
- `cargo test` 102/102 (오프셋 재개, 부분 라인, fingerprint, carried state 등 신규 테스트 7개 포함)
- `npm run build` 통과
- 코드리뷰 2회(전체 diff + codex 집중) 지적사항 반영 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)