### PR TITLE
ci: build macOS Intel (x86_64) alongside Apple Silicon

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+# actionlint ships a hardcoded runner-label list that still predates GitHub's
+# Intel-image migration: it accepts the retired `macos-13` and rejects the
+# current `macos-15-intel`. Declare the labels we actually use so linting
+# reflects the real runner catalog.
+self-hosted-runner:
+  labels:
+    - macos-15-intel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
             BODY="No notable changes."
           fi
 
-          CHANGELOG="## AI Token Monitor ${{ steps.bump.outputs.version }}\n\n${BODY}### Download\n- macOS (Apple Silicon): \`.dmg\` 파일을 다운로드하세요.\n- Windows: \`.exe\` 인스톨러를 다운로드하세요."
+          CHANGELOG="## AI Token Monitor ${{ steps.bump.outputs.version }}\n\n${BODY}### Download\n- macOS (Apple Silicon): \`aarch64.dmg\` 파일을 다운로드하세요.\n- macOS (Intel): \`x64.dmg\` 파일을 다운로드하세요.\n- Windows: \`.exe\` 인스톨러를 다운로드하세요."
 
           {
             echo "changelog<<CHANGELOG_EOF"
@@ -164,8 +164,26 @@ jobs:
   build-macos:
     needs: bump-version
     if: needs.bump-version.outputs.build_macos == 'true'
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
+    strategy:
+      # Sequential: both arches upload to the same release, and tauri-action
+      # updates latest.json by read-modify-write (it downloads the existing
+      # manifest and merges its `platforms` map). Concurrent uploads race that
+      # cycle and can drop a platform key, silently breaking auto-update.
+      max-parallel: 1
+      # One arch failing must not delete the other's uploaded assets.
+      fail-fast: false
+      matrix:
+        include:
+          - arch: aarch64
+            target: aarch64-apple-darwin
+            runner: macos-latest
+          # Last x86_64 image GitHub offers (supported until Aug 2027).
+          # macos-13 was retired; macos-*-large are billed on public repos.
+          - arch: x86_64
+            target: x86_64-apple-darwin
+            runner: macos-15-intel
     steps:
       - uses: actions/checkout@v4
         with:
@@ -177,10 +195,10 @@ jobs:
           node-version: 20
           cache: npm
 
-      - name: Install Rust stable (aarch64)
+      - name: Install Rust stable (${{ matrix.arch }})
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin
+          targets: ${{ matrix.target }}
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
@@ -208,7 +226,7 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple: -k "" $KEYCHAIN_PATH
           security list-keychain -d user -s $KEYCHAIN_PATH
 
-      - name: Build Tauri app (Apple Silicon only)
+      - name: Build Tauri app (macOS ${{ matrix.arch }})
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -224,11 +242,18 @@ jobs:
           releaseBody: ${{ needs.bump-version.outputs.changelog }}
           releaseDraft: false
           prerelease: false
-          args: --target aarch64-apple-darwin
+          args: --target ${{ matrix.target }}
 
   build-windows:
-    needs: bump-version
-    if: needs.bump-version.outputs.build_windows == 'true'
+    # Also waits on build-macos (not just bump-version): every tauri-action
+    # upload rewrites latest.json by read-modify-write, so concurrent jobs can
+    # drop each other's platform keys and silently break auto-update. `always()`
+    # keeps Windows building even if macOS is skipped or fails.
+    needs: [bump-version, build-macos]
+    if: |
+      always() &&
+      needs.bump-version.result == 'success' &&
+      needs.bump-version.outputs.build_windows == 'true'
     runs-on: windows-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,11 @@ on:
           - all
           - macos-only
           - windows-only
+      prerelease:
+        description: 'Mark as pre-release (installed apps keep seeing the current stable; use to validate a release before promoting it)'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -241,7 +246,7 @@ jobs:
           releaseName: ${{ needs.bump-version.outputs.tag }}
           releaseBody: ${{ needs.bump-version.outputs.changelog }}
           releaseDraft: false
-          prerelease: false
+          prerelease: ${{ inputs.prerelease }}
           args: --target ${{ matrix.target }}
 
   build-windows:
@@ -289,4 +294,4 @@ jobs:
           releaseName: ${{ needs.bump-version.outputs.tag }}
           releaseBody: ${{ needs.bump-version.outputs.changelog }}
           releaseDraft: false
-          prerelease: false
+          prerelease: ${{ inputs.prerelease }}


### PR DESCRIPTION
Closes #175

## Summary

The macOS release job hardcoded `--target aarch64-apple-darwin`, so every release shipped Apple Silicon only — Intel Mac users (2019 and earlier) had no download and had to build from source. This turns that job into an **arch matrix** that also produces an `x86_64` bundle.

| | before | after |
|---|---|---|
| macOS Apple Silicon | ✅ `aarch64.dmg` | ✅ `aarch64.dmg` |
| macOS Intel | ❌ *missing* | ✅ `x64.dmg` |
| Windows | ✅ | ✅ |

Intel users also get **auto-update**, not just a manual download — `latest.json` gains a `darwin-x86_64` key.

## Why separate per-arch builds, not a universal binary

A universal binary looked like the tidier option at first, but it would **permanently break auto-update for every user already on Apple Silicon**.

The updater resolves its manifest key by composing `{os}-{arch}` and trying `{os}-{arch}-{installer}` then `{os}-{arch}` — [there is no `darwin-universal` fallback](https://raw.githubusercontent.com/tauri-apps/plugins-workspace/v2/plugins/updater/src/updater.rs). Shipping universal would mean:

1. adding `updaterJsonKeepUniversal: true`, **and**
2. pinning `.target("darwin-universal")` in Rust — a source change

…after which the `darwin-aarch64` key disappears from `latest.json`. Every client already shipped (v0.19.43 and earlier) looks up `darwin-aarch64`, finds nothing, and silently stops updating forever. Those users would need a manual reinstall.

Separate per-arch artifacts keep `darwin-aarch64` exactly as-is, so existing installs are untouched. They're also half the download size (~7 MB vs ~14 MB).

## The non-obvious part: serialized uploads

`tauri-action` updates `latest.json` by **read-modify-write** — it downloads the existing manifest and merges its `platforms` map ([source](https://raw.githubusercontent.com/tauri-apps/tauri-action/dev/src/upload-version-json.ts)). That merge is why v0.19.43's manifest correctly holds both macOS and Windows keys today.

But read-modify-write races under concurrency. Before this change `build-macos` and `build-windows` both depended only on `bump-version`, so they started simultaneously — v0.19.43 survived on timing luck. Adding a third uploading job raises the odds that one job's platform key gets dropped, which breaks auto-update **silently**: the release looks complete, assets are all present, and only affected users notice their app never updates again.

So uploads are now serialized:
- `max-parallel: 1` within the macOS matrix
- `build-windows` now also waits on `build-macos`

Guards so this doesn't cost flexibility:
- `fail-fast: false` — one arch failing must not cancel the other or delete its uploaded assets
- `always()` + explicit `bump-version.result == 'success'` — Windows still builds when macOS is skipped (`windows-only`) or fails, but not when versioning itself failed

Verified across all five paths: `all`, `windows-only`, `macos-only`, macOS-build-failure, and bump-failure.

## Runner choice

`macos-15-intel`. `macos-13` was **retired** by GitHub, and the `macos-*-large` images are billed on public repos. This is the last x86_64 image GitHub offers, [supported until Aug 2027](https://docs.github.com/en/actions/reference/runners/github-hosted-runners) and free on public repositories.

An `.github/actionlint.yaml` is included because actionlint's bundled label list predates that migration — it still accepts the retired `macos-13` and rejects the current `macos-15-intel`. The label was confirmed against GitHub's official runner docs.

## Validating this safely

This change alters how `latest.json` is produced, and that file cannot be verified without actually running the release workflow. Publishing it straight to stable would mean every installed app sees the result immediately — and if a platform key were dropped, those users' auto-update would stop working **silently**, with the release still looking complete.

So a `prerelease` input was added to the workflow (defaults to `false`; normal releases unchanged). The updater endpoint resolves `releases/latest/download/latest.json`, and GitHub excludes pre-releases from `latest` — so a pre-release run leaves installed apps pointing at the current stable while the new artifacts get checked.

Intended sequence:

1. release with `prerelease: true`
2. confirm `latest.json` contains all four keys — `darwin-aarch64`, `darwin-x86_64`, `windows-x86_64*`
3. smoke-test the Intel `.dmg`
4. promote to a full release once it checks out

## Test plan

- [x] YAML parses; matrix expands to exactly 2 entries (`aarch64`→`macos-latest`, `x86_64`→`macos-15-intel`)
- [x] `actionlint` clean
- [x] `build-windows` conditions verified across all 5 scenarios above
- [x] No arch-specific code in `src-tauri` — no `target_arch` branches anywhere; `cocoa`/`objc` are gated on `target_os` only, so x86_64 compiles unchanged
- [x] `minimumSystemVersion: 10.15` already covers Intel Macs
- [ ] **Verify on the next release**: confirm `latest.json` ends up with all four keys (`darwin-aarch64`, `darwin-x86_64`, `windows-x86_64*`) and that the Intel `.dmg` launches on a real Intel Mac

## Note for the reviewer

The last checklist item can only be confirmed by running an actual release — CI cannot exercise the release workflow (`workflow_dispatch` only). Use the pre-release path above rather than shipping it straight to stable, so the manifest is verified before any installed app can act on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

