### PR TITLE
fix(macos): use cocoa YES so the Intel target compiles

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -608,13 +608,15 @@ fn start_file_watcher(app_handle: tauri::AppHandle) {
 fn activate_app() {
     #[allow(deprecated)]
     use cocoa::appkit::NSApplication;
+    // `YES` rather than a bare `true`: objc types BOOL as `bool` on arm64 but
+    // as `i8` on x86_64, so a literal only compiles for one of the two targets.
     #[allow(deprecated)]
-    use cocoa::base::nil;
+    use cocoa::base::{nil, YES};
     unsafe {
         #[allow(deprecated)]
         let ns_app = NSApplication::sharedApplication(nil);
         #[allow(deprecated)]
-        ns_app.activateIgnoringOtherApps_(true);
+        ns_app.activateIgnoringOtherApps_(YES);
     }
 }
 


### PR DESCRIPTION
Follow-up to #176 / #175.

## What happened

The first `x86_64` release build (v0.19.44 pre-release) failed to compile:

```
error[E0308]: mismatched types
   --> src/lib.rs:617:43
    |
617 |         ns_app.activateIgnoringOtherApps_(true);
    |                -------------------------- ^^^^ expected `i8`, found `bool`
```

`objc` defines `BOOL` per-architecture — `bool` on arm64, `c_schar` (i8) on x86_64 — so a bare `true` only ever compiled for Apple Silicon. Nothing was wrong with the workflow from #176; this is app code that had never been built for Intel before.

Passing the crate's own `YES` constant resolves to the correct type on both targets (`objc` defines `YES` alongside `BOOL`, so it's `true` on arm64 and `1` on x86_64).

## Verification

Cross-compiled locally against both targets:

| target | result |
|---|---|
| `aarch64-apple-darwin` | ✅ pass |
| `x86_64-apple-darwin` | ✅ pass |

Reverting just this hunk reproduces the exact CI error, confirming it's the cause and not an incidental change.

Also swept for other occurrences: `activateIgnoringOtherApps_` is the only cocoa call in the tree that takes a `BOOL` literal — the remaining calls (`setLevel_`, `makeKeyAndOrderFront_`) pass integers or pointers, so they're arch-independent. The failing build reported exactly one error, consistent with that.

## Note on the pre-release path

Worth recording that #176's pre-release option did its job here. The v0.19.44 pre-release ended up **incomplete** — aarch64 and Windows uploaded, Intel missing — yet the updater endpoint still resolved to v0.19.43 throughout, so no installed app ever saw the broken release:

```
releases/latest/download/latest.json  →  v0.19.43   (v0.19.44 pre-release ignored)
```

Had this gone out as a normal release, users would have been offered a version with no Intel build and a manifest missing `darwin-x86_64`.

## Test plan

- [x] `cargo check --target aarch64-apple-darwin` passes
- [x] `cargo check --target x86_64-apple-darwin` passes
- [x] Reverting the hunk reproduces the CI error
- [x] No other `BOOL`-literal cocoa call sites in the tree
- [ ] Re-run the pre-release after merge and confirm the Intel `.dmg` builds and `latest.json` carries all four keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)
