### PR TITLE
feat(pricing): add Claude Opus 5 support

### DIFF
--- a/src-tauri/pricing.json
+++ b/src-tauri/pricing.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.8.0",
-  "last_updated": "2026-07-11",
+  "version": "1.9.0",
+  "last_updated": "2026-07-25",
   "sources": {
     "claude": "https://platform.claude.com/docs/en/about-claude/pricing",
     "codex": "https://developers.openai.com/api/docs/pricing"
@@ -12,6 +12,7 @@
       { "match": "fable",     "label": "Fable 5",              "input": 10.0, "output": 50.0,  "cache_read": 1.00, "cache_write": 12.5,  "cache_write_1h": 20.0  },
       { "match": "mythos-5",  "label": "Mythos 5",             "input": 10.0, "output": 50.0,  "cache_read": 1.00, "cache_write": 12.5,  "cache_write_1h": 20.0  },
       { "match": "mythos",    "label": "Mythos 5",             "input": 10.0, "output": 50.0,  "cache_read": 1.00, "cache_write": 12.5,  "cache_write_1h": 20.0  },
+      { "match": "opus-5",    "label": "Opus 5",               "input": 5.0,  "output": 25.0,  "cache_read": 0.50, "cache_write": 6.25,  "cache_write_1h": 10.0  },
       { "match": "opus-4-8",  "label": "Opus 4.8/4.7/4.6/4.5", "input": 5.0,  "output": 25.0,  "cache_read": 0.50, "cache_write": 6.25,  "cache_write_1h": 10.0  },
       { "match": "opus-4-7",  "label": "Opus 4.8/4.7/4.6/4.5", "input": 5.0,  "output": 25.0,  "cache_read": 0.50, "cache_write": 6.25,  "cache_write_1h": 10.0  },
       { "match": "opus-4-6",  "label": "Opus 4.8/4.7/4.6/4.5", "input": 5.0,  "output": 25.0,  "cache_read": 0.50, "cache_write": 6.25,  "cache_write_1h": 10.0  },
@@ -71,6 +72,7 @@
       { "match": "fable",             "label": "Claude Fable 5",               "input": 10.0,  "output": 50.0,   "cache_read": 1.00,  "cache_write": 12.5   },
       { "match": "mythos-5",          "label": "Claude Mythos 5",              "input": 10.0,  "output": 50.0,   "cache_read": 1.00,  "cache_write": 12.5   },
       { "match": "mythos",            "label": "Claude Mythos 5",              "input": 10.0,  "output": 50.0,   "cache_read": 1.00,  "cache_write": 12.5   },
+      { "match": "opus-5",            "label": "Claude Opus 5",                "input": 5.0,   "output": 25.0,   "cache_read": 0.50,  "cache_write": 6.25   },
       { "match": "opus-4-8",          "label": "Claude Opus 4.8/4.7/4.6/4.5", "input": 5.0,   "output": 25.0,   "cache_read": 0.50,  "cache_write": 6.25   },
       { "match": "opus-4-7",          "label": "Claude Opus 4.8/4.7/4.6/4.5", "input": 5.0,   "output": 25.0,   "cache_read": 0.50,  "cache_write": 6.25   },
       { "match": "opus-4-6",          "label": "Claude Opus 4.8/4.7/4.6/4.5", "input": 5.0,   "output": 25.0,   "cache_read": 0.50,  "cache_write": 6.25   },

--- a/src-tauri/src/providers/pricing.rs
+++ b/src-tauri/src/providers/pricing.rs
@@ -452,6 +452,48 @@ mod tests {
         assert!((p.cache_write_1h - 20.0).abs() < 0.001);
     }
 
+    // Regression guard: "claude-opus-5" must resolve to its own "Opus 5" entry.
+    // Its price ($5/$25) coincides with the generic "opus" fallback, so the
+    // label is the signal that the match landed on the right entry — without a
+    // dedicated entry the tooltip/breakdown would mislabel it "Opus 4.8/4.7/4.6/4.5".
+    #[test]
+    fn claude_opus_5_matches_own_entry() {
+        let p = get_claude_pricing("claude-opus-5");
+        assert!((p.input - 5.0).abs() < 0.001, "Opus 5 input must be $5/MTok, got ${}", p.input);
+        assert!((p.output - 25.0).abs() < 0.001, "Opus 5 output must be $25/MTok, got ${}", p.output);
+        assert!((p.cache_read - 0.50).abs() < 0.001);
+        assert!((p.cache_write_5m - 6.25).abs() < 0.001);
+        assert!((p.cache_write_1h - 10.0).abs() < 0.001);
+
+        let cfg: PricingConfig = serde_json::from_str(EMBEDDED_PRICING).unwrap();
+        let entry = find_pricing(&cfg.claude, "claude-opus-5");
+        assert_eq!(entry.label, "Opus 5", "claude-opus-5 must match its own entry, not the generic opus fallback");
+    }
+
+    // "opus-5" must not shadow the opus-4-x entries ("claude-opus-4-5..." does
+    // not contain "opus-5"), and 1M-context variants like "claude-opus-5[1m]"
+    // must still land on the Opus 5 entry.
+    #[test]
+    fn claude_opus_5_ordering_is_safe() {
+        let cfg: PricingConfig = serde_json::from_str(EMBEDDED_PRICING).unwrap();
+        let opus45 = find_pricing(&cfg.claude, "claude-opus-4-5-20251101");
+        assert_eq!(opus45.label, "Opus 4.8/4.7/4.6/4.5");
+        let opus5_1m = find_pricing(&cfg.claude, "claude-opus-5[1m]");
+        assert_eq!(opus5_1m.label, "Opus 5");
+    }
+
+    #[test]
+    fn opencode_opus_5_pricing() {
+        let p = get_opencode_pricing("anthropic/claude-opus-5");
+        assert!((p.input - 5.0).abs() < 0.001, "Opencode Opus 5 input must be $5/MTok, got ${}", p.input);
+        assert!((p.output - 25.0).abs() < 0.001);
+
+        let cfg: PricingConfig = serde_json::from_str(EMBEDDED_PRICING).unwrap();
+        let oc = cfg.opencode.as_ref().expect("opencode config present");
+        let entry = find_pricing(oc, "anthropic/claude-opus-5");
+        assert_eq!(entry.label, "Claude Opus 5");
+    }
+
     #[test]
     fn claude_sonnet_pricing() {
         let p = get_claude_pricing("claude-sonnet-4-6-20260320");

--- a/src/components/ModelBreakdown.tsx
+++ b/src/components/ModelBreakdown.tsx
@@ -8,11 +8,12 @@ interface Props {
 }
 
 function shortModelName(name: string): string {
-  // Extract family and version: "claude-opus-4-6" → "Opus 4.6"
-  const match = name.match(/(opus|sonnet|haiku)-(\d+)-(\d+)/);
+  // Extract family and version: "claude-opus-4-6" → "Opus 4.6", "claude-opus-5" → "Opus 5".
+  // Version digits are capped at 2 so date suffixes ("-20260320") never read as versions.
+  const match = name.match(/(opus|sonnet|haiku|fable|mythos)-(\d{1,2})(?:-(\d{1,2}))?(?!\d)/);
   if (match) {
     const family = match[1].charAt(0).toUpperCase() + match[1].slice(1);
-    return `${family} ${match[2]}.${match[3]}`;
+    return match[3] ? `${family} ${match[2]}.${match[3]}` : `${family} ${match[2]}`;
   }
   if (name.includes("opus")) return "Opus";
   if (name.includes("sonnet")) return "Sonnet";


### PR DESCRIPTION
## Summary
- Add a dedicated `opus-5` pricing entry (claude + opencode sections, pricing.json v1.9.0). `claude-opus-5` previously fell through to the generic `opus` fallback — priced correctly by coincidence ($5/$25 matches Opus 4.8), but mislabeled "Opus 4.8/4.7/4.6/4.5" in the tooltip and model breakdown.
- Regression guards assert the **label** (price alone can't distinguish the entry from the fallback): own-entry match, `opus-4-5` not shadowed, `[1m]` variant, opencode path.
- Fix `shortModelName` to render single-digit versions: `claude-opus-5` → "Opus 5" (was bare "Opus"), also fixes "Sonnet 5", "Fable 5", and `claude-opus-4-20250514` → "Opus 4" (was "Opus 4.20250514").

## Pricing reference
Claude Opus 5 (`claude-opus-5`): $5 input / $25 output per MTok, cache read $0.50, cache write $6.25 (5m) / $10.00 (1h) — identical to Opus 4.8, per platform.claude.com pricing docs.

## Test plan
- [x] `cargo test --lib` — 112 passed (3 new pricing guards)
- [x] `npx tsc --noEmit` clean
- [x] `shortModelName` behavior verified across 10 model-id cases incl. legacy `claude-3-5-sonnet-20241022`

🤖 Generated with [Claude Code](https://claude.com/claude-code)