### PR TITLE
feat: add Hermes Agent provider + leaderboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Shared data: daily token count, cost, messages/sessions. **No code or conversati
 | **Codex** | `~/.codex/sessions/**/*.jsonl` | Supports multiple roots. |
 | **OpenCode** | `~/.local/share/opencode/**/*.jsonl` | Per-model pricing from bundled registry. |
 | **GJC (Gajae Code)** | `~/.gjc/agent/sessions/**/*.jsonl` | Per-message usage (`message.usage`) with pre-computed cost; dedup by API response id. Supports multiple roots. |
+| **Hermes Agent** | `$HERMES_HOME/state.db` (default `~/.hermes/state.db`) | Per-session aggregates from the `sessions` table; uses Hermes' own actual/estimated cost. |
 
 **Network requests**: only when leaderboard/chat is opted in (sends aggregated data to Supabase) or when a webhook fires. Without these features, the app runs completely offline. AI translation keys, if set, call the provider you chose directly.
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -11,6 +11,7 @@ use crate::providers::claude_code::ClaudeCodeProvider;
 use crate::providers::codex::CodexProvider;
 use crate::providers::gjc::GjcProvider;
 use crate::providers::glm::GlmProvider;
+use crate::providers::hermes::HermesProvider;
 use crate::providers::kimi::KimiProvider;
 use crate::providers::opencode::OpenCodeProvider;
 use crate::providers::pricing;
@@ -183,6 +184,33 @@ pub async fn get_gjc_stats(app: tauri::AppHandle) -> Result<AllStats, String> {
         }
         Err(e) => Err(e),
     }
+}
+
+#[tauri::command]
+pub async fn get_hermes_stats(app: tauri::AppHandle) -> Result<AllStats, String> {
+    let result = tauri::async_runtime::spawn_blocking(|| {
+        let provider = HermesProvider::new();
+        if !provider.is_available() {
+            return Err("Hermes stats not available".to_string());
+        }
+        provider.fetch_stats()
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+
+    match result {
+        Ok(mut stats) => {
+            crate::hydration::apply(&mut stats, "hermes");
+            crate::update_tray_title(&app);
+            Ok(stats)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+#[tauri::command]
+pub fn is_hermes_available() -> bool {
+    HermesProvider::new().is_available()
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -328,7 +328,15 @@ pub fn update_tray_title(app_handle: &tauri::AppHandle) {
             0.0
         };
 
-        let today_cost = claude_cost + codex_cost + opencode_cost + kimi_cost + glm_cost + gjc_cost;
+        let hermes_cost = if prefs.include_hermes {
+            providers::hermes::get_cached_stats()
+                .and_then(|s| s.daily.iter().find(|d| d.date == today).map(|d| d.cost_usd))
+                .unwrap_or(0.0)
+        } else {
+            0.0
+        };
+
+        let today_cost = claude_cost + codex_cost + opencode_cost + kimi_cost + glm_cost + gjc_cost + hermes_cost;
         let cost_str = if today_cost >= 1.0 {
             format!("${:.0}", today_cost)
         } else {
@@ -408,6 +416,12 @@ fn get_all_watch_dirs() -> Vec<PathBuf> {
         dirs.push(default_gjc);
     }
 
+    // Hermes Agent keeps a single SQLite db in its home dir ($HERMES_HOME/~/.hermes)
+    let hermes_dir = providers::hermes::hermes_home();
+    if hermes_dir.exists() && !dirs.contains(&hermes_dir) {
+        dirs.push(hermes_dir);
+    }
+
     dirs
 }
 
@@ -420,7 +434,7 @@ fn start_file_watcher(app_handle: tauri::AppHandle) {
                 if matches!(event.kind, EventKind::Modify(_) | EventKind::Create(_)) {
                     let dominated = event.paths.iter().any(|p| {
                         let ext = p.extension().and_then(|e| e.to_str()).unwrap_or("");
-                        ext == "jsonl" || ext == "json" || ext == "db"
+                        ext == "jsonl" || ext == "json" || ext == "db" || ext == "db-wal"
                     });
                     if dominated {
                         let _ = tx.send(());
@@ -481,6 +495,7 @@ fn start_file_watcher(app_handle: tauri::AppHandle) {
                     providers::kimi::invalidate_stats_cache();
                     providers::glm::invalidate_stats_cache();
                     providers::gjc::invalidate_stats_cache();
+                    providers::hermes::invalidate_stats_cache();
                     // Re-parse in background, then notify the frontend. Emitting only
                     // after the parse completes means the frontend's get_*_stats calls
                     // hit the warm cache instead of racing this thread and parsing the
@@ -504,6 +519,9 @@ fn start_file_watcher(app_handle: tauri::AppHandle) {
                         }
                         if prefs.include_gjc {
                             let _ = providers::gjc::GjcProvider::new(prefs.gjc_dirs.clone()).fetch_stats();
+                        }
+                        if prefs.include_hermes {
+                            let _ = providers::hermes::HermesProvider::new().fetch_stats();
                         }
                         update_tray_title(&app_for_refresh);
                         let _ = app_for_refresh.emit("stats-updated", ());
@@ -529,6 +547,7 @@ fn start_file_watcher(app_handle: tauri::AppHandle) {
                         providers::kimi::invalidate_stats_cache();
                         providers::glm::invalidate_stats_cache();
                         providers::gjc::invalidate_stats_cache();
+                        providers::hermes::invalidate_stats_cache();
                         let _ = app_handle.emit("stats-updated", ());
                     }
                     update_tray_title(&app_handle);
@@ -880,6 +899,8 @@ pub fn run() {
             commands::is_glm_available,
             commands::get_gjc_stats,
             commands::is_gjc_available,
+            commands::get_hermes_stats,
+            commands::is_hermes_available,
             commands::get_preferences,
             commands::set_preferences,
             commands::get_stable_device_id,

--- a/src-tauri/src/providers/hermes.rs
+++ b/src-tauri/src/providers/hermes.rs
@@ -1,0 +1,369 @@
+//! Hermes Agent (Nous Research) provider.
+//!
+//! Hermes stores per-session aggregates in a local SQLite database:
+//! `$HERMES_HOME/state.db`, defaulting to `~/.hermes/state.db`. The `sessions`
+//! table carries token counts AND pre-computed costs per session, so no local
+//! pricing table is needed — `actual_cost_usd` wins over `estimated_cost_usd`.
+//!
+//! Granularity note: rows are per-session aggregates (not per-message), so a
+//! session's whole usage is attributed to the local calendar day it started on.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant, SystemTime};
+
+use super::traits::TokenProvider;
+use super::types::{AllStats, DailyUsage, ModelUsage};
+
+struct CachedStats {
+    stats: AllStats,
+    computed_at: Instant,
+    /// (mtime, size) of the db and its -wal sidecar for change detection.
+    file_meta: Vec<(PathBuf, SystemTime, u64)>,
+}
+
+static STATS_CACHE: Mutex<Option<CachedStats>> = Mutex::new(None);
+static CACHE_INVALIDATED: AtomicBool = AtomicBool::new(false);
+const CACHE_TTL: Duration = Duration::from_secs(120);
+
+pub fn invalidate_stats_cache() {
+    CACHE_INVALIDATED.store(true, Ordering::Relaxed);
+}
+
+pub fn get_cached_stats() -> Option<AllStats> {
+    STATS_CACHE.lock().ok()?.as_ref().map(|c| c.stats.clone())
+}
+
+/// Hermes home directory: `$HERMES_HOME` if set, else `~/.hermes`.
+pub fn hermes_home() -> PathBuf {
+    if let Ok(home) = std::env::var("HERMES_HOME") {
+        let trimmed = home.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+    dirs::home_dir().unwrap_or_default().join(".hermes")
+}
+
+fn db_path() -> PathBuf {
+    hermes_home().join("state.db")
+}
+
+/// One parsed session row from Hermes' `sessions` table.
+struct SessionRow {
+    model: String,
+    started_at: f64,
+    message_count: u32,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_read_tokens: u64,
+    cache_write_tokens: u64,
+    reasoning_tokens: u64,
+    cost_usd: f64,
+}
+
+/// Hermes stores `started_at` as epoch seconds or milliseconds depending on
+/// version — anything above 1e12 must already be milliseconds.
+fn started_at_to_local_date(started_at: f64) -> String {
+    use chrono::TimeZone;
+    let millis = if started_at > 1e12 {
+        started_at as i64
+    } else {
+        (started_at * 1000.0) as i64
+    };
+    chrono::Local
+        .timestamp_millis_opt(millis)
+        .single()
+        .map(|dt| dt.format("%Y-%m-%d").to_string())
+        .unwrap_or_else(|| "1970-01-01".to_string())
+}
+
+fn query_sessions(db: &PathBuf) -> Result<Vec<SessionRow>, String> {
+    let conn = rusqlite::Connection::open_with_flags(
+        db,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|e| format!("Failed to open Hermes state.db: {}", e))?;
+
+    let mut stmt = conn
+        .prepare(
+            r#"
+            SELECT
+                model,
+                started_at,
+                COALESCE(message_count, 0),
+                COALESCE(input_tokens, 0),
+                COALESCE(output_tokens, 0),
+                COALESCE(cache_read_tokens, 0),
+                COALESCE(cache_write_tokens, 0),
+                COALESCE(reasoning_tokens, 0),
+                COALESCE(actual_cost_usd, estimated_cost_usd, 0)
+            FROM sessions
+            WHERE model IS NOT NULL AND TRIM(model) != ''
+            "#,
+        )
+        .map_err(|e| format!("Failed to prepare Hermes sessions query: {}", e))?;
+
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(SessionRow {
+                model: row.get::<_, String>(0)?,
+                started_at: row.get::<_, f64>(1)?,
+                message_count: row.get::<_, i64>(2)?.max(0) as u32,
+                input_tokens: row.get::<_, i64>(3)?.max(0) as u64,
+                output_tokens: row.get::<_, i64>(4)?.max(0) as u64,
+                cache_read_tokens: row.get::<_, i64>(5)?.max(0) as u64,
+                cache_write_tokens: row.get::<_, i64>(6)?.max(0) as u64,
+                reasoning_tokens: row.get::<_, i64>(7)?.max(0) as u64,
+                cost_usd: row.get::<_, f64>(8)?,
+            })
+        })
+        .map_err(|e| format!("Failed to query Hermes sessions: {}", e))?
+        .filter_map(Result::ok)
+        .collect::<Vec<_>>();
+
+    Ok(rows)
+}
+
+fn build_stats(rows: &[SessionRow]) -> AllStats {
+    let mut daily_map: HashMap<String, DailyUsage> = HashMap::new();
+    let mut model_usage: HashMap<String, ModelUsage> = HashMap::new();
+    let mut total_messages: u32 = 0;
+    let mut first_date: Option<String> = None;
+
+    for row in rows {
+        // Reasoning tokens are billed as output by every Hermes billing provider,
+        // so fold them into output for display and totals.
+        let output = row.output_tokens + row.reasoning_tokens;
+        let total_tokens =
+            row.input_tokens + output + row.cache_read_tokens + row.cache_write_tokens;
+        if total_tokens == 0 && row.cost_usd <= 0.0 {
+            continue;
+        }
+
+        let date = started_at_to_local_date(row.started_at);
+        if first_date.as_ref().map_or(true, |d| date < *d) {
+            first_date = Some(date.clone());
+        }
+
+        let daily = daily_map.entry(date.clone()).or_insert_with(|| DailyUsage {
+            date,
+            ..Default::default()
+        });
+        *daily.tokens.entry(row.model.clone()).or_insert(0) += total_tokens;
+        daily.cost_usd += row.cost_usd;
+        daily.messages += row.message_count;
+        daily.sessions += 1;
+        daily.input_tokens += row.input_tokens;
+        daily.output_tokens += output;
+        daily.cache_read_tokens += row.cache_read_tokens;
+        daily.cache_write_tokens += row.cache_write_tokens;
+        total_messages += row.message_count;
+
+        let mu = model_usage.entry(row.model.clone()).or_insert_with(|| ModelUsage {
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read: 0,
+            cache_write: 0,
+            cost_usd: 0.0,
+        });
+        mu.input_tokens += row.input_tokens;
+        mu.output_tokens += output;
+        mu.cache_read += row.cache_read_tokens;
+        mu.cache_write += row.cache_write_tokens;
+        mu.cost_usd += row.cost_usd;
+    }
+
+    let mut daily: Vec<DailyUsage> = daily_map.into_values().collect();
+    daily.sort_by(|a, b| a.date.cmp(&b.date));
+    let total_sessions = daily.iter().map(|d| d.sessions).sum();
+
+    AllStats {
+        daily,
+        model_usage,
+        total_sessions,
+        total_messages,
+        first_session_date: first_date,
+        analytics: None,
+        rate_limits: None,
+    }
+}
+
+pub struct HermesProvider;
+
+impl HermesProvider {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Current (mtime, size) of the db and its WAL sidecar. SQLite in WAL mode
+    /// appends to `state.db-wal` between checkpoints, so watching only the main
+    /// file would miss fresh writes.
+    fn collect_file_meta() -> Vec<(PathBuf, SystemTime, u64)> {
+        let db = db_path();
+        let mut meta = Vec::new();
+        for path in [db.clone(), PathBuf::from(format!("{}-wal", db.display()))] {
+            if let Ok(m) = fs::metadata(&path) {
+                let mtime = m.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+                meta.push((path, mtime, m.len()));
+            }
+        }
+        meta
+    }
+}
+
+impl Default for HermesProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TokenProvider for HermesProvider {
+    fn name(&self) -> &str {
+        "Hermes"
+    }
+
+    fn fetch_stats(&self) -> Result<AllStats, String> {
+        let was_invalidated = CACHE_INVALIDATED.swap(false, Ordering::Relaxed);
+
+        if !was_invalidated {
+            if let Ok(cache) = STATS_CACHE.lock() {
+                if let Some(ref cached) = *cache {
+                    if cached.computed_at.elapsed() < CACHE_TTL {
+                        return Ok(cached.stats.clone());
+                    }
+                }
+            }
+        }
+
+        let current_meta = Self::collect_file_meta();
+
+        // Unchanged db (+wal) → refresh timestamp and reuse.
+        if let Ok(mut cache) = STATS_CACHE.lock() {
+            if let Some(ref mut cached) = *cache {
+                if cached.file_meta == current_meta {
+                    cached.computed_at = Instant::now();
+                    return Ok(cached.stats.clone());
+                }
+            }
+        }
+
+        // The sessions table holds one aggregate row per session (not per
+        // message), so a full re-query on change is cheap.
+        let rows = query_sessions(&db_path())?;
+        let stats = build_stats(&rows);
+
+        if let Ok(mut cache) = STATS_CACHE.lock() {
+            *cache = Some(CachedStats {
+                stats: stats.clone(),
+                computed_at: Instant::now(),
+                file_meta: current_meta,
+            });
+        }
+
+        Ok(stats)
+    }
+
+    fn is_available(&self) -> bool {
+        db_path().exists()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_db(name: &str, rows: &[(&str, f64, i64, i64, i64, i64, i64, i64, Option<f64>, Option<f64>)]) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "atm-hermes-test-{}-{}.db",
+            std::process::id(),
+            name
+        ));
+        let _ = fs::remove_file(&path);
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                model TEXT,
+                billing_provider TEXT,
+                started_at REAL,
+                message_count INTEGER,
+                input_tokens INTEGER,
+                output_tokens INTEGER,
+                cache_read_tokens INTEGER,
+                cache_write_tokens INTEGER,
+                reasoning_tokens INTEGER,
+                estimated_cost_usd REAL,
+                actual_cost_usd REAL
+            );
+            "#,
+        )
+        .unwrap();
+        for (i, r) in rows.iter().enumerate() {
+            conn.execute(
+                "INSERT INTO sessions (id, model, billing_provider, started_at, message_count,
+                 input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+                 reasoning_tokens, estimated_cost_usd, actual_cost_usd)
+                 VALUES (?1, ?2, 'anthropic', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                rusqlite::params![
+                    format!("sess-{}", i),
+                    r.0, r.1, r.2, r.3, r.4, r.5, r.6, r.7, r.8, r.9
+                ],
+            )
+            .unwrap();
+        }
+        path
+    }
+
+    #[test]
+    fn parses_sessions_with_cost_fallback() {
+        // 2026-07-01 12:00 UTC in epoch seconds; second session uses milliseconds.
+        let db = temp_db(
+            "basic",
+            &[
+                ("hermes-4-405b", 1_782_907_200.0, 10, 1000, 500, 200, 100, 50, Some(0.5), Some(0.42)),
+                ("claude-sonnet-5", 1_782_907_200_000.0, 4, 300, 100, 0, 0, 0, Some(0.2), None),
+            ],
+        );
+        let rows = query_sessions(&db).expect("query");
+        assert_eq!(rows.len(), 2);
+        let stats = build_stats(&rows);
+
+        // actual (0.42) wins for row 1; estimated (0.2) fallback for row 2.
+        let total_cost: f64 = stats.daily.iter().map(|d| d.cost_usd).sum();
+        assert!((total_cost - 0.62).abs() < 1e-9, "got {}", total_cost);
+
+        // sec and ms timestamps land on the same calendar day.
+        assert_eq!(stats.daily.len(), 1);
+        assert_eq!(stats.total_messages, 14);
+        assert_eq!(stats.daily[0].sessions, 2);
+
+        // reasoning folded into output: 500 + 50 = 550.
+        assert_eq!(stats.daily[0].output_tokens, 550 + 100);
+        let hermes_total = stats.daily[0].tokens.get("hermes-4-405b").copied().unwrap_or(0);
+        assert_eq!(hermes_total, 1000 + 550 + 200 + 100);
+
+        let _ = fs::remove_file(&db);
+    }
+
+    #[test]
+    fn skips_empty_and_unnamed_sessions() {
+        let db = temp_db(
+            "empty",
+            &[
+                ("", 1_782_907_200.0, 1, 100, 100, 0, 0, 0, None, None),
+                ("hermes-4-70b", 1_782_907_200.0, 0, 0, 0, 0, 0, 0, None, None),
+            ],
+        );
+        let rows = query_sessions(&db).expect("query");
+        // Unnamed model filtered by SQL; zero-usage row filtered by build_stats.
+        let stats = build_stats(&rows);
+        assert_eq!(stats.daily.len(), 0);
+
+        let _ = fs::remove_file(&db);
+    }
+}

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -2,6 +2,7 @@ pub mod claude_code;
 pub mod codex;
 pub mod gjc;
 pub mod glm;
+pub mod hermes;
 pub mod kimi;
 pub mod opencode;
 pub mod pricing;

--- a/src-tauri/src/providers/types.rs
+++ b/src-tauri/src/providers/types.rs
@@ -130,6 +130,8 @@ pub struct UserPreferences {
     pub include_glm: bool,
     #[serde(default)]
     pub include_gjc: bool,
+    #[serde(default)]
+    pub include_hermes: bool,
     #[serde(default = "default_gjc_dirs")]
     pub gjc_dirs: Vec<String>,
     #[serde(default = "default_codex_dirs")]
@@ -293,6 +295,7 @@ impl Default for UserPreferences {
             include_kimi: false,
             include_glm: false,
             include_gjc: false,
+            include_hermes: false,
             gjc_dirs: default_gjc_dirs(),
             codex_dirs: default_codex_dirs(),
             salary_enabled: false,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,6 +77,7 @@ function AppContent() {
     includeKimi: prefs.include_kimi,
     includeGlm: prefs.include_glm,
     includeGjc: prefs.include_gjc,
+    includeHermes: prefs.include_hermes,
   });
   const t = useI18n();
   const { user, profile } = useAuth();

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -156,6 +156,7 @@ function LeaderboardContent({ user }: { user: User }) {
   if (prefs.include_kimi) availableProviders.push("kimi");
   if (prefs.include_glm) availableProviders.push("glm");
   if (prefs.include_gjc) availableProviders.push("gjc");
+  if (prefs.include_hermes) availableProviders.push("hermes");
   // Default to claude if nothing enabled
   if (availableProviders.length === 0) availableProviders.push("claude");
 

--- a/src/components/LeaderboardUploader.tsx
+++ b/src/components/LeaderboardUploader.tsx
@@ -31,6 +31,7 @@ export function LeaderboardUploader() {
   const { stats: kimiStats } = useTokenStats("kimi");
   const { stats: glmStats } = useTokenStats("glm");
   const { stats: gjcStats } = useTokenStats("gjc");
+  const { stats: hermesStats } = useTokenStats("hermes");
 
   const claude = useSnapshotUploader({
     stats: prefs.include_claude ? claudeStats : null,
@@ -68,6 +69,12 @@ export function LeaderboardUploader() {
     optedIn,
     provider: "gjc",
   });
+  const hermes = useSnapshotUploader({
+    stats: prefs.include_hermes ? hermesStats : null,
+    user,
+    optedIn,
+    provider: "hermes",
+  });
 
   const runners = useMemo<Partial<Record<LeaderboardProvider, BackfillRunner>>>(
     () => ({
@@ -77,6 +84,7 @@ export function LeaderboardUploader() {
       kimi: prefs.include_kimi && kimi.ready ? kimi.manualBackfill : undefined,
       glm: prefs.include_glm && glm.ready ? glm.manualBackfill : undefined,
       gjc: prefs.include_gjc && gjc.ready ? gjc.manualBackfill : undefined,
+      hermes: prefs.include_hermes && hermes.ready ? hermes.manualBackfill : undefined,
     }),
     [
       prefs.include_claude,
@@ -85,18 +93,21 @@ export function LeaderboardUploader() {
       prefs.include_kimi,
       prefs.include_glm,
       prefs.include_gjc,
+      prefs.include_hermes,
       claude.ready,
       codex.ready,
       opencode.ready,
       kimi.ready,
       glm.ready,
       gjc.ready,
+      hermes.ready,
       claude.manualBackfill,
       codex.manualBackfill,
       opencode.manualBackfill,
       kimi.manualBackfill,
       glm.manualBackfill,
       gjc.manualBackfill,
+      hermes.manualBackfill,
     ],
   );
 

--- a/src/components/SourceSelector.tsx
+++ b/src/components/SourceSelector.tsx
@@ -9,7 +9,8 @@ type SourceKey =
   | "include_opencode"
   | "include_kimi"
   | "include_glm"
-  | "include_gjc";
+  | "include_gjc"
+  | "include_hermes";
 
 interface SourceDef {
   key: SourceKey;
@@ -25,6 +26,7 @@ export function SourceSelector() {
   const [kimiAvailable, setKimiAvailable] = useState(false);
   const [glmAvailable, setGlmAvailable] = useState(false);
   const [gjcAvailable, setGjcAvailable] = useState(false);
+  const [hermesAvailable, setHermesAvailable] = useState(false);
   const [availabilityLoaded, setAvailabilityLoaded] = useState(false);
   const [open, setOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -36,12 +38,14 @@ export function SourceSelector() {
       invoke<boolean>("is_kimi_available").catch(() => false),
       invoke<boolean>("is_glm_available").catch(() => false),
       invoke<boolean>("is_gjc_available").catch(() => false),
-    ]).then(([codex, opencode, kimi, glm, gjc]) => {
+      invoke<boolean>("is_hermes_available").catch(() => false),
+    ]).then(([codex, opencode, kimi, glm, gjc, hermes]) => {
       setCodexAvailable(codex);
       setOpencodeAvailable(opencode);
       setKimiAvailable(kimi);
       setGlmAvailable(glm);
       setGjcAvailable(gjc);
+      setHermesAvailable(hermes);
       setAvailabilityLoaded(true);
     });
   }, []);
@@ -59,8 +63,9 @@ export function SourceSelector() {
     if (prefs.include_kimi && !kimiAvailable) patch.include_kimi = false;
     if (prefs.include_glm && !glmAvailable) patch.include_glm = false;
     if (prefs.include_gjc && !gjcAvailable) patch.include_gjc = false;
+    if (prefs.include_hermes && !hermesAvailable) patch.include_hermes = false;
     if (Object.keys(patch).length > 0) updatePrefs(patch);
-  }, [availabilityLoaded, codexAvailable, opencodeAvailable, kimiAvailable, glmAvailable, gjcAvailable, prefs.include_codex, prefs.include_opencode, prefs.include_kimi, prefs.include_glm, prefs.include_gjc, updatePrefs]);
+  }, [availabilityLoaded, codexAvailable, opencodeAvailable, kimiAvailable, glmAvailable, gjcAvailable, hermesAvailable, prefs.include_codex, prefs.include_opencode, prefs.include_kimi, prefs.include_glm, prefs.include_gjc, prefs.include_hermes, updatePrefs]);
 
   useEffect(() => {
     if (!open) return;
@@ -91,7 +96,8 @@ export function SourceSelector() {
     { key: "include_kimi", label: t("sources.kimi"), available: kimiAvailable },
     { key: "include_glm", label: t("sources.glm"), available: glmAvailable },
     { key: "include_gjc", label: t("sources.gjc"), available: gjcAvailable },
-  ], [t, codexAvailable, opencodeAvailable, kimiAvailable, glmAvailable, gjcAvailable]);
+    { key: "include_hermes", label: t("sources.hermes"), available: hermesAvailable },
+  ], [t, codexAvailable, opencodeAvailable, kimiAvailable, glmAvailable, gjcAvailable, hermesAvailable]);
 
   const visibleSources = sources.filter((s) => s.available);
   const totalCount = visibleSources.length;

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -23,6 +23,7 @@ const defaultPrefs: UserPreferences = {
   include_kimi: false,
   include_glm: false,
   include_gjc: false,
+  include_hermes: false,
   theme: "github",
   color_mode: "system",
   language: "en",

--- a/src/hooks/useBackfill.ts
+++ b/src/hooks/useBackfill.ts
@@ -10,7 +10,7 @@ import {
 } from "../lib/backfillRegistry";
 import type { LeaderboardProvider } from "../lib/types";
 
-const PROVIDERS: LeaderboardProvider[] = ["claude", "codex", "opencode", "kimi", "glm", "gjc"];
+const PROVIDERS: LeaderboardProvider[] = ["claude", "codex", "opencode", "kimi", "glm", "gjc", "hermes"];
 
 function activeProviders(prefs: {
   include_claude: boolean;
@@ -19,6 +19,7 @@ function activeProviders(prefs: {
   include_kimi: boolean;
   include_glm: boolean;
   include_gjc: boolean;
+  include_hermes: boolean;
 }): LeaderboardProvider[] {
   return PROVIDERS.filter((p) => {
     if (p === "claude") return prefs.include_claude;
@@ -26,7 +27,8 @@ function activeProviders(prefs: {
     if (p === "opencode") return prefs.include_opencode;
     if (p === "kimi") return prefs.include_kimi;
     if (p === "glm") return prefs.include_glm;
-    return prefs.include_gjc;
+    if (p === "gjc") return prefs.include_gjc;
+    return prefs.include_hermes;
   });
 }
 

--- a/src/hooks/useCombinedStats.ts
+++ b/src/hooks/useCombinedStats.ts
@@ -9,15 +9,17 @@ interface UseCombinedStatsProps {
   includeKimi: boolean;
   includeGlm: boolean;
   includeGjc: boolean;
+  includeHermes: boolean;
 }
 
-export function useCombinedStats({ includeClaude, includeCodex, includeOpencode, includeKimi, includeGlm, includeGjc }: UseCombinedStatsProps) {
+export function useCombinedStats({ includeClaude, includeCodex, includeOpencode, includeKimi, includeGlm, includeGjc, includeHermes }: UseCombinedStatsProps) {
   const claude = useTokenStats("claude");
   const codex = useTokenStats("codex");
   const opencode = useTokenStats("opencode");
   const kimi = useTokenStats("kimi");
   const glm = useTokenStats("glm");
   const gjc = useTokenStats("gjc");
+  const hermes = useTokenStats("hermes");
 
   const stats = useMemo<AllStats | null>(() => {
     const sources: (AllStats | null)[] = [];
@@ -27,6 +29,7 @@ export function useCombinedStats({ includeClaude, includeCodex, includeOpencode,
     if (includeKimi) sources.push(kimi.stats);
     if (includeGlm) sources.push(glm.stats);
     if (includeGjc) sources.push(gjc.stats);
+    if (includeHermes) sources.push(hermes.stats);
 
     const validStats = sources.filter((s): s is AllStats => s !== null);
     if (validStats.length === 0) {
@@ -36,14 +39,15 @@ export function useCombinedStats({ includeClaude, includeCodex, includeOpencode,
       if (includeKimi) return kimi.stats;
       if (includeGlm) return glm.stats;
       if (includeGjc) return gjc.stats;
+      if (includeHermes) return hermes.stats;
       return null;
     }
     if (validStats.length === 1) return validStats[0];
 
     return mergeStats(validStats);
-  }, [claude.stats, codex.stats, opencode.stats, kimi.stats, glm.stats, gjc.stats, includeClaude, includeCodex, includeOpencode, includeKimi, includeGlm, includeGjc]);
+  }, [claude.stats, codex.stats, opencode.stats, kimi.stats, glm.stats, gjc.stats, hermes.stats, includeClaude, includeCodex, includeOpencode, includeKimi, includeGlm, includeGjc, includeHermes]);
 
-  const loading = (includeClaude && claude.loading) || (includeCodex && codex.loading) || (includeOpencode && opencode.loading) || (includeKimi && kimi.loading) || (includeGlm && glm.loading) || (includeGjc && gjc.loading);
+  const loading = (includeClaude && claude.loading) || (includeCodex && codex.loading) || (includeOpencode && opencode.loading) || (includeKimi && kimi.loading) || (includeGlm && glm.loading) || (includeGjc && gjc.loading) || (includeHermes && hermes.loading);
   const error = useMemo(() => {
     if (stats) return null;
 
@@ -53,9 +57,10 @@ export function useCombinedStats({ includeClaude, includeCodex, includeOpencode,
     if (includeKimi && kimi.error) return kimi.error;
     if (includeGlm && glm.error) return glm.error;
     if (includeGjc && gjc.error) return gjc.error;
+    if (includeHermes && hermes.error) return hermes.error;
 
     return null;
-  }, [stats, includeClaude, includeCodex, includeOpencode, includeKimi, includeGlm, includeGjc, claude.error, codex.error, opencode.error, kimi.error, glm.error, gjc.error]);
+  }, [stats, includeClaude, includeCodex, includeOpencode, includeKimi, includeGlm, includeGjc, includeHermes, claude.error, codex.error, opencode.error, kimi.error, glm.error, gjc.error, hermes.error]);
 
   return { stats, loading, error };
 }

--- a/src/hooks/useTokenStats.ts
+++ b/src/hooks/useTokenStats.ts
@@ -3,7 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import type { AllStats } from "../lib/types";
 
-export type StatsProvider = "claude" | "codex" | "opencode" | "kimi" | "glm" | "gjc";
+export type StatsProvider = "claude" | "codex" | "opencode" | "kimi" | "glm" | "gjc" | "hermes";
 
 export function useTokenStats(provider: StatsProvider = "claude") {
   const [stats, setStats] = useState<AllStats | null>(null);
@@ -15,7 +15,7 @@ export function useTokenStats(provider: StatsProvider = "claude") {
   const fetchStats = useCallback(async () => {
     const requestId = ++requestIdRef.current;
     try {
-      const command = provider === "codex" ? "get_codex_stats" : provider === "opencode" ? "get_opencode_stats" : provider === "kimi" ? "get_kimi_stats" : provider === "glm" ? "get_glm_stats" : provider === "gjc" ? "get_gjc_stats" : "get_all_stats";
+      const command = provider === "codex" ? "get_codex_stats" : provider === "opencode" ? "get_opencode_stats" : provider === "kimi" ? "get_kimi_stats" : provider === "glm" ? "get_glm_stats" : provider === "gjc" ? "get_gjc_stats" : provider === "hermes" ? "get_hermes_stats" : "get_all_stats";
       const data = await invoke<AllStats>(command);
       if (requestId !== requestIdRef.current) return;
       setStats(data);

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -15,6 +15,7 @@
   "sources.kimi": "Kimi",
   "sources.glm": "GLM",
   "sources.gjc": "GJC",
+  "sources.hermes": "Hermes",
   "sources.summary.count": "{{active}} von {{total}} aktiv",
   "sources.open": "Quellenmenü öffnen",
   "today.title": "Heute",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -15,6 +15,7 @@
   "sources.kimi": "Kimi",
   "sources.glm": "GLM",
   "sources.gjc": "GJC",
+  "sources.hermes": "Hermes",
   "sources.summary.count": "{{active}} of {{total}} active",
   "sources.open": "Open sources menu",
   "today.title": "Today",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -15,6 +15,7 @@
   "sources.kimi": "Kimi",
   "sources.glm": "GLM",
   "sources.gjc": "GJC",
+  "sources.hermes": "Hermes",
   "sources.summary.count": "{{active}} de {{total}} activas",
   "sources.open": "Abrir menú de fuentes",
   "today.title": "Hoy",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -15,6 +15,7 @@
   "sources.kimi": "Kimi",
   "sources.glm": "GLM",
   "sources.gjc": "GJC",
+  "sources.hermes": "Hermes",
   "sources.summary.count": "{{active}} sur {{total}} actives",
   "sources.open": "Ouvrir le menu des sources",
   "today.title": "Aujourd'hui",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -15,6 +15,7 @@
   "sources.kimi": "Kimi",
   "sources.glm": "GLM",
   "sources.gjc": "GJC",
+  "sources.hermes": "Hermes",
   "sources.summary.count": "{{active}} di {{total}} attive",
   "sources.open": "Apri menu sorgenti",
   "today.title": "Oggi",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -15,6 +15,7 @@
   "sources.kimi": "Kimi",
   "sources.glm": "GLM",
   "sources.gjc": "GJC",
+  "sources.hermes": "Hermes",
   "sources.summary.count": "{{total}}中{{active}}使用",
   "sources.open": "ソースメニューを開く",
   "today.title": "今日",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -15,6 +15,7 @@
   "sources.kimi": "Kimi",
   "sources.glm": "GLM",
   "sources.gjc": "GJC",
+  "sources.hermes": "Hermes",
   "sources.summary.count": "{{total}}개 중 {{active}}개 사용",
   "sources.open": "소스 메뉴 열기",
   "today.title": "오늘",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -15,6 +15,7 @@
   "sources.kimi": "Kimi",
   "sources.glm": "GLM",
   "sources.gjc": "GJC",
+  "sources.hermes": "Hermes",
   "sources.summary.count": "{{total}} içinden {{active}} aktif",
   "sources.open": "Kaynak menüsünü aç",
   "today.title": "Bugün",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -15,6 +15,7 @@
   "sources.kimi": "Kimi",
   "sources.glm": "GLM",
   "sources.gjc": "GJC",
+  "sources.hermes": "Hermes",
   "sources.summary.count": "{{total}} 个中 {{active}} 个启用",
   "sources.open": "打开来源菜单",
   "today.title": "今日",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -15,6 +15,7 @@
   "sources.kimi": "Kimi",
   "sources.glm": "GLM",
   "sources.gjc": "GJC",
+  "sources.hermes": "Hermes",
   "sources.summary.count": "{{total}} 個中 {{active}} 個啟用",
   "sources.open": "開啟來源選單",
   "today.title": "今日",

--- a/src/lib/badgeSvgTemplate.ts
+++ b/src/lib/badgeSvgTemplate.ts
@@ -17,6 +17,7 @@ export const PROVIDER_COLORS: Record<LeaderboardProvider, string> = {
   kimi: "#1a73e8",
   glm: "#00b96b",
   gjc: "#e11d48",
+  hermes: "#0d9488",
 };
 
 export const PROVIDER_LABELS: Record<LeaderboardProvider, string> = {
@@ -26,6 +27,7 @@ export const PROVIDER_LABELS: Record<LeaderboardProvider, string> = {
   kimi: "Kimi",
   glm: "GLM",
   gjc: "GJC",
+  hermes: "Hermes",
 };
 
 export const PERIOD_LABELS: Record<string, string> = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -80,7 +80,7 @@ export interface AllStats {
   rate_limits?: CodexRateLimits | null;
 }
 
-export type LeaderboardProvider = "claude" | "codex" | "opencode" | "kimi" | "glm" | "gjc";
+export type LeaderboardProvider = "claude" | "codex" | "opencode" | "kimi" | "glm" | "gjc" | "hermes";
 
 export interface UserPreferences {
   number_format: "compact" | "full";
@@ -93,6 +93,7 @@ export interface UserPreferences {
   include_kimi: boolean;
   include_glm: boolean;
   include_gjc: boolean;
+  include_hermes: boolean;
   theme: "github" | "purple" | "ocean" | "sunset";
   color_mode: "system" | "light" | "dark";
   language: "en" | "ko" | "ja" | "zh-CN" | "zh-TW" | "fr" | "es" | "de" | "tr" | "it";

--- a/supabase/functions/badge/index.ts
+++ b/supabase/functions/badge/index.ts
@@ -7,6 +7,7 @@ const PROVIDER_COLORS: Record<string, string> = {
   kimi: "#1a73e8",
   glm: "#00b96b",
   gjc: "#e11d48",
+  hermes: "#0d9488",
 };
 
 const PROVIDER_LABELS: Record<string, string> = {
@@ -16,6 +17,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   kimi: "Kimi",
   glm: "GLM",
   gjc: "GJC",
+  hermes: "Hermes",
 };
 
 const PERIOD_LABELS: Record<string, string> = {
@@ -24,7 +26,7 @@ const PERIOD_LABELS: Record<string, string> = {
   month: "This Month",
 };
 
-const VALID_PROVIDERS = new Set(["claude", "codex", "opencode", "kimi", "glm", "gjc"]);
+const VALID_PROVIDERS = new Set(["claude", "codex", "opencode", "kimi", "glm", "gjc", "hermes"]);
 const VALID_PERIODS = new Set(["today", "week", "month"]);
 const VALID_STYLES = new Set(["flat", "flat-square", "card"]);
 

--- a/supabase/migrations/20260707010000_add_hermes_provider.sql
+++ b/supabase/migrations/20260707010000_add_hermes_provider.sql
@@ -1,0 +1,162 @@
+-- Extend the provider whitelist on daily_snapshots to accept 'hermes' (Hermes Agent).
+--
+-- The client-side Hermes provider was added alongside this migration, but the
+-- Supabase layer still rejects 'hermes' at two points:
+--   1. the daily_snapshots_provider_check CHECK constraint
+--   2. the sync_device_snapshots() RPC's provider validation
+-- Without this migration, leaderboard uploads for Hermes silently fail at the
+-- RPC boundary with 'Invalid provider'.
+--
+-- The function body below is copied verbatim from
+-- 20260627000000_add_gjc_provider.sql (the current bulk-UPSERT v2
+-- implementation) with only the provider lists widened to add 'hermes'.
+-- Keeping the rest identical avoids accidental behavior drift.
+
+alter table daily_snapshots
+drop constraint if exists daily_snapshots_provider_check;
+
+alter table daily_snapshots
+add constraint daily_snapshots_provider_check
+check (provider in ('claude', 'codex', 'opencode', 'kimi', 'glm', 'gjc', 'hermes'));
+
+create or replace function sync_device_snapshots(
+  p_provider text,
+  p_device_id text,
+  p_rows jsonb default '[]'::jsonb,
+  p_stale_dates date[] default '{}'::date[]
+) returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+begin
+  if v_user_id is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  if p_provider not in ('claude', 'codex', 'opencode', 'kimi', 'glm', 'gjc', 'hermes') then
+    raise exception 'Invalid provider';
+  end if;
+
+  if p_device_id is null or btrim(p_device_id) = '' then
+    raise exception 'Missing device_id';
+  end if;
+
+  -- Step 1: bulk stale cleanup.
+  if p_stale_dates is not null and array_length(p_stale_dates, 1) is not null then
+    delete from daily_snapshots d
+    where d.user_id = v_user_id
+      and d.provider = p_provider
+      and d.date = any(p_stale_dates)
+      and coalesce(
+        (
+          select jsonb_object_agg(key, value)
+          from jsonb_each(coalesce(d.device_snapshots, '{}'::jsonb) - p_device_id) e
+          where coalesce((e.value->>'submitted_at')::timestamptz, now())
+                >= now() - interval '30 days'
+        ),
+        '{}'::jsonb
+      ) = '{}'::jsonb;
+
+    with pruned as (
+      select
+        s.user_id,
+        s.date,
+        s.provider,
+        (
+          select jsonb_object_agg(key, value)
+          from jsonb_each(coalesce(s.device_snapshots, '{}'::jsonb) - p_device_id) e
+          where coalesce((e.value->>'submitted_at')::timestamptz, now())
+                >= now() - interval '30 days'
+        ) as next_snapshots
+      from daily_snapshots s
+      where s.user_id = v_user_id
+        and s.provider = p_provider
+        and s.date = any(p_stale_dates)
+      for update
+    )
+    update daily_snapshots d
+    set
+      device_snapshots = p.next_snapshots,
+      total_tokens = t.total_tokens,
+      cost_usd = t.cost_usd,
+      messages = t.messages,
+      sessions = t.sessions,
+      submitted_at = now()
+    from pruned p, lateral snapshot_totals(p.next_snapshots) t
+    where d.user_id = p.user_id
+      and d.provider = p.provider
+      and d.date = p.date
+      and p.next_snapshots is not null;
+  end if;
+
+  -- Step 2: bulk upsert.
+  if p_rows is not null and jsonb_array_length(p_rows) > 0 then
+    with incoming as (
+      select
+        (row_data->>'date')::date as date,
+        jsonb_build_object(
+          'total_tokens', coalesce((row_data->>'total_tokens')::bigint, 0),
+          'cost_usd',     coalesce((row_data->>'cost_usd')::numeric(10,4), 0),
+          'messages',     coalesce((row_data->>'messages')::integer, 0),
+          'sessions',     coalesce((row_data->>'sessions')::integer, 0),
+          'submitted_at', now()
+        ) as device_payload
+      from jsonb_array_elements(coalesce(p_rows, '[]'::jsonb)) row_data
+    ),
+    merged as (
+      select
+        i.date,
+        coalesce(
+          (
+            select jsonb_object_agg(key, value)
+            from jsonb_each(
+              jsonb_set(
+                coalesce(existing.device_snapshots, '{}'::jsonb) - '__legacy__',
+                array[p_device_id],
+                i.device_payload,
+                true
+              )
+            ) e
+            where coalesce((e.value->>'submitted_at')::timestamptz, now())
+                  >= now() - interval '30 days'
+          ),
+          jsonb_build_object(p_device_id, i.device_payload)
+        ) as next_snapshots
+      from incoming i
+      left join daily_snapshots existing
+        on existing.user_id = v_user_id
+       and existing.provider = p_provider
+       and existing.date = i.date
+    )
+    insert into daily_snapshots (
+      user_id, date, provider,
+      total_tokens, cost_usd, messages, sessions,
+      device_snapshots, submitted_at
+    )
+    select
+      v_user_id,
+      m.date,
+      p_provider,
+      t.total_tokens,
+      t.cost_usd,
+      t.messages,
+      t.sessions,
+      m.next_snapshots,
+      now()
+    from merged m, lateral snapshot_totals(m.next_snapshots) t
+    on conflict (user_id, date, provider) do update set
+      device_snapshots = excluded.device_snapshots,
+      total_tokens     = excluded.total_tokens,
+      cost_usd         = excluded.cost_usd,
+      messages         = excluded.messages,
+      sessions         = excluded.sessions,
+      submitted_at     = excluded.submitted_at;
+  end if;
+end;
+$$;
+
+revoke all on function sync_device_snapshots(text, text, jsonb, date[]) from public;
+grant execute on function sync_device_snapshots(text, text, jsonb, date[]) to authenticated;


### PR DESCRIPTION
Closes #140

## 배경

이슈 #140에서 Hermes Agent(Nous Research) 사용량 추적 요청이 있었습니다. Hermes는 `$HERMES_HOME/state.db`(기본 `~/.hermes/state.db`) SQLite의 `sessions` 테이블에 세션별 토큰·비용 집계를 저장하므로, 이 앱의 로컬 파싱 아키텍처와 정확히 맞습니다.

## 구현 (GJC #152 체크리스트 미러링)

**로컬 통계**
- `providers/hermes.rs`: `sessions` 테이블 쿼리 → 세션 시작일 기준 일별 귀속, reasoning 토큰은 output에 합산, 비용은 Hermes가 저장한 `actual_cost_usd` → `estimated_cost_usd` → 0 폴백 (로컬 pricing 테이블 불필요)
- `started_at`이 초/밀리초 혼재 가능성 대응 (>1e12 휴리스틱)
- 캐시는 `state.db` + `state.db-wal` 사이드카의 (mtime, size) 기준 — WAL 모드에서 체크포인트 전 쓰기도 감지하도록 워처 확장자 필터에 `db-wal` 추가
- `include_hermes` 설정(기본 off), 트레이 비용/워처/백그라운드 재파싱/SourceSelector/합산 통계/10개 로케일 배선

**리더보드**
- 마이그레이션 `20260707010000_add_hermes_provider.sql` (CHECK 제약 + `sync_device_snapshots` 허용 목록 확장) — ⚠️ **아직 프로덕션에 적용하지 않음** (아래 테스트 계획 참고)
- provider 탭, 백필 러너, 업로더, badge 색상/라벨/VALID_PROVIDERS

## 테스트

- `cargo test` 106/106 — SQLite 픽스처 기반 신규 테스트 2개 (비용 폴백, 초/밀리초 타임스탬프, 0행 필터)
- `npm run build` 통과
- 스키마는 실사용 데이터 없이 [tokscale의 Hermes 파서](https://github.com/junhoyeo/tokscale/blob/main/crates/tokscale-core/src/sessions/hermes.rs)와 교차 검증했습니다

## 테스트 계획 (머지 전)

실제 Hermes 사용자의 검증이 필요합니다. #140 제보자(Windows 11)께 다음을 요청할 예정입니다:
1. `sqlite3 %USERPROFILE%\.hermes\state.db ".schema sessions"` 출력으로 스키마 확인
2. 이 브랜치 빌드(또는 다음 베타)에서 Hermes 사용량이 표시되는지 확인

검증 완료 후 머지 + Supabase 마이그레이션 적용 + badge 함수 재배포 순서로 릴리즈합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)