### PR TITLE
fix: 콜드 스타트 중 워치독 오탐 리로드 차단

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::sync::Mutex;
+use std::sync::OnceLock;
 use std::thread;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
@@ -24,6 +25,10 @@ static LAST_SHOWN_MS: AtomicU64 = AtomicU64::new(0);
 /// no beat arrives shortly after, the webview's content process is dead
 /// (WKWebView renders solid white and all JS stops) — we then reload it.
 static WEBVIEW_HEARTBEAT_MS: AtomicU64 = AtomicU64::new(0);
+
+/// Process start time — the watchdog never reloads during the cold-start
+/// window, when heavy first-parse CPU contention can delay ping round-trips.
+static PROCESS_START: OnceLock<Instant> = OnceLock::new();
 
 /// Stores a deep-link URL that arrived before the frontend was ready (cold start).
 /// The frontend can retrieve it via the `get_pending_deep_link` command.
@@ -839,16 +844,35 @@ fn heartbeat() {
 /// visibilitychange is not guaranteed to fire across native orderOut/
 /// orderFrontRegardless transitions, so the frontend's own beats can lag.
 fn watchdog_check_after_show(window: tauri::WebviewWindow, shown_at_ms: u64) {
+    // Cold-start grace: the first full JSONL parse can saturate CPU for
+    // minutes on heavy corpora, delaying ping round-trips far past any fixed
+    // window — and a content process that died this early is practically
+    // impossible. Reloading here would restart the frontend's stats fetches
+    // mid-parse and make startup dramatically slower, not faster.
+    let in_cold_start = PROCESS_START
+        .get()
+        .map_or(true, |s| s.elapsed() < std::time::Duration::from_secs(180));
+    if in_cold_start {
+        return;
+    }
     // Safety: eval() runs a fixed compile-time constant in our own webview —
     // no user or external input is interpolated into the script.
     let _ = window.eval("window.__heartbeat && window.__heartbeat()");
     std::thread::spawn(move || {
-        std::thread::sleep(std::time::Duration::from_millis(1500));
-        if !window.is_visible().unwrap_or(false) {
-            return;
-        }
-        if WEBVIEW_HEARTBEAT_MS.load(Ordering::SeqCst) >= shown_at_ms {
-            return;
+        // Two strikes before reloading: a single ping can lose the race
+        // against momentary CPU saturation (large JSONL re-parses); a
+        // genuinely dead content process fails both.
+        for attempt in 0..2 {
+            std::thread::sleep(std::time::Duration::from_millis(3000));
+            if !window.is_visible().unwrap_or(false) {
+                return;
+            }
+            if WEBVIEW_HEARTBEAT_MS.load(Ordering::SeqCst) >= shown_at_ms {
+                return;
+            }
+            if attempt == 0 {
+                let _ = window.eval("window.__heartbeat && window.__heartbeat()");
+            }
         }
         eprintln!("[WATCHDOG] no heartbeat after show — reloading dead webview");
         let _ = window.reload();
@@ -1137,6 +1161,8 @@ pub fn run() {
                     _ => {}
                 }
             });
+
+            let _ = PROCESS_START.set(Instant::now());
 
             // Initial tray cost update
             update_tray_title(&app.handle());


### PR DESCRIPTION
## 문제

v0.19.37 워치독이 ping 1회 1.5초 무응답만으로 웹뷰를 리로드함. 헤비 유저의 콜드 스타트에서는 첫 풀 JSONL 파싱이 수 분간 CPU를 포화시켜 ping 왕복이 밀릴 수 있는데, 이때 **살아있는 웹뷰를 오판 리로드** → 프론트가 리마운트되며 스탯 요청을 재발사 → 파싱과 겹쳐 시작이 오히려 크게 느려짐.

## 해결

- **시작 후 180초 리로드 금지**: 이 구간에 콘텐츠 프로세스가 죽어 있을 가능성은 사실상 0. 최악의 경우에도 해당 구간만 워치독 도입 이전 동작으로 폴백
- **2-스트라이크**: 3초 무응답 → 재핑 → 다시 3초 무응답일 때만 리로드. 일시적 CPU 포화는 두 번 연속 실패하지 않고, 진짜 죽은 프로세스는 둘 다 실패 (감지 시간 1.5초 → 약 6초)

리로드를 덜 하게 만드는 순수 게이팅 변경이라 실패 모드가 양성(감지 지연)임. eval/reload 스레드 안전성은 PR #168 리뷰에서 검증됨.

## 테스트
- `cargo test --lib` 109개 통과
- 실기기 진단 근거: 22:22 시작 → 22:24 warm (콜드 파싱 ~2분 실측, $1.3k/day 코퍼스)

🤖 Generated with [Claude Code](https://claude.com/claude-code)