### PR TITLE
feat(ai): call the Kiro API directly instead of shelling out to kiro-cli

### DIFF
--- a/src-tauri/src/ai_translate.rs
+++ b/src-tauri/src/ai_translate.rs
@@ -1,6 +1,8 @@
 use reqwest::Client;
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 use std::sync::OnceLock;
+use std::time::Duration;
 
 use crate::commands::get_preferences;
 
@@ -9,6 +11,8 @@ static HTTP_CLIENT: OnceLock<Client> = OnceLock::new();
 fn client() -> &'static Client {
     HTTP_CLIENT.get_or_init(Client::new)
 }
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 
 fn build_prompt(text: &str, target_language: &str, source_language: Option<&str>) -> String {
     if let Some(src) = source_language {
@@ -30,7 +34,7 @@ async fn post_json(
     body: &Value,
     provider: &str,
 ) -> Result<Value, String> {
-    let mut req = client().post(url).json(body);
+    let mut req = client().post(url).json(body).timeout(REQUEST_TIMEOUT);
     for &(k, v) in headers {
         req = req.header(k, v);
     }
@@ -38,9 +42,36 @@ async fn post_json(
         .send()
         .await
         .map_err(|e| format!("{} request failed: {}", provider, e))?;
-    resp.json()
+    let status = resp.status();
+    let raw = resp
+        .text()
         .await
-        .map_err(|e| format!("{} parse failed: {}", provider, e))
+        .map_err(|e| format!("{} read failed: {}", provider, e))?;
+    if !status.is_success() {
+        return Err(format!(
+            "{} HTTP {}: {}",
+            provider,
+            status.as_u16(),
+            error_message(&raw)
+        ));
+    }
+    serde_json::from_str(&raw).map_err(|e| format!("{} parse failed: {}", provider, e))
+}
+
+/// Pull the human-readable text out of an OpenAI/Anthropic-shaped error body,
+/// falling back to a truncated copy of the raw body.
+fn error_message(body: &str) -> String {
+    serde_json::from_str::<Value>(body)
+        .ok()
+        .and_then(|v| {
+            v["error"]["message"]
+                .as_str()
+                .or_else(|| v["error"].as_str())
+                .or_else(|| v["message"].as_str())
+                .map(str::to_string)
+        })
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| body.trim().chars().take(200).collect())
 }
 
 fn extract_text(data: &Value, path: &[&str]) -> Result<String, String> {
@@ -89,6 +120,19 @@ async fn call_openai(key: &str, model: &str, prompt: &str) -> Result<String, Str
         .ok_or_else(|| "OpenAI returned no text".to_string())
 }
 
+/// First `text` block of an Anthropic-shaped `content` array. Index 0 is not
+/// reliably the answer — a gateway emulating extended thinking can prepend a
+/// `thinking` block — so scan for the first text block instead.
+fn first_text_block(data: &Value) -> Option<String> {
+    data["content"]
+        .as_array()?
+        .iter()
+        .find(|b| b["type"] == "text")
+        .and_then(|b| b["text"].as_str())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
 async fn call_anthropic(key: &str, model: &str, prompt: &str) -> Result<String, String> {
     let body = json!({
         "model": model,
@@ -105,10 +149,7 @@ async fn call_anthropic(key: &str, model: &str, prompt: &str) -> Result<String, 
         &body,
         "Anthropic",
     ).await?;
-    data["content"][0]["text"]
-        .as_str()
-        .map(|s| s.trim().to_string())
-        .ok_or_else(|| "Anthropic returned no text".to_string())
+    first_text_block(&data).ok_or_else(|| "Anthropic returned no text".to_string())
 }
 
 fn build_detect_prompt(text: &str) -> String {
@@ -130,205 +171,277 @@ async fn call_model(keys: &crate::providers::types::AiKeys, model: &str, prompt:
         call_anthropic(key, model, prompt).await
     } else if model.starts_with("kiro") {
         let key = keys.kiro.as_deref().ok_or("Kiro API key not set")?;
-        call_kiro(key, prompt).await
+        call_kiro(key, model, prompt).await
     } else {
         Err(format!("Unknown model provider for model: {}", model))
     }
 }
 
-/// Translate via the local `kiro-cli` binary, authenticating with the user-provided
-/// API key (injected as `KIRO_API_KEY`) rather than any cached `kiro-cli login` session.
-///
-/// `kiro-cli chat --no-interactive` decorates stdout with ANSI codes, a `> ` prompt
-/// marker and a `Credits: … Time: …` footer, so we ask the model to wrap its answer in a
-/// compact JSON object (`{"t":"…"}`) and extract it via balanced-brace matching — the
-/// footer/ANSI chrome carries no braces, so this isolates the answer reliably.
-async fn call_kiro(key: &str, prompt: &str) -> Result<String, String> {
-    let key = key.to_string();
-    let kiro_prompt = format!(
-        "{}\n\nIMPORTANT: Respond with ONLY a compact single-line JSON object of the form \
-         {{\"t\":\"<your answer here>\"}} and nothing else — no markdown fences, no explanation.",
-        prompt
-    );
-    tauri::async_runtime::spawn_blocking(move || run_kiro_blocking(&key, &kiro_prompt))
-        .await
-        .map_err(|e| format!("Kiro task join failed: {}", e))?
+// ============================================================================
+// Kiro (Amazon Q Developer / CodeWhisperer) — direct API calls
+//
+// Kiro speaks AWS-JSON 1.0: a `x-amz-target`-dispatched POST whose response is a
+// byte soup with JSON event objects embedded in it. Everything below mirrors the
+// `kiro-gateway` reference implementation's passthrough path, minus the parts a
+// one-shot translation never needs (tools, streaming, history, thinking budgets).
+// ============================================================================
+
+/// Kiro region. The runtime endpoint is region-scoped; override for another region.
+const KIRO_DEFAULT_REGION: &str = "us-east-1";
+
+/// Model used when the stored selection is a bare `kiro` — what earlier builds
+/// saved, before per-model selection existed.
+const KIRO_DEFAULT_MODEL: &str = "claude-haiku-4.5";
+
+const KIRO_AMZ_TARGET: &str =
+    "AmazonCodeWhispererStreamingService.GenerateAssistantResponse";
+
+/// Kiro IDE version advertised in the user agent, matching the reference gateway.
+const KIRO_IDE_VERSION: &str = "0.7.45";
+
+fn kiro_endpoint() -> String {
+    let region = std::env::var("KIRO_REGION")
+        .map(|s| s.trim().to_string())
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| KIRO_DEFAULT_REGION.to_string());
+    format!("https://runtime.{}.kiro.dev/generateAssistantResponse", region)
 }
 
-/// Resolve the `kiro-cli` binary. GUI apps inherit a minimal PATH, so probe common
-/// install locations first and fall back to the bare name (PATH lookup).
-fn resolve_kiro_cli() -> std::path::PathBuf {
-    let bin = if cfg!(target_os = "windows") { "kiro-cli.exe" } else { "kiro-cli" };
-    if let Some(home) = dirs::home_dir() {
-        for rel in [".local/bin", ".kiro/bin"] {
-            let c = home.join(rel).join(bin);
-            if c.exists() {
-                return c;
-            }
-        }
+/// Map a stored `kiro/<model>` selection to the model id Kiro expects.
+fn kiro_model_id(model: &str) -> &str {
+    match model.strip_prefix("kiro/") {
+        Some(m) if !m.is_empty() => m,
+        _ => KIRO_DEFAULT_MODEL,
     }
-    if !cfg!(target_os = "windows") {
-        for p in ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin"] {
-            let c = std::path::Path::new(p).join(bin);
-            if c.exists() {
-                return c;
-            }
-        }
-    }
-    std::path::PathBuf::from(bin)
 }
 
-const KIRO_MAX_ATTEMPTS: u32 = 3;
+/// Stable client fingerprint decorating the Kiro user agent. Kiro may correlate
+/// it across requests, so it must not vary per call — hence a digest of a fixed
+/// seed rather than anything host-derived.
+fn kiro_fingerprint() -> &'static str {
+    static FINGERPRINT: OnceLock<String> = OnceLock::new();
+    FINGERPRINT.get_or_init(|| {
+        let mut hasher = Sha256::new();
+        hasher.update(b"ai-token-monitor");
+        hasher
+            .finalize()
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect()
+    })
+}
 
-/// Run `kiro-cli` up to a few times; the chat output occasionally lacks parseable JSON.
-fn run_kiro_blocking(key: &str, prompt: &str) -> Result<String, String> {
-    let mut last_err = String::new();
-    for attempt in 1..=KIRO_MAX_ATTEMPTS {
-        match run_kiro_once(key, prompt) {
-            Ok(s) => return Ok(s),
-            // Auth failures are deterministic — don't waste retries on a bad/expired key.
-            Err(e) if e.starts_with("AUTH:") => {
-                return Err(e.trim_start_matches("AUTH:").to_string());
-            }
-            Err(e) => {
-                last_err = e;
-                if attempt < KIRO_MAX_ATTEMPTS {
-                    std::thread::sleep(std::time::Duration::from_millis(500 * attempt as u64));
+/// RFC 4122 v4 UUID. Kiro only needs opaque correlation ids, so a formatted
+/// random 128-bit value is enough — no `uuid` dependency required.
+fn uuid_v4() -> String {
+    use rand::RngCore;
+    let mut b = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut b);
+    b[6] = (b[6] & 0x0f) | 0x40; // version 4
+    b[8] = (b[8] & 0x3f) | 0x80; // RFC 4122 variant
+    let hex = |r: &[u8]| -> String { r.iter().map(|x| format!("{:02x}", x)).collect() };
+    format!(
+        "{}-{}-{}-{}-{}",
+        hex(&b[0..4]),
+        hex(&b[4..6]),
+        hex(&b[6..8]),
+        hex(&b[8..10]),
+        hex(&b[10..16])
+    )
+}
+
+/// Translate via the Kiro API, authenticating with the user's own `ksk_…` key.
+/// `tokentype: API_KEY` is what tells Kiro the bearer token is an API key rather
+/// than an OAuth access token.
+async fn call_kiro(key: &str, model: &str, prompt: &str) -> Result<String, String> {
+    let payload = json!({
+        "conversationState": {
+            "chatTriggerType": "MANUAL",
+            "conversationId": uuid_v4(),
+            "currentMessage": {
+                "userInputMessage": {
+                    "content": prompt,
+                    "modelId": kiro_model_id(model),
+                    "origin": "AI_EDITOR",
                 }
             }
         }
-    }
-    Err(format!(
-        "Kiro CLI failed after {} attempts: {}",
-        KIRO_MAX_ATTEMPTS, last_err
-    ))
-}
-
-fn run_kiro_once(key: &str, prompt: &str) -> Result<String, String> {
-    use std::io::Read;
-    use std::process::{Command, Stdio};
-    use std::time::{Duration, Instant};
-
-    let cli = resolve_kiro_cli();
-    let mut child = Command::new(&cli)
-        // `--` is an end-of-options sentinel: everything after it is treated as a
-        // positional argument, never a flag. The prompt embeds untrusted chat text, so
-        // without this a message starting with `-`/`--` could smuggle CLI flags into kiro-cli.
-        .args(["chat", "--no-interactive", "--", prompt])
-        .env("KIRO_API_KEY", key)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|e| format!("spawn failed ({}): {}", cli.display(), e))?;
-
-    // Drain pipes on dedicated threads so a large output can't deadlock the child.
-    let mut out_h = child.stdout.take();
-    let mut err_h = child.stderr.take();
-    let out_t = std::thread::spawn(move || {
-        let mut s = String::new();
-        if let Some(ref mut h) = out_h {
-            let _ = h.read_to_string(&mut s);
-        }
-        s
-    });
-    let err_t = std::thread::spawn(move || {
-        let mut s = String::new();
-        if let Some(ref mut h) = err_h {
-            let _ = h.read_to_string(&mut s);
-        }
-        s
     });
 
-    let start = Instant::now();
-    let timeout = Duration::from_secs(60);
-    let status = loop {
-        match child.try_wait() {
-            Ok(Some(st)) => break st,
-            Ok(None) if start.elapsed() < timeout => {
-                std::thread::sleep(Duration::from_millis(100));
-            }
-            Ok(None) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return Err("Kiro CLI timed out".to_string());
-            }
-            Err(e) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return Err(format!("Kiro CLI wait error: {}", e));
-            }
-        }
-    };
+    let fp = kiro_fingerprint();
+    let resp = client()
+        .post(kiro_endpoint())
+        .timeout(REQUEST_TIMEOUT)
+        .header("Authorization", format!("Bearer {}", key))
+        .header("Content-Type", "application/x-amz-json-1.0")
+        .header("x-amz-target", KIRO_AMZ_TARGET)
+        .header("tokentype", "API_KEY")
+        .header(
+            "User-Agent",
+            format!(
+                "aws-sdk-js/1.0.27 ua/2.1 os/win32#10.0.19044 lang/js md/nodejs#22.21.1 \
+                 api/codewhispererstreaming#1.0.27 m/E KiroIDE-{}-{}",
+                KIRO_IDE_VERSION, fp
+            ),
+        )
+        .header(
+            "x-amz-user-agent",
+            format!("aws-sdk-js/1.0.27 KiroIDE-{}-{}", KIRO_IDE_VERSION, fp),
+        )
+        .header("x-amzn-codewhisperer-optout", "true")
+        .header("x-amzn-kiro-agent-mode", "vibe")
+        .header("amz-sdk-invocation-id", uuid_v4())
+        .header("amz-sdk-request", "attempt=1; max=3")
+        .body(serde_json::to_vec(&payload).map_err(|e| format!("Kiro encode failed: {}", e))?)
+        .send()
+        .await
+        .map_err(|e| format!("Kiro request failed: {}", e))?;
 
-    let stdout = out_t.join().unwrap_or_default();
-    let stderr = err_t.join().unwrap_or_default();
+    let status = resp.status();
+    let raw = resp
+        .bytes()
+        .await
+        .map_err(|e| format!("Kiro read failed: {}", e))?;
+    // Kiro frames its events in a non-UTF-8 envelope, so decode lossily; the
+    // event scanner only relies on ASCII delimiters surviving.
+    let text = String::from_utf8_lossy(&raw);
 
-    if !status.success() {
+    if !status.is_success() {
         return Err(format!(
-            "Kiro CLI exit {}: {}",
-            status.code().unwrap_or(-1),
-            stderr.trim()
+            "Kiro HTTP {}: {}",
+            status.as_u16(),
+            error_message(&text)
         ));
     }
 
-    let combined = format!("{}\n{}", stdout, stderr);
-
-    // kiro-cli exits 0 even on auth failure, printing an "Authentication failed" notice
-    // instead of a reply. Detect it so we surface a clear error and skip retries.
-    if combined.contains("Authentication failed") || combined.contains("invalid or expired") {
-        return Err("AUTH:Kiro authentication failed — check your API key".to_string());
+    let answer = strip_thinking_tags(&collect_kiro_content(&text));
+    let answer = answer.trim();
+    if answer.is_empty() {
+        return Err("Kiro returned no text".to_string());
     }
-
-    let value = extract_json_object(&combined).ok_or("Kiro CLI returned no parseable JSON")?;
-    value
-        .get("t")
-        .and_then(|v| v.as_str())
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .ok_or_else(|| "Kiro CLI JSON missing non-empty 't' field".to_string())
+    Ok(answer.to_string())
 }
 
-/// Extract the first balanced, string-aware JSON object from arbitrary text.
-/// ASCII delimiters (`{` `}` `"` `\`) never collide with UTF-8 continuation bytes
-/// (all >= 0x80), so byte indexing stays on char boundaries for the `{ … }` slice.
-fn extract_json_object(text: &str) -> Option<Value> {
-    let bytes = text.as_bytes();
-    for i in 0..bytes.len() {
-        if bytes[i] != b'{' {
+/// Leading keys of the JSON events Kiro embeds in a response body.
+const KIRO_EVENT_PATTERNS: [&str; 7] = [
+    "{\"content\":",
+    "{\"name\":",
+    "{\"input\":",
+    "{\"stop\":",
+    "{\"followupPrompt\":",
+    "{\"usage\":",
+    "{\"contextUsagePercentage\":",
+];
+
+const KIRO_CONTENT_PATTERN: &str = "{\"content\":";
+
+/// Concatenate the assistant text out of a `generateAssistantResponse` body.
+///
+/// The response is not a binary AWS eventstream that a codec could decode — it is
+/// framing bytes with JSON event objects interleaved, so events are located by
+/// scanning for their leading key and brace-matching to their end.
+///
+/// Every known event prefix is scanned and the *earliest* match always consumed,
+/// not just the content ones: a `followupPrompt` event nests its own
+/// `{"content": …}` object, which a content-only scan would otherwise pick up and
+/// append as if it were assistant text.
+fn collect_kiro_content(text: &str) -> String {
+    let mut out = String::new();
+    let mut last: Option<String> = None;
+    let mut rest = text;
+
+    while let Some((start, pattern)) = KIRO_EVENT_PATTERNS
+        .iter()
+        .filter_map(|p| rest.find(p).map(|i| (i, *p)))
+        .min_by_key(|(i, _)| *i)
+    {
+        let end = match find_matching_brace(rest, start) {
+            Some(e) => e,
+            None => break, // truncated trailing event
+        };
+        let raw = &rest[start..=end];
+        rest = &rest[end + 1..];
+
+        if pattern != KIRO_CONTENT_PATTERN {
             continue;
         }
-        let mut depth: i32 = 0;
-        let mut in_str = false;
-        let mut esc = false;
-        let mut j = i;
-        while j < bytes.len() {
-            let c = bytes[j];
-            if esc {
-                esc = false;
-            } else if in_str {
-                if c == b'\\' {
-                    esc = true;
-                } else if c == b'"' {
-                    in_str = false;
-                }
-            } else if c == b'"' {
-                in_str = true;
-            } else if c == b'{' {
-                depth += 1;
-            } else if c == b'}' {
-                depth -= 1;
-                if depth == 0 {
-                    if let Ok(v) = serde_json::from_str::<Value>(&text[i..=j]) {
-                        return Some(v);
-                    }
-                    break; // wrong start point — try next '{'
-                }
+        let event: Value = match serde_json::from_str(raw) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let chunk = match event["content"].as_str() {
+            Some(c) => c,
+            None => continue,
+        };
+        // Kiro occasionally double-emits a chunk; the reference parser drops
+        // consecutive duplicates, so match that rather than stuttering.
+        if last.as_deref() == Some(chunk) {
+            continue;
+        }
+        out.push_str(chunk);
+        last = Some(chunk.to_string());
+    }
+    out
+}
+
+/// Index of the `}` closing the `{` at `start`, or `None` if unbalanced.
+/// ASCII delimiters (`{` `}` `"` `\`) never collide with UTF-8 continuation
+/// bytes (all >= 0x80), so byte indexing stays on char boundaries.
+fn find_matching_brace(text: &str, start: usize) -> Option<usize> {
+    let bytes = text.as_bytes();
+    if bytes.get(start) != Some(&b'{') {
+        return None;
+    }
+    let mut depth: i32 = 0;
+    let mut in_str = false;
+    let mut esc = false;
+    for (i, &c) in bytes.iter().enumerate().skip(start) {
+        if esc {
+            esc = false;
+        } else if in_str {
+            match c {
+                b'\\' => esc = true,
+                b'"' => in_str = false,
+                _ => {}
             }
-            j += 1;
+        } else {
+            match c {
+                b'"' => in_str = true,
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(i);
+                    }
+                }
+                _ => {}
+            }
         }
     }
     None
+}
+
+/// Kiro models sometimes narrate inside a reasoning tag even when nothing asked
+/// them to. Drop those spans (and an unterminated trailing one) so the tag text
+/// never lands in a translation.
+fn strip_thinking_tags(text: &str) -> String {
+    const TAGS: [&str; 4] = ["thinking", "think", "reasoning", "thought"];
+    let mut out = text.to_string();
+    for tag in TAGS {
+        let open = format!("<{}>", tag);
+        let close = format!("</{}>", tag);
+        while let Some(start) = out.find(&open) {
+            match out[start..].find(&close) {
+                Some(rel) => {
+                    out.replace_range(start..start + rel + close.len(), "");
+                }
+                // Unterminated: everything from the tag onward is reasoning.
+                None => out.truncate(start),
+            }
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -336,26 +449,135 @@ mod tests {
     use super::*;
 
     #[test]
-    fn extracts_json_from_kiro_chrome() {
-        // Real `kiro-cli chat --no-interactive` output: ANSI + "> " marker + JSON + Credits footer.
-        let raw = "\n\u{1b}[38;5;252m\u{1b}[0m\u{1b}[?25l\u{1b}[38;5;141m> \u{1b}[0m{\"t\":\"안녕하세요 세계\"}\u{1b}[0m\u{1b}[0m\n\u{1b}[38;5;8m\n ▸ Credits: 0.03 • Time: 2s\n\n\u{1b}[0m";
-        let v = extract_json_object(raw).expect("should find JSON object");
-        assert_eq!(v.get("t").and_then(|x| x.as_str()), Some("안녕하세요 세계"));
+    fn maps_kiro_selection_to_upstream_model() {
+        assert_eq!(kiro_model_id("kiro/claude-sonnet-4.6"), "claude-sonnet-4.6");
+        assert_eq!(kiro_model_id("kiro/glm-5"), "glm-5");
     }
 
     #[test]
-    fn extracts_json_with_braces_inside_string() {
-        let raw = "noise > {\"t\":\"use {curly} braces\"} ▸ Credits: 0.01";
-        let v = extract_json_object(raw).expect("should find JSON object");
+    fn bare_kiro_selection_falls_back_to_default_model() {
+        // What pre-gateway builds stored in `ai_model`.
+        assert_eq!(kiro_model_id("kiro"), KIRO_DEFAULT_MODEL);
+        assert_eq!(kiro_model_id("kiro/"), KIRO_DEFAULT_MODEL);
+    }
+
+    #[test]
+    fn picks_first_text_block_past_thinking() {
+        let data = json!({
+            "content": [
+                { "type": "thinking", "thinking": "let me translate…" },
+                { "type": "text", "text": "  안녕하세요 세계  " }
+            ]
+        });
+        assert_eq!(first_text_block(&data).as_deref(), Some("안녕하세요 세계"));
+    }
+
+    #[test]
+    fn no_text_block_yields_none() {
+        assert!(first_text_block(&json!({ "content": [] })).is_none());
+        assert!(first_text_block(&json!({ "content": [{ "type": "text", "text": "  " }] })).is_none());
+        assert!(first_text_block(&json!({ "error": "nope" })).is_none());
+    }
+
+    #[test]
+    fn error_message_prefers_structured_message() {
         assert_eq!(
-            v.get("t").and_then(|x| x.as_str()),
-            Some("use {curly} braces")
+            error_message(r#"{"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}"#),
+            "invalid x-api-key"
         );
+        // AWS-JSON errors put the text at the top level.
+        assert_eq!(
+            error_message(r#"{"message":"Improperly formed request."}"#),
+            "Improperly formed request."
+        );
+        assert_eq!(error_message("upstream exploded"), "upstream exploded");
     }
 
     #[test]
-    fn returns_none_without_json() {
-        assert!(extract_json_object("just some ▸ Credits: 0.01 text").is_none());
+    fn finds_matching_brace_past_quoted_delimiters() {
+        let s = r#"{"content":"use {curly} \"quoted\" braces"}tail"#;
+        let end = find_matching_brace(s, 0).expect("balanced");
+        assert_eq!(&s[..=end], r#"{"content":"use {curly} \"quoted\" braces"}"#);
+        assert_eq!(find_matching_brace(r#"{"content":"unterminated"#, 0), None);
+        assert_eq!(find_matching_brace("no brace here", 0), None);
+    }
+
+    #[test]
+    fn collects_content_events_from_framed_body() {
+        // Shape of a real `generateAssistantResponse` body: every JSON event sits
+        // inside an eventstream frame whose length prefix and trailing CRC are not
+        // valid UTF-8, and each content event carries a `modelId` sibling field.
+        let frame = |json: &str| -> Vec<u8> {
+            let mut f = b"\x00\x00\x00\xb1\x00\x00\x00\x5c\x82\xff\xd0\x0b:event-type\x07\x00\x16\
+                assistantResponseEvent\r:content-type\x07\x00\x10application/json\
+                \r:message-type\x07\x00\x05event"
+                .to_vec();
+            f.extend_from_slice(json.as_bytes());
+            f.extend_from_slice(b"\x7f\xfe\xc3\x03");
+            f
+        };
+        let mut body = Vec::new();
+        for json in [
+            r#"{"content":"안녕","modelId":"claude-haiku-4.5"}"#,
+            r#"{"content":"하세요","modelId":"claude-haiku-4.5"}"#,
+        ] {
+            body.extend_from_slice(&frame(json));
+        }
+        body.extend_from_slice(br#"{"usage":{"inputTokens":8}}{"contextUsagePercentage":3}"#);
+
+        let text = String::from_utf8_lossy(&body);
+        assert_eq!(collect_kiro_content(&text), "안녕하세요");
+    }
+
+    #[test]
+    fn skips_followup_prompt_nested_content() {
+        // The nested `{"content": …}` here is a suggested follow-up question, not
+        // assistant text — consuming the whole followupPrompt event drops it.
+        let body = "{\"content\":\"Bonjour\"}{\"followupPrompt\":{\"content\":\"Want another?\",\"userIntent\":null}}";
+        assert_eq!(collect_kiro_content(body), "Bonjour");
+    }
+
+    #[test]
+    fn drops_consecutive_duplicate_chunks() {
+        let body = "{\"content\":\"ha\"}{\"content\":\"ha\"}{\"content\":\"!\"}";
+        assert_eq!(collect_kiro_content(body), "ha!");
+    }
+
+    #[test]
+    fn strips_unsolicited_reasoning_tags() {
+        assert_eq!(
+            strip_thinking_tags("<thinking>the user wants Korean</thinking>안녕하세요"),
+            "안녕하세요"
+        );
+        assert_eq!(strip_thinking_tags("Hola<think>done</think>"), "Hola");
+        // Unterminated tag: everything from it onward is reasoning.
+        assert_eq!(strip_thinking_tags("Hola<reasoning>cut off"), "Hola");
+        assert_eq!(strip_thinking_tags("plain text"), "plain text");
+    }
+
+    #[test]
+    fn uuid_v4_is_well_formed_and_unique() {
+        let a = uuid_v4();
+        assert_eq!(a.len(), 36);
+        let fields: Vec<&str> = a.split('-').collect();
+        assert_eq!(
+            fields.iter().map(|f| f.len()).collect::<Vec<_>>(),
+            vec![8, 4, 4, 4, 12]
+        );
+        assert!(a.chars().all(|c| c == '-' || c.is_ascii_hexdigit()));
+        assert!(fields[2].starts_with('4'), "version nibble: {}", a);
+        assert!(
+            matches!(fields[3].as_bytes()[0], b'8' | b'9' | b'a' | b'b'),
+            "variant nibble: {}",
+            a
+        );
+        assert_ne!(a, uuid_v4());
+    }
+
+    #[test]
+    fn fingerprint_is_stable_across_calls() {
+        assert_eq!(kiro_fingerprint(), kiro_fingerprint());
+        assert_eq!(kiro_fingerprint().len(), 64);
     }
 }
 

--- a/src/components/SettingsOverlay.tsx
+++ b/src/components/SettingsOverlay.tsx
@@ -1071,8 +1071,12 @@ const AI_PROVIDERS: AiProvider[] = [
   {
     id: "kiro",
     i18nKey: "settings.aiKeyKiro",
+    // Kiro serves Claude models too, so ids carry a `kiro/` prefix to stay
+    // distinct from the direct-Anthropic entries above (the backend strips it).
     models: [
-      { id: "kiro", label: "Kiro CLI" },
+      { id: "kiro/claude-haiku-4.5", label: "Kiro Haiku 4.5" },
+      { id: "kiro/claude-sonnet-4.6", label: "Kiro Sonnet 4.6" },
+      { id: "kiro/glm-5", label: "Kiro GLM-5" },
     ],
   },
 ];

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -313,7 +313,7 @@
   "settings.aiKeyGemini": "Gemini API Key",
   "settings.aiKeyOpenAI": "OpenAI API Key",
   "settings.aiKeyAnthropic": "Anthropic API Key",
-  "settings.aiKeyKiro": "Kiro API Key (requires kiro-cli)",
+  "settings.aiKeyKiro": "Kiro API Key (ksk_…)",
   "settings.aiModel": "AI Model",
   "settings.aiDescription": "Translate chat messages using AI",
   "settings.aiFeatures": "• Click translate button on any message to read in your language\n• Auto-translate your replies to match the other person's language\n• Add an API key from any provider below to get started",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -313,7 +313,7 @@
   "settings.aiKeyGemini": "Gemini API 키",
   "settings.aiKeyOpenAI": "OpenAI API 키",
   "settings.aiKeyAnthropic": "Anthropic API 키",
-  "settings.aiKeyKiro": "Kiro API 키 (kiro-cli 필요)",
+  "settings.aiKeyKiro": "Kiro API 키 (ksk_…)",
   "settings.aiModel": "AI 모델",
   "settings.aiDescription": "AI를 활용하여 채팅 메시지를 번역합니다",
   "settings.aiFeatures": "• 메시지의 번역 버튼을 눌러 내 언어로 확인\n• 답글 작성 시 상대방 언어로 자동 번역하여 전송\n• 아래 제공업체 중 하나의 API 키를 추가하면 사용할 수 있습니다",


### PR DESCRIPTION
## What

Kiro translation no longer runs the local `kiro-cli` binary. It calls the Kiro API over HTTP directly, mirroring the `kiro-gateway` passthrough path.

## Why the CLI path had to go

`call_kiro` spawned `kiro-cli chat --no-interactive` as a subprocess: probe the filesystem for the binary (GUI apps inherit a minimal PATH), drain stdout/stderr on two threads with a `try_wait` poll loop, then scrape the answer back out of ANSI codes, a `> ` prompt marker and a `Credits: … Time: …` footer. That output has no machine-readable shape, so the prompt asked the model to wrap its answer in `{"t":"…"}` and the reply was recovered by balanced-brace matching — retried up to 3x when it came back unparseable. It also required users to install kiro-cli separately.

## How

AWS-JSON 1.0 `POST runtime.{region}.kiro.dev/generateAssistantResponse`, dispatched via `x-amz-target`, authenticated with the user's own `ksk_` key plus `tokentype: API_KEY`. Only what a one-shot translation needs is ported — no tools, history, streaming or thinking budgets.

Response parsing needs the same event scan the gateway uses: Kiro's body is **not** a binary eventstream a codec could decode, it's framing bytes with JSON events interleaved, so events are located by their leading key and brace-matched to their end. All known event prefixes are scanned and the **earliest** always consumed, not just the content ones — a `followupPrompt` event nests its own `{"content": …}` object, which a content-only scan would append as if it were assistant text. Consecutive duplicate chunks are dropped, matching the reference parser's handling of Kiro's occasional double-emits.

No new dependencies: `uuid_v4` uses `rand`, the stable client fingerprint uses `sha2` — both already in the tree.

## Also in here

- `post_json` checks HTTP status and surfaces `error.message`, so a 401 reads as an auth failure instead of silently becoming "returned no text". Gets a 60s timeout matching the old CLI one.
- Anthropic replies are read from the first `text` block rather than `content[0]`, which isn't reliably the answer when a thinking block is present.
- Reasoning-tag spans are stripped — the reference gateway runs its thinking FSM unconditionally and some models narrate unprompted. **Note:** this is defensive; no live call in testing actually produced one, so it's unit-test-only coverage.

## Model picker

`claude-haiku-4.5`, `claude-sonnet-4.6` and `glm-5` under a `kiro/` prefix that keeps them distinct from the direct-Anthropic entries (the backend strips it). A bare `kiro` — what earlier builds stored in `ai_model` — falls back to haiku, so existing installs keep working.

## Verification

`cargo test`: **143 passed, 0 failed**. `tsc --noEmit` clean.

Verified against the **live API with a real `ksk_` key**, sending exactly the request this code builds:

| Model | Response | Parsed |
|---|---|---|
| `claude-haiku-4.5` | 200, 1240 B | `빌드가 오류 없이 완료되었습니다.` |
| `claude-sonnet-4.6` | 200, 937 B | `모든 테스트가 통과되었습니다.` |
| `glm-5` | 200, 758 B | `모든 테스트가 통과했습니다.` |
| `claude-haiku-4.5` (detect step) | 200, 597 B | `Korean` |

Each raw body was fed through `collect_kiro_content` + `strip_thinking_tags` to produce the right-hand column, so the parser is verified against real wire data and not just synthesized input.

That capture also corrected the test suite: `collects_content_events_from_framed_body` was a `&str` literal, so it never exercised the lossy decode that the non-UTF-8 length prefixes and CRCs actually require, and it didn't model the `modelId` field riding along with each content event. It's now built from the real frame shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)