### PR TITLE
fix: 죽은 웹뷰 자동 복구 + GPT-5.6 가격 + 리액션 호버 표시

### DIFF
--- a/src-tauri/pricing.json
+++ b/src-tauri/pricing.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.7.0",
-  "last_updated": "2026-07-01",
+  "version": "1.8.0",
+  "last_updated": "2026-07-11",
   "sources": {
     "claude": "https://platform.claude.com/docs/en/about-claude/pricing",
     "codex": "https://developers.openai.com/api/docs/pricing"
@@ -35,6 +35,10 @@
   "codex": {
     "default": "gpt-5.4",
     "models": [
+      { "match": "gpt-5.6-sol",        "label": "gpt-5.6-sol",        "input": 5.00, "output": 30.00, "cached_input": 0.50  },
+      { "match": "gpt-5.6-terra",      "label": "gpt-5.6-terra",      "input": 2.50, "output": 15.00, "cached_input": 0.25  },
+      { "match": "gpt-5.6-luna",       "label": "gpt-5.6-luna",       "input": 1.00, "output": 6.00,  "cached_input": 0.10  },
+      { "match": "gpt-5.6",            "label": "gpt-5.6",            "input": 5.00, "output": 30.00, "cached_input": 0.50  },
       { "match": "gpt-5.5-pro",        "label": "gpt-5.5-pro",        "input": 30.00,"output": 180.00,"cached_input": 0.0   },
       { "match": "gpt-5.5",            "label": "gpt-5.5",            "input": 5.00, "output": 30.00, "cached_input": 0.50  },
       { "match": "gpt-5.4-pro",        "label": "gpt-5.4-pro",        "input": 30.00,"output": 180.00,"cached_input": 0.0   },
@@ -84,6 +88,10 @@
       { "match": "sonnet",            "label": "Claude Sonnet 4.x",        "input": 3.0,   "output": 15.0,   "cache_read": 0.30,  "cache_write": 3.75   },
       { "match": "haiku-4-5",         "label": "Claude Haiku 4.5",         "input": 1.0,   "output": 5.0,    "cache_read": 0.10,  "cache_write": 1.25   },
       { "match": "haiku",             "label": "Claude Haiku 4.5",         "input": 1.0,   "output": 5.0,    "cache_read": 0.10,  "cache_write": 1.25   },
+      { "match": "gpt-5.6-sol",       "label": "GPT-5.6 Sol",              "input": 5.00,  "output": 30.0,   "cache_read": 0.50,  "cache_write": 0.0    },
+      { "match": "gpt-5.6-terra",     "label": "GPT-5.6 Terra",            "input": 2.50,  "output": 15.0,   "cache_read": 0.25,  "cache_write": 0.0    },
+      { "match": "gpt-5.6-luna",      "label": "GPT-5.6 Luna",             "input": 1.00,  "output": 6.0,    "cache_read": 0.10,  "cache_write": 0.0    },
+      { "match": "gpt-5.6",           "label": "GPT-5.6",                  "input": 5.00,  "output": 30.0,   "cache_read": 0.50,  "cache_write": 0.0    },
       { "match": "gpt-5.5-pro",       "label": "GPT-5.5 Pro",              "input": 30.00, "output": 180.0,  "cache_read": 0.0,   "cache_write": 0.0    },
       { "match": "gpt-5.5",           "label": "GPT-5.5",                  "input": 5.00,  "output": 30.0,   "cache_read": 0.50,  "cache_write": 0.0    },
       { "match": "gpt-5.4-pro",       "label": "GPT-5.4 Pro",              "input": 30.00, "output": 180.0,  "cache_read": 0.0,   "cache_write": 0.0    },

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,6 +19,12 @@ static DIALOG_OPEN: AtomicBool = AtomicBool::new(false);
 /// Timestamp (ms) when the window was last shown — prevents immediate focus-loss hide.
 static LAST_SHOWN_MS: AtomicU64 = AtomicU64::new(0);
 
+/// Timestamp (ms) of the last frontend heartbeat. The frontend beats on an
+/// interval and on every visibilitychange→visible. If the window is shown and
+/// no beat arrives shortly after, the webview's content process is dead
+/// (WKWebView renders solid white and all JS stops) — we then reload it.
+static WEBVIEW_HEARTBEAT_MS: AtomicU64 = AtomicU64::new(0);
+
 /// Stores a deep-link URL that arrived before the frontend was ready (cold start).
 /// The frontend can retrieve it via the `get_pending_deep_link` command.
 static PENDING_DEEP_LINK: Mutex<Option<String>> = Mutex::new(None);
@@ -766,6 +772,40 @@ fn hide_window(window: tauri::WebviewWindow) {
 }
 
 #[tauri::command]
+fn heartbeat() {
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    WEBVIEW_HEARTBEAT_MS.store(now_ms, Ordering::SeqCst);
+}
+
+/// After showing the window, verify the webview is actually alive by pinging
+/// it directly: eval() runs in the page and answers with a heartbeat within
+/// milliseconds, while a dead content process silently drops the eval. If no
+/// beat lands within the wait window, reload (native WKWebView reload
+/// re-spawns the process; a dead page can never recover on its own and leaves
+/// an uncloseable blank white popover). The ping is deliberate — macOS
+/// visibilitychange is not guaranteed to fire across native orderOut/
+/// orderFrontRegardless transitions, so the frontend's own beats can lag.
+fn watchdog_check_after_show(window: tauri::WebviewWindow, shown_at_ms: u64) {
+    // Safety: eval() runs a fixed compile-time constant in our own webview —
+    // no user or external input is interpolated into the script.
+    let _ = window.eval("window.__heartbeat && window.__heartbeat()");
+    std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(1500));
+        if !window.is_visible().unwrap_or(false) {
+            return;
+        }
+        if WEBVIEW_HEARTBEAT_MS.load(Ordering::SeqCst) >= shown_at_ms {
+            return;
+        }
+        eprintln!("[WATCHDOG] no heartbeat after show — reloading dead webview");
+        let _ = window.reload();
+    });
+}
+
+#[tauri::command]
 fn show_window(window: tauri::WebviewWindow) {
     eprintln!("[CMD] show_window called");
     let _ = window.show();
@@ -892,6 +932,7 @@ pub fn run() {
             get_home_dir,
             set_dialog_open,
             hide_window,
+            heartbeat,
             show_window,
             get_pending_deep_link,
             quit_app,
@@ -950,6 +991,8 @@ pub fn run() {
                                     let _ = window.show();
                                     let _ = window.set_focus();
                                 }
+
+                                watchdog_check_after_show(window.clone(), now_ms);
                             }
                         }
                     }

--- a/src-tauri/src/providers/pricing.rs
+++ b/src-tauri/src/providers/pricing.rs
@@ -560,6 +560,50 @@ mod tests {
         assert!((p.input - 2.50).abs() < 0.001);
     }
 
+    // Regression guard: the GPT-5.6 tiers (Sol/Terra/Luna, GA 2026-07-09) must
+    // each match their own entry instead of falling through the substring chain
+    // to bare "gpt-5" ($1.25/$10) — Sol would be under-billed 4x, Luna
+    // over-billed on input.
+    #[test]
+    fn codex_gpt56_sol_pricing() {
+        let p = get_codex_pricing("gpt-5.6-sol");
+        assert!((p.input - 5.00).abs() < 0.001, "gpt-5.6-sol input must be $5/MTok, got ${}", p.input);
+        assert!((p.output - 30.00).abs() < 0.001, "gpt-5.6-sol output must be $30/MTok, got ${}", p.output);
+        assert!((p.cached_input - 0.50).abs() < 0.001);
+    }
+
+    #[test]
+    fn codex_gpt56_terra_pricing() {
+        let p = get_codex_pricing("gpt-5.6-terra");
+        assert!((p.input - 2.50).abs() < 0.001, "gpt-5.6-terra input must be $2.5/MTok, got ${}", p.input);
+        assert!((p.output - 15.00).abs() < 0.001);
+        assert!((p.cached_input - 0.25).abs() < 0.001);
+    }
+
+    #[test]
+    fn codex_gpt56_luna_pricing() {
+        let p = get_codex_pricing("gpt-5.6-luna");
+        assert!((p.input - 1.00).abs() < 0.001, "gpt-5.6-luna input must be $1/MTok, got ${}", p.input);
+        assert!((p.output - 6.00).abs() < 0.001);
+        assert!((p.cached_input - 0.10).abs() < 0.001);
+    }
+
+    // Bare "gpt-5.6" (no tier suffix) is priced at the flagship Sol rate and
+    // must not fall through to the bare "gpt-5" entry.
+    #[test]
+    fn codex_gpt56_bare_not_billed_as_gpt5() {
+        let p = get_codex_pricing("gpt-5.6");
+        assert!((p.input - 5.00).abs() < 0.001, "gpt-5.6 input must be $5/MTok, got ${}", p.input);
+        assert!((p.output - 30.00).abs() < 0.001);
+    }
+
+    #[test]
+    fn opencode_gpt56_terra_pricing() {
+        let p = get_opencode_pricing("openai/gpt-5.6-terra");
+        assert!((p.input - 2.50).abs() < 0.001, "opencode gpt-5.6-terra input must be $2.5/MTok, got ${}", p.input);
+        assert!((p.output - 15.00).abs() < 0.001);
+    }
+
     // Regression guard: "gpt-5-codex" (the default Codex CLI model) must match
     // its own entry, not fall through to the gpt-5.4 default and get billed at
     // $2.50/$15 instead of the correct $1.25/$10 (~1.9x overcharge). Reporter saw

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import { useState, useMemo, useEffect } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import { useCombinedStats } from "./hooks/useCombinedStats";
 import { useToday } from "./hooks/useToday";
 import { useUnreadChat } from "./hooks/useUnreadChat";
@@ -60,18 +59,9 @@ function AnalyticsEmptyState({ message }: { message: string }) {
 }
 
 function AppContent() {
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      // Only hide the window if no overlay/modal has already handled this Escape press
-      if (e.key === "Escape" && !e.defaultPrevented) {
-        invoke("hide_window").catch(() => {});
-      }
-    };
-    // Use capture=false so modal keydown handlers (which run first) can call
-    // e.preventDefault() to stop this from also closing the window.
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, []);
+  // Escape → hide-window handling lives in main.tsx (module level) so it
+  // survives React crashes; modal handlers still preempt it via capture-phase
+  // preventDefault.
   const { prefs } = useSettings();
   const { stats, error, loading } = useCombinedStats({
     includeClaude: prefs.include_claude,

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -4,6 +4,8 @@ import type { ChatMessage as ChatMessageData, ReactionMap, ReactionType } from "
 import { useMiniProfile } from "../contexts/MiniProfileContext";
 import { useI18n } from "../i18n/I18nContext";
 import { RichMessageContent } from "./RichMessageContent";
+import { getOrFetchProfile } from "../lib/profileCache";
+import { supabase } from "../lib/supabase";
 
 export function ReplyIcon({ size = 12 }: { size?: number }) {
   return (
@@ -72,6 +74,127 @@ const REACTION_EMOJIS: { type: ReactionType; emoji: string }[] = [
   { type: "dislike", emoji: "👎" },
 ];
 
+/** How many reactor names the hover tooltip spells out before collapsing the
+ *  rest into "and N more" — keeps a 100-like message readable. */
+const MAX_REACTOR_NAMES = 3;
+
+function fetchReactorProfile(uid: string) {
+  return getOrFetchProfile(uid, async () => {
+    if (!supabase) return { nickname: "Unknown", avatar_url: null };
+    const { data } = await supabase
+      .from("profiles")
+      .select("nickname, avatar_url")
+      .eq("id", uid)
+      .single();
+    return {
+      nickname: data?.nickname ?? "Unknown",
+      avatar_url: data?.avatar_url ?? null,
+    };
+  });
+}
+
+/** One reaction button with a hover tooltip naming who reacted ("나, Alice,
+ *  Bob 외 97명"). Names resolve through the shared profile cache, so repeat
+ *  hovers are instant and only the displayed few are ever fetched. */
+function ReactionChip({
+  emoji,
+  reactorIds,
+  isMine,
+  myUserId,
+  align,
+  onClick,
+}: {
+  emoji: string;
+  reactorIds: string[];
+  isMine: boolean;
+  myUserId?: string;
+  align: "left" | "right";
+  onClick: () => void;
+}) {
+  const t = useI18n();
+  const [showTip, setShowTip] = useState(false);
+  const [tip, setTip] = useState<string | null>(null);
+  const hoverSeq = useRef(0);
+  const count = reactorIds.length;
+
+  const onEnter = () => {
+    if (count === 0) return;
+    setTip(null); // drop the previous hover's names while fresh ones resolve
+    setShowTip(true);
+    const seq = ++hoverSeq.current;
+    // Put myself first (like most chat apps), then the rest in stored order.
+    const ordered = isMine && myUserId
+      ? [myUserId, ...reactorIds.filter((id) => id !== myUserId)]
+      : reactorIds;
+    const shown = ordered.slice(0, MAX_REACTOR_NAMES);
+    Promise.all(
+      shown.map((id) =>
+        id === myUserId
+          ? Promise.resolve(t("chat.reactedBy.you"))
+          : fetchReactorProfile(id).then((p) => p.nickname),
+      ),
+    ).then((names) => {
+      if (hoverSeq.current !== seq) return; // hover moved on
+      const extra = ordered.length - shown.length;
+      setTip(
+        extra > 0
+          ? t("chat.reactedBy.more", { names: names.join(", "), count: extra })
+          : names.join(", "),
+      );
+    });
+  };
+
+  return (
+    <span
+      style={{ position: "relative", display: "inline-flex" }}
+      onMouseEnter={onEnter}
+      onMouseLeave={() => setShowTip(false)}
+    >
+      <button
+        onClick={onClick}
+        style={{
+          background: isMine ? "rgba(124, 92, 252, 0.15)" : "transparent",
+          border: isMine ? "1px solid rgba(124, 92, 252, 0.3)" : "1px solid transparent",
+          borderRadius: 10,
+          padding: "1px 5px",
+          fontSize: 10,
+          cursor: "pointer",
+          display: "flex",
+          alignItems: "center",
+          gap: 2,
+          color: "var(--text-secondary)",
+          lineHeight: 1.4,
+        }}
+      >
+        <span style={{ fontSize: 9 }}>{emoji}</span>
+        {count > 0 && <span style={{ fontSize: 8, fontWeight: 700 }}>{count}</span>}
+      </button>
+      {showTip && tip && count > 0 && (
+        <span style={{
+          position: "absolute",
+          bottom: "calc(100% + 4px)",
+          ...(align === "right" ? { right: 0 } : { left: 0 }),
+          background: "var(--text-primary)",
+          color: "var(--bg-primary)",
+          padding: "3px 8px",
+          borderRadius: 6,
+          fontSize: 9,
+          fontWeight: 600,
+          whiteSpace: "nowrap",
+          maxWidth: 240,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          pointerEvents: "none",
+          zIndex: 30,
+          boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
+        }}>
+          {tip}
+        </span>
+      )}
+    </span>
+  );
+}
+
 /** Combined reaction + action toolbar below each bubble. Fixed height to prevent layout shift. */
 function BubbleToolbar({
   reactions,
@@ -133,30 +256,19 @@ function BubbleToolbar({
     }}>
       {/* Reactions */}
       {showReactions && REACTION_EMOJIS.map(({ type, emoji }) => {
-        const count = reactions?.[type]?.length ?? 0;
-        const isMine = reactions?.[type]?.includes(userId!) ?? false;
-        if (count === 0 && !hovered) return null;
+        const ids = reactions?.[type] ?? [];
+        const isMine = userId ? ids.includes(userId) : false;
+        if (ids.length === 0 && !hovered) return null;
         return (
-          <button
+          <ReactionChip
             key={type}
+            emoji={emoji}
+            reactorIds={ids}
+            isMine={isMine}
+            myUserId={userId}
+            align={align}
             onClick={() => onReact!(messageId, type)}
-            style={{
-              background: isMine ? "rgba(124, 92, 252, 0.15)" : "transparent",
-              border: isMine ? "1px solid rgba(124, 92, 252, 0.3)" : "1px solid transparent",
-              borderRadius: 10,
-              padding: "1px 5px",
-              fontSize: 10,
-              cursor: "pointer",
-              display: "flex",
-              alignItems: "center",
-              gap: 2,
-              color: "var(--text-secondary)",
-              lineHeight: 1.4,
-            }}
-          >
-            <span style={{ fontSize: 9 }}>{emoji}</span>
-            {count > 0 && <span style={{ fontSize: 8, fontWeight: 700 }}>{count}</span>}
-          </button>
+          />
         );
       })}
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -291,6 +291,8 @@
   "chat.typing.many": "{{name}} und {{count}} weitere tippen...",
   "chat.notification.mention": "{{name}} hat dich erwähnt",
   "chat.notification.reply": "{{name}} hat auf deine Nachricht geantwortet",
+  "chat.reactedBy.you": "Du",
+  "chat.reactedBy.more": "{{names}} und {{count}} weitere",
   "settings.aiTranslation": "KI-Übersetzung",
   "settings.aiKeyGemini": "Gemini API-Schlüssel",
   "settings.aiKeyOpenAI": "OpenAI API-Schlüssel",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -297,6 +297,8 @@
   "chat.typing.many": "{{name}} and {{count}} others are typing...",
   "chat.notification.mention": "{{name}} mentioned you",
   "chat.notification.reply": "{{name}} replied to your message",
+  "chat.reactedBy.you": "You",
+  "chat.reactedBy.more": "{{names}} and {{count}} more",
   "settings.aiTranslation": "AI Translation",
   "settings.aiKeyGemini": "Gemini API Key",
   "settings.aiKeyOpenAI": "OpenAI API Key",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -291,6 +291,8 @@
   "chat.typing.many": "{{name}} y {{count}} más están escribiendo...",
   "chat.notification.mention": "{{name}} te mencionó",
   "chat.notification.reply": "{{name}} respondió a tu mensaje",
+  "chat.reactedBy.you": "Tú",
+  "chat.reactedBy.more": "{{names}} y {{count}} más",
   "settings.aiTranslation": "Traducción IA",
   "settings.aiKeyGemini": "Clave API de Gemini",
   "settings.aiKeyOpenAI": "Clave API de OpenAI",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -291,6 +291,8 @@
   "chat.typing.many": "{{name}} et {{count}} autres sont en train d'écrire...",
   "chat.notification.mention": "{{name}} vous a mentionné",
   "chat.notification.reply": "{{name}} a répondu à votre message",
+  "chat.reactedBy.you": "Vous",
+  "chat.reactedBy.more": "{{names}} et {{count}} autres",
   "settings.aiTranslation": "Traduction IA",
   "settings.aiKeyGemini": "Clé API Gemini",
   "settings.aiKeyOpenAI": "Clé API OpenAI",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -291,6 +291,8 @@
   "chat.typing.many": "{{name}} e altri {{count}} stanno scrivendo...",
   "chat.notification.mention": "{{name}} ti ha menzionato",
   "chat.notification.reply": "{{name}} ha risposto al tuo messaggio",
+  "chat.reactedBy.you": "Tu",
+  "chat.reactedBy.more": "{{names}} e altri {{count}}",
   "settings.aiTranslation": "Traduzione AI",
   "settings.aiKeyGemini": "Chiave API Gemini",
   "settings.aiKeyOpenAI": "Chiave API OpenAI",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -291,6 +291,8 @@
   "chat.typing.many": "{{name}}さん他{{count}}人が入力中...",
   "chat.notification.mention": "{{name}}さんがあなたをメンションしました",
   "chat.notification.reply": "{{name}}さんがあなたのメッセージに返信しました",
+  "chat.reactedBy.you": "自分",
+  "chat.reactedBy.more": "{{names}} 他{{count}}人",
   "settings.aiTranslation": "AI翻訳",
   "settings.aiKeyGemini": "Gemini APIキー",
   "settings.aiKeyOpenAI": "OpenAI APIキー",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -297,6 +297,8 @@
   "chat.typing.many": "{{name}}님 외 {{count}}명이 입력 중...",
   "chat.notification.mention": "{{name}}님이 회원님을 멘션했습니다",
   "chat.notification.reply": "{{name}}님이 회원님의 메시지에 답글을 달았습니다",
+  "chat.reactedBy.you": "나",
+  "chat.reactedBy.more": "{{names}} 외 {{count}}명",
   "settings.aiTranslation": "AI 번역",
   "settings.aiKeyGemini": "Gemini API 키",
   "settings.aiKeyOpenAI": "OpenAI API 키",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -291,6 +291,8 @@
   "chat.typing.many": "{{name}} ve diğer {{count}} kişi yazıyor...",
   "chat.notification.mention": "{{name}} sizden bahsetti",
   "chat.notification.reply": "{{name}} mesajınızı yanıtladı",
+  "chat.reactedBy.you": "Siz",
+  "chat.reactedBy.more": "{{names}} ve {{count}} kişi daha",
   "settings.aiTranslation": "AI Çeviri",
   "settings.aiKeyGemini": "Gemini API Anahtarı",
   "settings.aiKeyOpenAI": "OpenAI API Anahtarı",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -291,6 +291,8 @@
   "chat.typing.many": "{{name}}和其他{{count}}人正在输入...",
   "chat.notification.mention": "{{name}}提到了你",
   "chat.notification.reply": "{{name}}回复了你的消息",
+  "chat.reactedBy.you": "我",
+  "chat.reactedBy.more": "{{names}} 及其他 {{count}} 人",
   "settings.aiTranslation": "AI翻译",
   "settings.aiKeyGemini": "Gemini API密钥",
   "settings.aiKeyOpenAI": "OpenAI API密钥",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -291,6 +291,8 @@
   "chat.typing.many": "{{name}}和其他{{count}}人正在輸入...",
   "chat.notification.mention": "{{name}}提到了你",
   "chat.notification.reply": "{{name}}回覆了你的訊息",
+  "chat.reactedBy.you": "我",
+  "chat.reactedBy.more": "{{names}} 及其他 {{count}} 人",
   "settings.aiTranslation": "AI翻譯",
   "settings.aiKeyGemini": "Gemini API金鑰",
   "settings.aiKeyOpenAI": "OpenAI API金鑰",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,99 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { invoke } from "@tauri-apps/api/core";
 import App from "./App";
 import "./styles/global.css";
 
 // Disable default browser context menu so custom menus work
 document.addEventListener("contextmenu", (e) => e.preventDefault());
+
+// ---------------------------------------------------------------------------
+// Everything below lives at module level, OUTSIDE React, so it keeps working
+// even if the React tree crashes and unmounts.
+// ---------------------------------------------------------------------------
+
+// Webview liveness heartbeat: the Rust side shows the window, waits briefly,
+// and reloads the webview if no beat arrived (dead WKWebView content process
+// renders an uncloseable blank white popover). Beat on an interval and
+// immediately on every popover open (visibilitychange→visible).
+const sendHeartbeat = () => {
+  invoke("heartbeat").catch(() => {});
+};
+sendHeartbeat();
+setInterval(sendHeartbeat, 15_000);
+document.addEventListener("visibilitychange", () => {
+  if (document.visibilityState === "visible") sendHeartbeat();
+});
+// The Rust watchdog eval()s this right after showing the window: an alive
+// page answers instantly, a dead content process silently drops the eval.
+// Direct ping, because visibilitychange is not guaranteed to fire across
+// native NSWindow orderOut/orderFrontRegardless transitions.
+(window as unknown as { __heartbeat: () => void }).__heartbeat = sendHeartbeat;
+
+// Escape → hide window. Bubble phase on window: modal/overlay handlers use
+// capture phase on document and call preventDefault() to keep the window open
+// while closing only themselves.
+window.addEventListener("keydown", (e) => {
+  if (e.key === "Escape" && !e.defaultPrevented) {
+    invoke("hide_window").catch(() => {});
+  }
+});
+
+// Crash fallback: when an uncaught error unmounts the React root, show a
+// minimal vanilla-DOM card so the user can reload or close instead of being
+// stuck on a blank window.
+function showCrashFallback() {
+  const root = document.getElementById("root");
+  if (!root || root.childElementCount > 0) return; // React tree still alive
+  if (document.getElementById("crash-fallback")) return;
+
+  const ko = navigator.language.startsWith("ko");
+  const dark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+
+  const overlay = document.createElement("div");
+  overlay.id = "crash-fallback";
+  overlay.style.cssText = [
+    "position:fixed", "inset:0", "display:flex", "align-items:center",
+    "justify-content:center", "padding:24px",
+    `background:${dark ? "#0d1117" : "#ffffff"}`,
+    `color:${dark ? "#e6edf3" : "#1f2328"}`,
+    "font-family:-apple-system,BlinkMacSystemFont,sans-serif",
+  ].join(";");
+
+  const card = document.createElement("div");
+  card.style.cssText = "max-width:300px;text-align:center;display:flex;flex-direction:column;gap:12px;";
+
+  const title = document.createElement("div");
+  title.style.cssText = "font-size:14px;font-weight:700;";
+  title.textContent = ko ? "문제가 발생했어요" : "Something went wrong";
+
+  const body = document.createElement("div");
+  body.style.cssText = `font-size:12px;line-height:1.5;color:${dark ? "#9ca3af" : "#656d76"};`;
+  body.textContent = ko
+    ? "화면을 그리는 중 오류가 발생했습니다. 새로고침하면 대부분 해결됩니다."
+    : "An error occurred while rendering. Reloading usually fixes it.";
+
+  const row = document.createElement("div");
+  row.style.cssText = "display:flex;gap:8px;justify-content:center;";
+
+  const reloadBtn = document.createElement("button");
+  reloadBtn.textContent = ko ? "새로고침" : "Reload";
+  reloadBtn.style.cssText = "padding:8px 16px;font-size:12px;font-weight:700;border:none;border-radius:8px;cursor:pointer;background:#2da44e;color:#fff;";
+  reloadBtn.addEventListener("click", () => location.reload());
+
+  const closeBtn = document.createElement("button");
+  closeBtn.textContent = ko ? "닫기" : "Close";
+  closeBtn.style.cssText = `padding:8px 16px;font-size:12px;font-weight:700;border:none;border-radius:8px;cursor:pointer;background:transparent;color:${dark ? "#9ca3af" : "#656d76"};`;
+  closeBtn.addEventListener("click", () => invoke("hide_window").catch(() => {}));
+
+  row.append(reloadBtn, closeBtn);
+  card.append(title, body, row);
+  overlay.append(card);
+  document.body.appendChild(overlay);
+}
+
+window.addEventListener("error", () => setTimeout(showCrashFallback, 50));
+window.addEventListener("unhandledrejection", () => setTimeout(showCrashFallback, 50));
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
## 요약

사용자 영향이 큰 수정 1건 + 기능 2건입니다.

### 1. 빈 창(흰 화면) 버그 수정 🔧
트레이 상주 중 WKWebView 콘텐츠 프로세스가 죽으면(메모리 압박·절전 복귀) 흰 창만 뜨고 Escape로도 닫을 수 없던 문제:
- **Rust 워치독**: 창 표시 직후 `eval()` ping → 1.5초 내 heartbeat 무응답이면 죽은 프로세스로 판정, `reload()`로 재생성. visibilitychange 대신 직접 ping이라 빠른 여닫기 오탐 없음
- **Escape 핸들러를 main.tsx 모듈 레벨로 이전** — React 크래시에도 창 닫기 생존
- **크래시 폴백 카드** — React 트리 언마운트 시 순정 DOM으로 [새로고침]/[닫기] 제공

### 2. GPT-5.6 가격 추가 (pricing v1.8.0) 💰
공식 페이지 기준 Sol($5/$30)·Terra($2.5/$15)·Luna($1/$6) + 방어용 bare `gpt-5.6`(Sol 요율)을 codex/opencode 양쪽 목록 최상단에 추가. 항목이 없으면 substring 폴백으로 `gpt-5`($1.25/$10)에 매칭되어 Sol이 4배 과소청구되는 구조라 순서가 중요. 회귀 테스트 5개 추가.

### 3. 리액션 호버 시 누른 사람 표시 👍
리액션 칩에 호버하면 닉네임 툴팁 표시. 최대 3명 + "외 N명"으로 요약(100명이 눌러도 프로필 조회는 3건), 본인이 맨 앞, 공유 프로필 캐시 재사용. 10개 로케일 번역 포함.

## 테스트
- `npm run build` + `cargo test --lib` 109개 통과
- 코드리뷰 수행: 워치독 visibilitychange 오탐 지적(신뢰도 85) → eval ping 방식으로 반영, `WebviewWindow::reload()` 스레드 안전성은 tauri 소스로 검증됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)