### PR TITLE
fix: macOS 채팅 한글 자모 분리 입력 수정

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -600,10 +600,10 @@ fn start_file_watcher(app_handle: tauri::AppHandle) {
     });
 }
 
-/// Bring the app to the foreground so WKWebView renders.
+/// Bring the app to the foreground so WKWebView renders and input methods
+/// (Korean/CJK IME composition) work — both require an active app.
 /// Required on macOS 26 Tahoe where the app runs as Accessory policy
 /// and won't auto-activate — without this the window appears but content is white.
-/// Skipped in fullscreen Spaces to avoid Space-switching.
 #[cfg(target_os = "macos")]
 fn activate_app() {
     #[allow(deprecated)]
@@ -792,10 +792,14 @@ fn show_window_native(window: &tauri::WebviewWindow) {
 
             let in_fullscreen = is_fullscreen_space();
             if in_fullscreen {
-                // In fullscreen: skip activateIgnoringOtherApps to avoid
-                // Space-switching. The window is already visible via
-                // orderFrontRegardless + CanJoinAllSpaces + FullScreenAuxiliary.
-                // Try to accept keyboard input without full activation.
+                // The panel is already frontmost on the fullscreen Space via
+                // orderFrontRegardless + CanJoinAllSpaces + FullScreenAuxiliary,
+                // so activating the app here does not reorder windows into
+                // another Space. Activation is REQUIRED for text input: macOS
+                // input methods only compose inside the active app — without
+                // it, Korean typing in chat degrades to raw compatibility jamo
+                // ("자모 분리", user report 2026-07-13).
+                activate_app();
                 let _: () = msg_send![ns_win, makeKeyWindow];
             } else {
                 // Normal desktop: activate app (needed for WKWebView on Tahoe)

--- a/src/components/ChatRoom.tsx
+++ b/src/components/ChatRoom.tsx
@@ -258,11 +258,17 @@ function ChatContent({ userId, activated, visible }: { userId: string; activated
   }, [input, sending, sendMessage, replyingTo, translatingReply, pendingImage, uploadingImage, userId, stopTyping]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    // A composing Enter is the IME committing the current syllable, not a
+    // command — keep it away from BOTH the mention autocomplete (which would
+    // insert the highlighted suggestion) and the send path. Arrow keys etc.
+    // still reach the mention dropdown while composing.
+    const composingEnter = e.key === "Enter" && e.nativeEvent.isComposing;
     // Delegate to mention autocomplete first
-    if (mentionState && mentionRef.current?.handleKeyDown(e)) {
+    if (mentionState && !composingEnter && mentionRef.current?.handleKeyDown(e)) {
       return;
     }
     if (e.key === "Enter" && !e.shiftKey) {
+      if (composingEnter) return;
       e.preventDefault();
       handleSend();
     }

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -347,7 +347,9 @@ export function useChat(userId: string | null, enabled: boolean = true, visible:
   const sendMessage = useCallback(async (content: string, replyTo?: string, imageUrl?: string): Promise<{ error?: string }> => {
     if (!supabase || !userId) return { error: "Not authenticated" };
 
-    const trimmed = content.trim();
+    // NFC-normalize so decomposed Hangul (NFD from some IMEs/paste sources)
+    // is stored precomposed and renders identically for every reader.
+    const trimmed = content.trim().normalize("NFC");
     if (!trimmed && !imageUrl) return { error: "Invalid message" };
     if (trimmed.length > 500) return { error: "Invalid message" };
 


### PR DESCRIPTION
## 문제 (사용자 제보)

macOS에서 채팅 메시지가 "ㅁㅐㄱㅇㅔㅅㅓ ㅈㅏㅁㅗㅂㅜㄴㄹㅣㄱㅏ ㄷㅗㅣㄴㅔㅇㅛ"처럼 자모 낱자로 전송되는 현상.

## 원인

팝오버는 NonActivatingPanel + Accessory 앱인데, **풀스크린 Space 표시 경로는 Space 전환 방지를 위해 앱 활성화를 생략**해 왔음. macOS 입력기(IME)는 활성 앱에서만 조합이 동작하므로, 풀스크린 앱 위에서 팝오버를 열고 한글을 치면 조합 없이 호환 자모가 낱자로 입력됨.

## 수정

1. **풀스크린 분기에서도 `activate_app()` 호출** — 창은 이미 orderFrontRegardless + FullScreenAuxiliary로 해당 Space 최전면에 있어 활성화가 Space를 옮기지 않음 (Raycast류와 동일 구성)
2. **조합 중 Enter 가드** — 전송·멘션 삽입 모두 차단 (조합 중 화살표 키는 멘션 드롭다운에 정상 전달)
3. **전송 시 NFC 정규화** — NFD 유입(일부 IME/붙여넣기) 방어

## 수동 검증 필요

- [ ] 풀스크린 앱 위에서 팝오버 열기 → Space가 데스크탑으로 전환되지 않는지
- [ ] 같은 상태에서 채팅 한글 입력 → 정상 조합되는지

## 테스트
- `npm run build` + `cargo test --lib` 109개 통과
- 코드리뷰 1건 반영 (멘션 드롭다운 + 조합 Enter 충돌)

🤖 Generated with [Claude Code](https://claude.com/claude-code)