### PR TITLE
feat: 업데이트 전 변경 내용 미리보기 팝오버

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from "react";
+import { parseReleaseNotes, categoryEmoji } from "../lib/releaseNotes";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
@@ -481,7 +482,24 @@ const indicatorWrapStyle: React.CSSProperties = {
 };
 
 function UpdateIndicator({ updater, t }: { updater: UpdaterState; t: ReturnType<typeof useI18n> }) {
-  const { version, downloading, downloaded, progress, error, restartFailed, download, install } = updater;
+  const { version, notes, downloading, downloaded, progress, error, restartFailed, download, install } = updater;
+  const [showNotes, setShowNotes] = useState(false);
+  const noteItems = parseReleaseNotes(notes);
+
+  // Close the what's-new popover on Escape without hiding the window
+  // (capture + preventDefault, the app-wide modal convention).
+  useEffect(() => {
+    if (!showNotes) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        setShowNotes(false);
+      }
+    };
+    document.addEventListener("keydown", onKey, true);
+    return () => document.removeEventListener("keydown", onKey, true);
+  }, [showNotes]);
 
   const stopDrag = (e: React.MouseEvent) => e.stopPropagation();
 
@@ -527,11 +545,94 @@ function UpdateIndicator({ updater, t }: { updater: UpdaterState; t: ReturnType<
   }
 
   return (
-    <div style={indicatorWrapStyle} onMouseDown={stopDrag}>
-      <span style={{ color: "var(--accent, #3b82f6)" }}>
-        {t("update.available", { version })}
-      </span>
+    <div style={{ ...indicatorWrapStyle, position: "relative" }} onMouseDown={stopDrag}>
+      {noteItems.length > 0 ? (
+        <button
+          onClick={() => setShowNotes((v) => !v)}
+          title={t("update.whatsNew", { version })}
+          style={{
+            background: "none",
+            border: "none",
+            padding: 0,
+            font: "inherit",
+            color: "var(--accent, #3b82f6)",
+            cursor: "pointer",
+            textDecoration: "underline dotted",
+            textUnderlineOffset: 3,
+          }}
+        >
+          {t("update.available", { version })}
+        </button>
+      ) : (
+        <span style={{ color: "var(--accent, #3b82f6)" }}>
+          {t("update.available", { version })}
+        </span>
+      )}
       <button onClick={download} style={indicatorBtnStyle}>{t("update.download")}</button>
+
+      {showNotes && noteItems.length > 0 && (
+        <>
+          {/* click-away backdrop */}
+          <div
+            style={{ position: "fixed", inset: 0, zIndex: 99 }}
+            onClick={() => setShowNotes(false)}
+          />
+          <div style={{
+            position: "absolute",
+            top: "100%",
+            // Anchored to the indicator's left edge: the indicator sits near
+            // the window's left side, so centering (translateX(-50%)) would
+            // push the card past PopoverShell's overflow:hidden boundary.
+            left: 0,
+            marginTop: 8,
+            width: 270,
+            padding: "12px 14px",
+            borderRadius: "var(--radius-md)",
+            background: "var(--bg-card)",
+            color: "var(--text-primary)",
+            boxShadow: "0 4px 20px rgba(0,0,0,0.25)",
+            border: "1px solid rgba(124, 92, 252, 0.15)",
+            zIndex: 100,
+            animation: "toast-in 0.2s ease",
+            display: "flex",
+            flexDirection: "column",
+            gap: 8,
+            cursor: "default",
+          }}>
+            <div style={{ fontSize: 12, fontWeight: 800 }}>
+              {t("update.whatsNew", { version })}
+            </div>
+            <ul style={{
+              margin: 0,
+              padding: 0,
+              listStyle: "none",
+              display: "flex",
+              flexDirection: "column",
+              gap: 5,
+              maxHeight: 180,
+              overflowY: "auto",
+              fontSize: 11,
+              lineHeight: 1.45,
+              color: "var(--text-secondary)",
+              textAlign: "left",
+              fontWeight: 500,
+            }}>
+              {noteItems.map((item, i) => (
+                <li key={i} style={{ display: "flex", gap: 6 }}>
+                  <span style={{ flexShrink: 0 }}>{categoryEmoji(item.category)}</span>
+                  <span>{item.text}</span>
+                </li>
+              ))}
+            </ul>
+            <button
+              onClick={() => { setShowNotes(false); download(); }}
+              style={{ ...indicatorBtnStyle, padding: "6px 0", fontSize: 11, width: "100%" }}
+            >
+              {t("update.download")}
+            </button>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/hooks/useUpdater.ts
+++ b/src/hooks/useUpdater.ts
@@ -6,6 +6,8 @@ import { invoke } from "@tauri-apps/api/core";
 export interface UpdaterState {
   updateAvailable: boolean;
   version: string;
+  /** Release-notes markdown from latest.json (empty when the manifest has none). */
+  notes: string;
   downloading: boolean;
   downloaded: boolean;
   progress: number;
@@ -18,6 +20,7 @@ export interface UpdaterState {
 export function useUpdater(): UpdaterState {
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const [version, setVersion] = useState("");
+  const [notes, setNotes] = useState("");
   const [downloading, setDownloading] = useState(false);
   const [downloaded, setDownloaded] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -36,6 +39,7 @@ export function useUpdater(): UpdaterState {
         if (update) {
           updateRef.current = update;
           setVersion(update.version);
+          setNotes(update.body ?? "");
           setUpdateAvailable(true);
         }
       } catch (e) {
@@ -107,6 +111,7 @@ export function useUpdater(): UpdaterState {
   return {
     updateAvailable,
     version,
+    notes,
     downloading,
     downloaded,
     progress,

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -236,6 +236,7 @@
   "update.restartBtn": "Neustarten",
   "update.error": "Update fehlgeschlagen",
   "update.restartManual": "Bitte manuell neu starten",
+  "update.whatsNew": "Neu in v{{version}}",
   "settings.usageAlerts": "Nutzungswarnungen",
   "settings.usageTracking": "Nutzungsverfolgung",
   "usageAlert.title": "Nutzung",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -242,6 +242,7 @@
   "update.restartBtn": "Restart",
   "update.error": "Update failed",
   "update.restartManual": "Please restart manually",
+  "update.whatsNew": "What's new in v{{version}}",
   "settings.usageAlerts": "Usage Alerts",
   "settings.usageTracking": "Usage Tracking",
   "usageAlert.title": "Usage",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -236,6 +236,7 @@
   "update.restartBtn": "Reiniciar",
   "update.error": "Error de actualización",
   "update.restartManual": "Reinicie manualmente",
+  "update.whatsNew": "Novedades de la v{{version}}",
   "settings.usageAlerts": "Alertas de uso",
   "settings.usageTracking": "Seguimiento de uso",
   "usageAlert.title": "Uso",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -236,6 +236,7 @@
   "update.restartBtn": "Redémarrer",
   "update.error": "Échec de la mise à jour",
   "update.restartManual": "Veuillez redémarrer manuellement",
+  "update.whatsNew": "Nouveautés de la v{{version}}",
   "settings.usageAlerts": "Alertes d'utilisation",
   "settings.usageTracking": "Suivi d'utilisation",
   "usageAlert.title": "Utilisation",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -236,6 +236,7 @@
   "update.restartBtn": "Riavvia",
   "update.error": "Aggiornamento fallito",
   "update.restartManual": "Riavvia manualmente",
+  "update.whatsNew": "Novità della v{{version}}",
   "settings.usageAlerts": "Avvisi di utilizzo",
   "settings.usageTracking": "Monitoraggio utilizzo",
   "usageAlert.title": "Utilizzo",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -236,6 +236,7 @@
   "update.restartBtn": "再起動",
   "update.error": "更新に失敗しました",
   "update.restartManual": "手動で再起動してください",
+  "update.whatsNew": "v{{version}} の更新内容",
   "settings.usageAlerts": "使用量アラート",
   "settings.usageTracking": "使用量トラッキング",
   "usageAlert.title": "使用量",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -242,6 +242,7 @@
   "update.restartBtn": "재시작",
   "update.error": "업데이트 실패",
   "update.restartManual": "수동으로 재시작해주세요",
+  "update.whatsNew": "v{{version}} 업데이트 내용",
   "settings.usageAlerts": "사용량 알림",
   "settings.usageTracking": "사용량 추적",
   "usageAlert.title": "사용량",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -236,6 +236,7 @@
   "update.restartBtn": "Yeniden Başlat",
   "update.error": "Güncelleme başarısız",
   "update.restartManual": "Lütfen manuel olarak yeniden başlatın",
+  "update.whatsNew": "v{{version}} yenilikleri",
   "settings.usageAlerts": "Kullanım Uyarıları",
   "settings.usageTracking": "Kullanım Takibi",
   "usageAlert.title": "Kullanım",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -236,6 +236,7 @@
   "update.restartBtn": "重启",
   "update.error": "更新失败",
   "update.restartManual": "请手动重启",
+  "update.whatsNew": "v{{version}} 更新内容",
   "settings.usageAlerts": "用量提醒",
   "settings.usageTracking": "用量追踪",
   "usageAlert.title": "用量",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -236,6 +236,7 @@
   "update.restartBtn": "重啟",
   "update.error": "更新失敗",
   "update.restartManual": "請手動重啟",
+  "update.whatsNew": "v{{version}} 更新內容",
   "settings.usageAlerts": "用量提醒",
   "settings.usageTracking": "用量追蹤",
   "usageAlert.title": "用量",

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -1,0 +1,70 @@
+/** Parses the release-notes markdown that the Release workflow writes into
+ *  latest.json (surfaced as `update.body` by the updater plugin) into a short
+ *  human-readable list for the what's-new popover.
+ *
+ *  Input shape (see .github release workflow):
+ *    ## AI Token Monitor v0.19.37
+ *    ### Bug Fixes
+ *    - fix: 죽은 웹뷰 자동 복구 (#168) (7d9a882)
+ *    ### Download
+ *    - macOS ...   ← installer instructions, not a change — skipped
+ */
+
+export type ReleaseNoteCategory = "feature" | "fix" | "perf" | "other";
+
+export interface ReleaseNoteItem {
+  category: ReleaseNoteCategory;
+  text: string;
+}
+
+const CATEGORY_EMOJI: Record<ReleaseNoteCategory, string> = {
+  feature: "✨",
+  fix: "🐛",
+  perf: "⚡",
+  other: "📦",
+};
+
+export function categoryEmoji(category: ReleaseNoteCategory): string {
+  return CATEGORY_EMOJI[category];
+}
+
+function sectionCategory(title: string): ReleaseNoteCategory | null {
+  if (/download/i.test(title)) return null; // installer instructions, not changes
+  if (/feature/i.test(title)) return "feature";
+  if (/fix/i.test(title)) return "fix";
+  if (/perf/i.test(title)) return "perf";
+  return "other";
+}
+
+/** Strips conventional-commit noise so users read plain descriptions:
+ *  "fix(chat): show reactions (#168) (7d9a882)" → "show reactions". */
+function cleanItemText(raw: string): string {
+  return raw
+    .replace(/^(feat|fix|perf|chore|refactor|docs|style|test|build|ci)(\([^)]*\))?!?:\s*/i, "")
+    .replace(/\s*\(#\d+\)/g, "")
+    .replace(/\s*\([0-9a-f]{7,10}\)\s*$/i, "")
+    .trim();
+}
+
+export function parseReleaseNotes(body: string): ReleaseNoteItem[] {
+  const items: ReleaseNoteItem[] = [];
+  let category: ReleaseNoteCategory | null = "other";
+
+  for (const line of body.split("\n")) {
+    const trimmed = line.trim();
+    const section = trimmed.match(/^#{2,4}\s+(.+)$/);
+    if (section) {
+      // The "## AI Token Monitor vX.Y.Z" heading is a title, not a section.
+      category = /^ai token monitor/i.test(section[1])
+        ? "other"
+        : sectionCategory(section[1]);
+      continue;
+    }
+    const bullet = trimmed.match(/^[-*]\s+(.+)$/);
+    if (bullet && category !== null) {
+      const text = cleanItemText(bullet[1]);
+      if (text) items.push({ category, text });
+    }
+  }
+  return items;
+}


### PR DESCRIPTION
## 요약

업데이트 버튼을 누르기 전에 **이번 업데이트에 무엇이 포함됐는지** 확인할 수 있는 팝오버를 추가합니다.

- 릴리즈 노트는 이미 `latest.json`의 `notes`로 도착하고 있었으나(`update.body`) 앱이 버리고 있었음 — 네트워크 요청 추가 없이 구현
- 헤더의 "vX.Y.Z available" 라벨이 점선 밑줄 버튼이 되고, 클릭 시 팝오버 표시:
  - 카테고리 이모지(✨기능/🐛수정/⚡성능) + 항목 목록 + [업데이트] 버튼
  - `fix:`/`feat:` 접두사, PR 번호, 커밋 해시 제거 / "Download" 섹션 제외
  - 바깥 클릭·Escape로 닫힘 (Escape는 capture+preventDefault — 창 닫힘 방지 관례 준수)
- 노트가 없는 릴리즈는 기존 동작 유지
- `update.whatsNew` i18n 키 10개 로케일 추가

## 테스트
- `npm run build` 통과
- 파서를 실제 v0.19.37 노트로 검증 (Download 섹션 제외·접두사 제거·카테고리 분류 확인)
- 코드리뷰 1건 반영: 팝오버 중앙정렬이 440px 창의 overflow:hidden 경계를 벗어나는 문제 → 왼쪽 고정 배치

🤖 Generated with [Claude Code](https://claude.com/claude-code)