### PR TITLE
fix: price and aggregate gateway-rewritten model ids correctly

### DIFF
--- a/src-tauri/src/providers/claude_code.rs
+++ b/src-tauri/src/providers/claude_code.rs
@@ -91,7 +91,12 @@ fn calculate_cost(
 /// v1 (missing/0): dates stored as UTC strings (bug)
 /// v2: dates stored as local-timezone strings (correct)
 /// v3: total_tokens now includes cache tokens; cache TTL-aware cost calculation
-const CACHE_VERSION: u32 = 4;
+/// v4: (see above)
+/// v5: model ids stored normalized (gateway spellings collapsed to one key).
+///     A v4 cache holds raw ids, so merging it would re-split the very rows
+///     normalization exists to join — and its costs were computed with the
+///     pre-fix pricing lookup. Both require a rebuild, not a migration.
+const CACHE_VERSION: u32 = 5;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct DiskCache {
@@ -560,12 +565,20 @@ fn parse_session_line(line: &str) -> Option<SessionEntry> {
         }
     };
 
-    let model = message.get("model")?.as_str()?.to_string();
+    let raw_model = message.get("model")?.as_str()?;
 
     // Filter out synthetic/placeholder models
-    if model.starts_with('<') || model == "synthetic" {
+    if raw_model.starts_with('<') || raw_model == "synthetic" {
         return None;
     }
+
+    // Normalize here, at the one place a model id enters the pipeline, so every
+    // downstream consumer (daily tokens, model_usage, analytics, pricing) agrees
+    // on one key per model. A gateway reports the same model under several
+    // spellings — `claude-opus-4-8` / `claude-opus-4.8`, `gpt-5.6-sol` /
+    // `anthropic-gpt-5.6-sol` — and each raw string would otherwise become its
+    // own row in the breakdown.
+    let model = pricing::normalize_model_id(raw_model);
 
     let session_id = value.get("sessionId").and_then(|v| v.as_str()).unwrap_or("").to_string();
     let message_id = message.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
@@ -1129,6 +1142,60 @@ mod tests {
     fn parse_session_line_rejects_non_assistant() {
         let line = r#"{"type":"human","timestamp":"2026-03-23T10:00:00Z","message":{"content":"hello"}}"#;
         assert!(parse_session_line(line).is_none());
+    }
+
+    /// One assistant line with the given model id and 1 input token.
+    fn line_with_model(model: &str, id: &str) -> String {
+        format!(
+            r#"{{"sessionId":"s","type":"assistant","timestamp":"2026-03-23T10:00:00Z","requestId":"{id}","message":{{"id":"m-{id}","model":"{model}","usage":{{"input_tokens":1,"output_tokens":1}}}}}}"#
+        )
+    }
+
+    // Gateways report one model under several spellings. Normalizing at the parse
+    // site is what keeps them from becoming separate rows in the breakdown; every
+    // downstream map is keyed off `entry.model`.
+    #[test]
+    fn parse_session_line_normalizes_gateway_model_spellings() {
+        let cases = [
+            ("claude-opus-4.8", "claude-opus-4-8"),
+            ("kiro/claude-opus-5", "claude-opus-5"),
+            ("anthropic-gpt-5.6-sol", "gpt-5-6-sol"),
+        ];
+        for (raw, expected) in cases {
+            let entry = parse_session_line(&line_with_model(raw, "r1")).expect("should parse");
+            assert_eq!(entry.model, expected, "{raw:?} should normalize to {expected:?}");
+        }
+    }
+
+    // The spellings must land on one key, with their tokens summed rather than
+    // split across separate rows. Asserted through `aggregate_entries`, which is
+    // the pure aggregation step — `build_stats` also merges the on-disk cache
+    // from the real home directory, which would make this depend on local data.
+    #[test]
+    fn aggregation_merges_gateway_spellings_into_one_model() {
+        let parsed: Vec<SessionEntry> = ["claude-opus-4-8", "claude-opus-4.8", "CLAUDE-OPUS-4-8"]
+            .iter()
+            .enumerate()
+            .map(|(i, raw)| parse_session_line(&line_with_model(raw, &format!("r{i}"))).expect("should parse"))
+            .collect();
+        let refs: Vec<&SessionEntry> = parsed.iter().collect();
+
+        let (daily_map, model_usage, messages, _) = aggregate_entries(&refs);
+
+        assert_eq!(messages, 3, "all three lines are distinct messages");
+        assert_eq!(
+            model_usage.keys().collect::<Vec<_>>(),
+            vec!["claude-opus-4-8"],
+            "the three spellings must collapse to one model key"
+        );
+        let usage = &model_usage["claude-opus-4-8"];
+        assert_eq!(usage.input_tokens, 3, "all three spellings' tokens must sum");
+        assert_eq!(usage.output_tokens, 3);
+
+        // The per-day token map is keyed by model too, and must merge the same way.
+        let day = daily_map.values().next().expect("one day");
+        assert_eq!(day.tokens.len(), 1, "one model key per day, got {:?}", day.tokens);
+        assert_eq!(day.tokens["claude-opus-4-8"], 6, "3 input + 3 output tokens");
     }
 
     #[test]

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -410,10 +410,14 @@ impl CodexProvider {
 
                                     let date = resolve_entry_date(path_date.as_deref(), &value);
 
+                                    // Normalized so one model yields one key here
+                                    // and in every other provider — the frontend
+                                    // merges providers' model_usage by key, so
+                                    // differing spellings would split a row.
                                     let model = if state.current_model.is_empty() {
                                         "codex".to_string()
                                     } else {
-                                        state.current_model.clone()
+                                        pricing::normalize_model_id(&state.current_model)
                                     };
 
                                     let cumulative = extract_cumulative_usage(info);

--- a/src-tauri/src/providers/grok.rs
+++ b/src-tauri/src/providers/grok.rs
@@ -146,11 +146,38 @@ fn history_path() -> PathBuf {
         .join("ai-token-monitor-grok-history.json")
 }
 
+/// Re-key each day's model map through [`pricing::normalize_model_id`], summing
+/// any entries that collapse together.
+///
+/// Snapshots written before model ids were normalized hold raw keys (`grok-4.5`),
+/// while fresh records now arrive normalized (`grok-4-5`), so without this the
+/// same model would appear as two rows — one frozen at the old total. The
+/// snapshot carries history already rolled off the logs and cannot be rebuilt,
+/// so it is migrated in place rather than discarded. Normalization is idempotent,
+/// which makes re-running this on an already-migrated snapshot a no-op.
+fn migrate_model_keys(history: &mut GrokHistory) {
+    for day in history.days.values_mut() {
+        let mut migrated: HashMap<String, HistoryModel> = HashMap::with_capacity(day.models.len());
+        for (model, usage) in day.models.drain() {
+            let acc = migrated
+                .entry(pricing::normalize_model_id(&model))
+                .or_default();
+            acc.input_tokens += usage.input_tokens;
+            acc.output_tokens += usage.output_tokens;
+            acc.cache_read_tokens += usage.cache_read_tokens;
+            acc.cost_usd += usage.cost_usd;
+        }
+        day.models = migrated;
+    }
+}
+
 fn load_history_from(path: &Path) -> GrokHistory {
-    fs::read_to_string(path)
+    let mut history: GrokHistory = fs::read_to_string(path)
         .ok()
         .and_then(|c| serde_json::from_str(&c).ok())
-        .unwrap_or_default()
+        .unwrap_or_default();
+    migrate_model_keys(&mut history);
+    history
 }
 
 fn save_history_to(path: &Path, history: &GrokHistory) {
@@ -383,12 +410,14 @@ impl GrokProvider {
                 continue;
             };
 
+            // Normalized so one model yields one key across providers — the
+            // frontend merges providers' model_usage by key.
             let model = value
                 .get("current_model_id")
                 .and_then(|v| v.as_str())
                 .filter(|s| !s.is_empty())
-                .unwrap_or(UNKNOWN_MODEL)
-                .to_string();
+                .map(pricing::normalize_model_id)
+                .unwrap_or_else(|| UNKNOWN_MODEL.to_string());
             let project = value
                 .pointer("/info/cwd")
                 .and_then(|v| v.as_str())
@@ -708,11 +737,14 @@ mod tests {
         }
     }
 
+    /// `model` is the raw id as the log carries it; it is normalized here because
+    /// the real parser normalizes at that point, so `SessionMeta` never holds a
+    /// raw id in production.
     fn meta_for(sid: &str, model: &str, project: &str) -> HashMap<String, SessionMeta> {
         HashMap::from([(
             sid.to_string(),
             SessionMeta {
-                model: model.to_string(),
+                model: pricing::normalize_model_id(model),
                 project: project.to_string(),
             },
         )])
@@ -764,7 +796,7 @@ mod tests {
 
         let day = &history.days["2026-07-24"];
         assert_eq!(day.messages, 2);
-        let m = &day.models["grok-4.5"];
+        let m = &day.models["grok-4-5"];
         assert_eq!(m.input_tokens, 600 + 1_500);
         assert_eq!(m.cache_read_tokens, 400 + 500);
         assert_eq!(m.output_tokens, 300);
@@ -876,6 +908,45 @@ mod tests {
         assert!(history.days["2026-07-24"].models.contains_key(UNKNOWN_MODEL));
     }
 
+    // A snapshot written before ids were normalized holds raw keys. Loading it
+    // must fold them onto the normalized key rather than leave two rows — one of
+    // them frozen, since fresh records only ever land on the normalized key. The
+    // snapshot holds history already rolled off the logs, so it is migrated
+    // rather than discarded.
+    #[test]
+    fn loading_migrates_pre_normalization_model_keys() {
+        let dir = std::env::temp_dir().join(format!("grok-migrate-test-{}", std::process::id()));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        let path = dir.join("history.json");
+
+        // Hand-built legacy snapshot: the same model under raw and normalized keys.
+        let mut legacy = GrokHistory::default();
+        let day = legacy.days.entry("2026-07-24".to_string()).or_default();
+        day.models.insert("grok-4.5".to_string(), HistoryModel {
+            input_tokens: 100, output_tokens: 10, cache_read_tokens: 5, cost_usd: 1.0,
+        });
+        day.models.insert("grok-4-5".to_string(), HistoryModel {
+            input_tokens: 200, output_tokens: 20, cache_read_tokens: 7, cost_usd: 2.0,
+        });
+        save_history_to(&path, &legacy);
+
+        let restored = load_history_from(&path);
+        let day = &restored.days["2026-07-24"];
+        assert_eq!(day.models.len(), 1, "raw and normalized keys must merge, got {:?}", day.models.keys());
+        let m = &day.models["grok-4-5"];
+        assert_eq!(m.input_tokens, 300, "both keys' tokens must sum");
+        assert_eq!(m.output_tokens, 30);
+        assert_eq!(m.cache_read_tokens, 12);
+        assert!((m.cost_usd - 3.0).abs() < 1e-9);
+
+        // Migration is idempotent: re-loading a migrated snapshot changes nothing.
+        save_history_to(&path, &restored);
+        let again = load_history_from(&path);
+        assert_eq!(again.days["2026-07-24"].models["grok-4-5"].input_tokens, 300);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
     #[test]
     fn survives_a_save_load_round_trip() {
         let records = vec![rec(1_000, "2026-07-24", "s1", 250_000, 200_000, 400)];
@@ -891,7 +962,7 @@ mod tests {
         assert_eq!(restored.cursor, history.cursor);
         let day = &restored.days["2026-07-24"];
         assert_eq!(day.session_ids.len(), 1);
-        assert_eq!(day.models["grok-4.5"].cache_read_tokens, 200_000);
+        assert_eq!(day.models["grok-4-5"].cache_read_tokens, 200_000);
         assert_eq!(day.projects["proj"].tokens, 250_400);
 
         // A restored snapshot must not re-absorb records it already counted.

--- a/src-tauri/src/providers/kimi.rs
+++ b/src-tauri/src/providers/kimi.rs
@@ -180,10 +180,12 @@ impl KimiProvider {
             let date = extract_date_from_value(&value)
                 .unwrap_or_else(|| extract_date_from_file_mtime(path));
 
+            // Normalized so one model yields one key across providers — the
+            // frontend merges providers' model_usage by key.
             let model = if current_model.is_empty() {
                 "kimi-k2".to_string()
             } else {
-                current_model.clone()
+                pricing::normalize_model_id(&current_model)
             };
 
             let key = format!("{}:{}", session_id, line_index);

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -608,7 +608,11 @@ fn parse_message_json(id: &str, data: &Value) -> Option<OpenCodeEntry> {
 
     Some(OpenCodeEntry {
         date,
-        model: model_id.to_string(),
+        // Normalized so one model yields one key across providers — the frontend
+        // merges providers' model_usage by key. opencode ids carry a provider
+        // prefix (`anthropic/claude-opus-5`), which is exactly what gets dropped;
+        // its pricing patterns are bare families, so matching is unaffected.
+        model: pricing::normalize_model_id(model_id),
         session_id,
         input_tokens: input,
         output_tokens: output,

--- a/src-tauri/src/providers/pricing.rs
+++ b/src-tauri/src/providers/pricing.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
-use std::sync::OnceLock;
+use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
 
 /// Embedded pricing JSON (compile-time fallback)
 const EMBEDDED_PRICING: &str = include_str!("../../pricing.json");
@@ -244,13 +245,69 @@ fn config() -> &'static PricingConfig {
     })
 }
 
-fn find_pricing<'a>(provider: &'a ProviderConfig, model: &str) -> &'a PricingEntry {
+/// Normalize a model id so cosmetic spelling differences don't defeat matching.
+///
+/// Proxies and gateways (omniroute, LiteLLM, Bedrock, …) rewrite the model id
+/// on its way into the log, so the same model arrives under several spellings:
+/// `claude-opus-4.8` (dots for hyphens), `CLAUDE5_SONNET` (upper snake), or
+/// `kiro/claude-opus-5` (vendor prefix). The patterns in `pricing.json` use one
+/// spelling — lowercase, hyphenated — so a dotted id like `claude-opus-4.8`
+/// misses `opus-4-8` and falls through to the broader `opus-4` entry, billing
+/// Opus 4.8 at Opus 4.1 rates (3x). Folding both sides to the same shape makes
+/// the match spelling-independent.
+///
+/// This only folds spelling; it leaves vendor prefixes alone, since patterns
+/// match as substrings and `kiro/claude-opus-5` already contains `opus-5`.
+/// Stripping the prefix is [`normalize_model_id`]'s job.
+fn canonical_model(model: &str) -> String {
+    model
+        .chars()
+        .map(|c| match c {
+            '.' | '_' => '-',
+            c => c.to_ascii_lowercase(),
+        })
+        .collect()
+}
+
+/// Model ids already reported as unmatched, so the warning fires once per id
+/// rather than once per message.
+static WARNED_UNMATCHED: Mutex<Option<HashSet<String>>> = Mutex::new(None);
+
+/// Warn once that `model` matched no pattern and is being billed at
+/// `provider`'s default rates. A silent fallback is how a new model id ends up
+/// mispriced with nothing to point at, so each unknown id gets one line.
+fn warn_unmatched(provider_name: &str, model: &str, default: &str) {
+    let mut guard = match WARNED_UNMATCHED.lock() {
+        Ok(g) => g,
+        Err(e) => e.into_inner(),
+    };
+    let seen = guard.get_or_insert_with(HashSet::new);
+    if seen.insert(format!("{}:{}", provider_name, model)) {
+        eprintln!(
+            "[PRICING] No pattern matched model {:?} in the {} table — billing at the default ({:?}) rates. \
+             Add an entry to pricing.json if this model has its own price.",
+            model, provider_name, default
+        );
+    }
+}
+
+/// Find the entry for `model`, or the provider's default when nothing matches.
+/// `provider_name` only labels the unmatched-model warning.
+fn find_pricing_in<'a>(
+    provider: &'a ProviderConfig,
+    provider_name: &str,
+    model: &str,
+) -> &'a PricingEntry {
+    // Compare canonical forms so dotted/upper/underscored ids from proxies land
+    // on the same entry as the hyphenated lowercase ids the patterns are written in.
+    let canonical = canonical_model(model);
     // First match wins (order in JSON matters)
     provider
         .models
         .iter()
-        .find(|e| model.contains(&e.match_pattern))
+        .find(|e| canonical.contains(&canonical_model(&e.match_pattern)))
         .unwrap_or_else(|| {
+            warn_unmatched(provider_name, model, &provider.default);
             // Fallback to default model
             provider
                 .models
@@ -262,13 +319,153 @@ fn find_pricing<'a>(provider: &'a ProviderConfig, model: &str) -> &'a PricingEnt
 
 // --- Public API ---
 
+/// Entry lookup without a provider label, for tests asserting which entry a
+/// model id lands on.
+#[cfg(test)]
+fn find_pricing<'a>(provider: &'a ProviderConfig, model: &str) -> &'a PricingEntry {
+    find_pricing_in(provider, "test", model)
+}
+
 /// Look up and date-resolve a model's prices in one step.
-fn resolved_pricing(provider: &ProviderConfig, model: &str) -> ResolvedPrice {
-    find_pricing(provider, model).resolve_for(&today_utc())
+fn resolved_pricing(provider: &ProviderConfig, provider_name: &str, model: &str) -> ResolvedPrice {
+    find_pricing_in(provider, provider_name, model).resolve_for(&today_utc())
+}
+
+/// Prefixes a gateway prepends to name the endpoint it routed through. They
+/// describe the route, not the model, so they only ever split one model across
+/// several rows in the breakdown.
+const VENDOR_PREFIXES: &[&str] = &[
+    "anthropic", "openai", "azure", "bedrock", "vertex", "google", "xai",
+    "moonshot", "zhipu", "kiro", "litellm", "omniroute", "openrouter",
+];
+
+/// Stable identity for a model, for use as an aggregation key.
+///
+/// A proxy can emit the same model under several spellings, and each distinct
+/// string becomes its own row in the model breakdown — `claude-opus-4-8` and
+/// `claude-opus-4.8` show up as two models, as do `gpt-5.6-sol` and
+/// `anthropic-gpt-5.6-sol`. Folding to one form collapses them back into one row.
+///
+/// Two prefixes are dropped:
+/// - a leading `vendor/` path segment (`kiro/claude-opus-5` → `claude-opus-5`),
+///   which is unambiguously routing metadata;
+/// - a leading `vendor-` token *only when the remainder belongs to a different
+///   vendor's family* (`anthropic-gpt-5.6-sol` → `gpt-5-6-sol`). That guard is
+///   what keeps `claude-opus-5` intact: stripping `claude-` would leave `opus-5`,
+///   an Anthropic family, so no strip happens.
+///
+/// The result still matches `pricing.json` patterns, which are compared in the
+/// same canonical form — every table's patterns are bare model families with no
+/// vendor path, so dropping the prefix cannot cost a match.
+pub fn normalize_model_id(model: &str) -> String {
+    let canonical = canonical_model(model);
+    // Routing path segment: the model is whatever follows the last slash.
+    let without_path = canonical.rsplit('/').next().unwrap_or(&canonical);
+    // Strip a vendor token only when what follows still names a model family.
+    // `moonshot` is both a vendor and part of real model ids (`moonshot-v1-8k`),
+    // and there the remainder (`v1-8k`) names no family — so it is left alone.
+    for vendor in VENDOR_PREFIXES {
+        if let Some(rest) = without_path.strip_prefix(&format!("{}-", vendor)) {
+            if names_a_family(rest) {
+                return rest.to_string();
+            }
+        }
+    }
+    without_path.to_string()
+}
+
+/// Anthropic model families, as they appear inside a model id.
+const ANTHROPIC_FAMILIES: &[&str] =
+    &["claude", "opus", "sonnet", "haiku", "fable", "mythos"];
+
+/// True when `id` names a recognizable model family (Anthropic or otherwise).
+/// Used to tell a vendor prefix apart from a vendor name that is genuinely part
+/// of the model id.
+fn names_a_family(id: &str) -> bool {
+    !id.is_empty()
+        && (ANTHROPIC_FAMILIES.iter().any(|f| id.contains(f))
+            || foreign_table(id).is_some()
+            || OTHER_FAMILIES.iter().any(|f| id.contains(f)))
+}
+
+/// Which non-Anthropic pricing table a model id belongs to, if any.
+///
+/// Claude Code's log records whatever model id the endpoint reported, so a
+/// gateway pointing it at a non-Anthropic model leaves a foreign id in a
+/// Claude-shaped log (omniroute writes `anthropic-gpt-5.6-sol` — an OpenAI model
+/// behind an Anthropic-compatible endpoint). Matching is on the model family in
+/// the id, never on the vendor prefix, precisely because that prefix lies here.
+///
+/// Returns `None` for Anthropic models and for anything unrecognized, so the
+/// caller falls through to the claude table and its unmatched-model warning.
+fn foreign_table(canonical: &str) -> Option<&'static str> {
+    // Anthropic families first: an Anthropic id must never be routed away, even
+    // if some future name happens to contain a foreign substring.
+    if ANTHROPIC_FAMILIES.iter().any(|f| canonical.contains(f)) {
+        return None;
+    }
+    // OpenAI/Codex: gpt-*, o3/o4 reasoning models, and the codex variants.
+    if canonical.contains("gpt")
+        || canonical.contains("codex")
+        || canonical.contains("o3-")
+        || canonical.contains("o4-")
+    {
+        return Some("codex");
+    }
+    if canonical.contains("grok") {
+        return Some("grok");
+    }
+    if canonical.contains("kimi") || canonical.contains("moonshot") {
+        return Some("kimi");
+    }
+    if canonical.contains("glm") {
+        return Some("glm");
+    }
+    None
+}
+
+/// Families that have no pricing table of their own but are still recognizable
+/// model names. Only [`names_a_family`] consults these: a vendor prefix in front
+/// of `gemini-3` is still routing metadata even though no table prices Gemini.
+const OTHER_FAMILIES: &[&str] = &["gemini", "deepseek", "qwen", "llama", "mistral"];
+
+/// Price a non-Anthropic model found in a Claude-shaped log, expressed as
+/// [`ClaudePricing`] so the caller's cost math is unchanged.
+///
+/// These providers quote a single discounted rate for cached input rather than
+/// Anthropic's separate read/write rates, so `cached_input` maps onto
+/// `cache_read` and the cache-write rates are zero — matching how the codex and
+/// grok providers already bill their own logs.
+fn foreign_model_pricing(model: &str) -> Option<ClaudePricing> {
+    let canonical = canonical_model(model);
+    let table = foreign_table(&canonical)?;
+    let cfg = config();
+    let (provider, cached_as_read) = match table {
+        "codex" => (&cfg.codex, true),
+        "grok" => (cfg.grok.as_ref()?, true),
+        "kimi" => (cfg.kimi.as_ref()?, false),
+        "glm" => (cfg.glm.as_ref()?, false),
+        _ => return None,
+    };
+    let p = resolved_pricing(provider, table, model);
+    Some(ClaudePricing {
+        input: p.input,
+        output: p.output,
+        cache_read: if cached_as_read { p.cached_input } else { p.cache_read },
+        cache_write_5m: p.cache_write,
+        cache_write_1h: if p.cache_write_1h > 0.0 { p.cache_write_1h } else { p.cache_write },
+    })
 }
 
 pub fn get_claude_pricing(model: &str) -> ClaudePricing {
-    let p = resolved_pricing(&config().claude, model);
+    // Claude Code's log can carry non-Anthropic models when a proxy/gateway
+    // routes them (omniroute reports e.g. `anthropic-gpt-5.6-sol`). Those have
+    // no entry in the claude table, so without this they'd silently bill at the
+    // Sonnet default. Route by model family, not by which log file it came from.
+    if let Some(p) = foreign_model_pricing(model) {
+        return p;
+    }
+    let p = resolved_pricing(&config().claude, "claude", model);
     ClaudePricing {
         input: p.input,
         output: p.output,
@@ -279,7 +476,7 @@ pub fn get_claude_pricing(model: &str) -> ClaudePricing {
 }
 
 pub fn get_codex_pricing(model: &str) -> CodexPricing {
-    let p = resolved_pricing(&config().codex, model);
+    let p = resolved_pricing(&config().codex, "codex", model);
     CodexPricing {
         input: p.input,
         output: p.output,
@@ -290,7 +487,7 @@ pub fn get_codex_pricing(model: &str) -> CodexPricing {
 pub fn get_kimi_pricing(model: &str) -> KimiPricing {
     let cfg = config();
     if let Some(ref kimi) = cfg.kimi {
-        let p = resolved_pricing(kimi, model);
+        let p = resolved_pricing(kimi, "kimi", model);
         return KimiPricing {
             input: p.input,
             output: p.output,
@@ -305,7 +502,7 @@ pub fn get_kimi_pricing(model: &str) -> KimiPricing {
 pub fn get_glm_pricing(model: &str) -> GlmPricing {
     let cfg = config();
     if let Some(ref glm) = cfg.glm {
-        let p = resolved_pricing(glm, model);
+        let p = resolved_pricing(glm, "glm", model);
         return GlmPricing {
             input: p.input,
             output: p.output,
@@ -319,7 +516,7 @@ pub fn get_glm_pricing(model: &str) -> GlmPricing {
 pub fn get_grok_pricing(model: &str) -> GrokPricing {
     let cfg = config();
     if let Some(ref grok) = cfg.grok {
-        let p = resolved_pricing(grok, model);
+        let p = resolved_pricing(grok, "grok", model);
         let high = p.high_context;
         return GrokPricing {
             input: p.input,
@@ -348,7 +545,7 @@ pub fn get_opencode_pricing(model: &str) -> OpenCodePricing {
     // Use dedicated opencode pricing if available, otherwise try to match
     // against claude or codex pricing tables based on model name.
     if let Some(ref oc) = cfg.opencode {
-        let p = resolved_pricing(oc, model);
+        let p = resolved_pricing(oc, "opencode", model);
         return OpenCodePricing {
             input: p.input,
             output: p.output,
@@ -359,7 +556,7 @@ pub fn get_opencode_pricing(model: &str) -> OpenCodePricing {
 
     // Fallback: try claude pricing first (for claude-* models), then codex
     if model.contains("claude") || model.contains("fable") || model.contains("mythos") || model.contains("sonnet") || model.contains("opus") || model.contains("haiku") {
-        let p = resolved_pricing(&cfg.claude, model);
+        let p = resolved_pricing(&cfg.claude, "claude", model);
         OpenCodePricing {
             input: p.input,
             output: p.output,
@@ -367,7 +564,7 @@ pub fn get_opencode_pricing(model: &str) -> OpenCodePricing {
             cache_write: p.cache_write,
         }
     } else {
-        let p = resolved_pricing(&cfg.codex, model);
+        let p = resolved_pricing(&cfg.codex, "codex", model);
         OpenCodePricing {
             input: p.input,
             output: p.output,
@@ -770,6 +967,256 @@ mod tests {
     fn claude_unknown_defaults_to_sonnet() {
         let p = get_claude_pricing("claude-unknown-model");
         assert!((p.input - 3.0).abs() < 0.001);
+    }
+
+    // --- Proxy/gateway model id normalization ---
+
+    #[test]
+    fn canonical_model_folds_case_dots_and_underscores() {
+        assert_eq!(canonical_model("claude-opus-4.8"), "claude-opus-4-8");
+        assert_eq!(canonical_model("CLAUDE5_SONNET"), "claude5-sonnet");
+        assert_eq!(canonical_model("claude-opus-4-8"), "claude-opus-4-8");
+        // Vendor prefixes survive: patterns match as substrings, and opencode's
+        // table matches on `anthropic/` deliberately.
+        assert_eq!(canonical_model("kiro/claude-opus-5"), "kiro/claude-opus-5");
+    }
+
+    // Regression guard: omniroute reports Opus 4.8 as `claude-opus-4.8` (dots).
+    // Before canonical matching, `"claude-opus-4.8".contains("opus-4-8")` was
+    // false, so it fell through to the broader `opus-4` entry and billed at Opus
+    // 4.1 rates ($15/$75) — a 3x overcharge on every such message.
+    #[test]
+    fn claude_dotted_opus_48_not_billed_as_41() {
+        let dotted = get_claude_pricing("claude-opus-4.8");
+        assert!((dotted.input - 5.0).abs() < 0.001, "dotted Opus 4.8 input must be $5/MTok, got ${}", dotted.input);
+        assert!((dotted.output - 25.0).abs() < 0.001, "dotted Opus 4.8 output must be $25/MTok, got ${}", dotted.output);
+
+        // Both spellings must price identically.
+        let hyphenated = get_claude_pricing("claude-opus-4-8");
+        assert!((dotted.input - hyphenated.input).abs() < 0.001);
+        assert!((dotted.output - hyphenated.output).abs() < 0.001);
+        assert!((dotted.cache_read - hyphenated.cache_read).abs() < 0.001);
+        assert!((dotted.cache_write_5m - hyphenated.cache_write_5m).abs() < 0.001);
+        assert!((dotted.cache_write_1h - hyphenated.cache_write_1h).abs() < 0.001);
+    }
+
+    // Dotted spellings must not shadow neighbouring versions: `claude-opus-4.1`
+    // still has to reach the Opus 4.1 entry, not the 4.8 one.
+    #[test]
+    fn claude_dotted_opus_41_still_resolves_to_41() {
+        let cfg: PricingConfig = serde_json::from_str(EMBEDDED_PRICING).unwrap();
+        let entry = find_pricing(&cfg.claude, "claude-opus-4.1");
+        assert_eq!(entry.label, "Opus 4.1/4");
+        let p = get_claude_pricing("claude-opus-4.1");
+        assert!((p.input - 15.0).abs() < 0.001, "Opus 4.1 input must stay $15/MTok, got ${}", p.input);
+    }
+
+    // Upper snake case ids (`CLAUDE5_SONNET`) matched nothing at all before
+    // canonicalization and fell to the default. Now they reach the Sonnet entry.
+    #[test]
+    fn claude_upper_snake_case_id_matches_sonnet() {
+        let cfg: PricingConfig = serde_json::from_str(EMBEDDED_PRICING).unwrap();
+        let entry = find_pricing(&cfg.claude, "CLAUDE5_SONNET");
+        assert_eq!(entry.label, "Sonnet 4.x");
+    }
+
+    // Canonicalization must not disturb any existing resolution. Every pattern,
+    // used as a model id, has to land on the entry it did before.
+    #[test]
+    fn canonical_matching_preserves_existing_resolutions() {
+        let cfg: PricingConfig = serde_json::from_str(EMBEDDED_PRICING).unwrap();
+        let tables: Vec<(&str, &ProviderConfig)> = vec![
+            ("claude", &cfg.claude),
+            ("codex", &cfg.codex),
+            ("opencode", cfg.opencode.as_ref().unwrap()),
+            ("kimi", cfg.kimi.as_ref().unwrap()),
+            ("glm", cfg.glm.as_ref().unwrap()),
+            ("grok", cfg.grok.as_ref().unwrap()),
+        ];
+        for (name, provider) in tables {
+            // No two patterns may collapse to the same canonical form — that
+            // would let one silently shadow the other.
+            let mut seen = std::collections::HashSet::new();
+            for e in &provider.models {
+                assert!(
+                    seen.insert(canonical_model(&e.match_pattern)),
+                    "[{}] pattern {:?} collides with another after canonicalization",
+                    name, e.match_pattern
+                );
+            }
+            // Each pattern, treated as a model id, still resolves to itself
+            // (first match wins, so the first pattern containing it may differ —
+            // assert against raw matching, which is the pre-change behaviour).
+            for e in &provider.models {
+                let raw = provider
+                    .models
+                    .iter()
+                    .find(|c| e.match_pattern.contains(&c.match_pattern))
+                    .map(|c| c.match_pattern.as_str());
+                let canon = find_pricing_in(provider, name, &e.match_pattern).match_pattern.as_str();
+                assert_eq!(
+                    raw, Some(canon),
+                    "[{}] {:?} resolves differently under canonical matching",
+                    name, e.match_pattern
+                );
+            }
+        }
+    }
+
+    // --- Aggregation-key normalization ---
+
+    // The point of normalization: spellings a gateway emits for one model must
+    // collapse to one key, or the breakdown shows the same model twice.
+    #[test]
+    fn normalize_model_id_collapses_gateway_spellings() {
+        // Dotted vs hyphenated.
+        assert_eq!(normalize_model_id("claude-opus-4.8"), normalize_model_id("claude-opus-4-8"));
+        // Vendor path segment.
+        assert_eq!(normalize_model_id("kiro/claude-opus-5"), normalize_model_id("claude-opus-5"));
+        assert_eq!(normalize_model_id("claude/claude-opus-5"), normalize_model_id("claude-opus-5"));
+        // Contradicting vendor token on a foreign model.
+        assert_eq!(normalize_model_id("anthropic-gpt-5.6-sol"), normalize_model_id("gpt-5.6-sol"));
+        // Case and underscores.
+        assert_eq!(normalize_model_id("CLAUDE-OPUS-5"), normalize_model_id("claude-opus-5"));
+    }
+
+    // Distinct models must stay distinct — normalization must not over-merge.
+    #[test]
+    fn normalize_model_id_keeps_distinct_models_apart() {
+        let ids = [
+            "claude-opus-5", "claude-opus-4-8", "claude-opus-4-1", "claude-sonnet-5",
+            "claude-sonnet-4-6", "claude-haiku-4-5-20251001", "claude-fable-5",
+            "claude-mythos-5", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5-codex", "grok-4.5",
+        ];
+        let mut seen = std::collections::HashMap::new();
+        for id in ids {
+            let key = normalize_model_id(id);
+            if let Some(prev) = seen.insert(key.clone(), id) {
+                panic!("{id:?} and {prev:?} both normalize to {key:?}");
+            }
+        }
+    }
+
+    // The Anthropic-family guard: `claude-` is in VENDOR_PREFIXES via `kiro`-style
+    // handling, but stripping a family token would turn `claude-opus-5` into
+    // `opus-5` and split it from ids that keep the prefix.
+    #[test]
+    fn normalize_model_id_preserves_anthropic_family_tokens() {
+        assert_eq!(normalize_model_id("claude-opus-5"), "claude-opus-5");
+        assert_eq!(normalize_model_id("claude-sonnet-5"), "claude-sonnet-5");
+        // A vendor prefix in front of an Anthropic model is dropped, but the
+        // Anthropic id underneath is left whole.
+        assert_eq!(normalize_model_id("bedrock/claude-opus-5"), "claude-opus-5");
+    }
+
+    // `moonshot` is both a vendor name and a real model-id prefix
+    // (`moonshot-v1-8k`). Stripping it there would destroy the id, so the strip
+    // only fires when what remains still names a family.
+    #[test]
+    fn normalize_model_id_keeps_vendor_names_that_are_part_of_the_id() {
+        assert_eq!(normalize_model_id("moonshot-v1-8k"), "moonshot-v1-8k");
+        // With a family after it, the prefix is routing metadata and goes.
+        assert_eq!(normalize_model_id("moonshot-kimi-k2"), "kimi-k2");
+    }
+
+    // Normalized ids must still price correctly — normalization feeds the same
+    // lookup, so a normalized key must not lose its pricing entry.
+    #[test]
+    fn normalized_ids_still_resolve_to_the_same_price() {
+        for id in [
+            "claude-opus-4.8", "kiro/claude-opus-5", "anthropic-gpt-5.6-sol",
+            "CLAUDE-OPUS-5", "claude-sonnet-5", "grok-4.5",
+        ] {
+            let raw = get_claude_pricing(id);
+            let normalized = get_claude_pricing(&normalize_model_id(id));
+            assert!(
+                (raw.input - normalized.input).abs() < 0.001
+                    && (raw.output - normalized.output).abs() < 0.001,
+                "{id:?} prices differently after normalization: ${}/${} vs ${}/${}",
+                raw.input, raw.output, normalized.input, normalized.output
+            );
+        }
+    }
+
+    // Normalization is idempotent — re-normalizing a stored key is a no-op, so a
+    // cache written with normalized keys stays stable across versions.
+    #[test]
+    fn normalize_model_id_is_idempotent() {
+        for id in [
+            "claude-opus-4.8", "kiro/claude-opus-5", "anthropic-gpt-5.6-sol",
+            "moonshot-v1-8k", "CLAUDE5_SONNET", "gpt-5.6-sol",
+        ] {
+            let once = normalize_model_id(id);
+            assert_eq!(normalize_model_id(&once), once, "{id:?} is not idempotent");
+        }
+    }
+
+    // --- Foreign models in Claude Code's log ---
+
+    // Regression guard: omniroute routes Claude Code at OpenAI models and logs
+    // them as `anthropic-gpt-5.6-sol` — an OpenAI model wearing an Anthropic
+    // prefix. Billing it from the claude table meant no pattern matched and it
+    // fell to the Sonnet default ($3/$15) instead of GPT-5.6 Sol's $5/$30.
+    #[test]
+    fn claude_log_gpt56_sol_billed_from_codex_table() {
+        let codex = get_codex_pricing("gpt-5.6-sol");
+        for id in ["gpt-5.6-sol", "anthropic-gpt-5.6-sol"] {
+            let p = get_claude_pricing(id);
+            assert!((p.input - codex.input).abs() < 0.001, "{id} input must be ${}, got ${}", codex.input, p.input);
+            assert!((p.output - codex.output).abs() < 0.001, "{id} output must be ${}, got ${}", codex.output, p.output);
+            // OpenAI quotes one discounted cached-input rate, mapped onto cache_read.
+            assert!((p.cache_read - codex.cached_input).abs() < 0.001);
+            assert!(p.cache_write_5m.abs() < 0.001, "{id} must have no cache-write rate");
+        }
+    }
+
+    #[test]
+    fn claude_log_foreign_families_route_to_their_tables() {
+        let grok = get_claude_pricing("grok-4.5");
+        let grok_ref = get_grok_pricing("grok-4.5");
+        assert!((grok.input - grok_ref.input).abs() < 0.001);
+        assert!((grok.output - grok_ref.output).abs() < 0.001);
+
+        let kimi = get_claude_pricing("kimi-k2");
+        let kimi_ref = get_kimi_pricing("kimi-k2");
+        assert!((kimi.input - kimi_ref.input).abs() < 0.001);
+        assert!((kimi.output - kimi_ref.output).abs() < 0.001);
+
+        let codex = get_claude_pricing("gpt-5-codex");
+        assert!((codex.input - 1.25).abs() < 0.001, "gpt-5-codex must bill at $1.25, got ${}", codex.input);
+    }
+
+    // Anthropic ids must never be routed away, and unknown ids must stay on the
+    // claude table so the default fallback (and its warning) still applies.
+    #[test]
+    fn anthropic_and_unknown_ids_stay_on_claude_table() {
+        for id in [
+            "claude-opus-5", "claude-sonnet-5", "claude-fable-5", "claude-mythos-5",
+            "claude-haiku-4-5-20251001", "opus", "sonnet", "haiku", "fable",
+            "kiro/claude-opus-5", "claude/claude-opus-5",
+        ] {
+            assert!(
+                foreign_table(&canonical_model(id)).is_none(),
+                "{id} must stay on the claude table"
+            );
+        }
+        assert_eq!(foreign_table(&canonical_model("some-unknown-model")), None);
+
+        // Vendor-prefixed foreign ids still route by family, not by prefix.
+        assert_eq!(foreign_table(&canonical_model("anthropic-gpt-5.6-sol")), Some("codex"));
+        assert_eq!(foreign_table(&canonical_model("openai/gpt-5.6-terra")), Some("codex"));
+    }
+
+    // A Claude id whose spelling comes from a proxy must still price as Anthropic.
+    #[test]
+    fn claude_pricing_unchanged_for_known_anthropic_ids() {
+        let opus5 = get_claude_pricing("claude-opus-5");
+        assert!((opus5.input - 5.0).abs() < 0.001);
+        assert!((opus5.output - 25.0).abs() < 0.001);
+        // Vendor-prefixed Claude ids price identically to the bare id.
+        let prefixed = get_claude_pricing("kiro/claude-opus-5");
+        assert!((prefixed.input - opus5.input).abs() < 0.001);
+        assert!((prefixed.output - opus5.output).abs() < 0.001);
     }
 
     #[test]

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,6 +11,7 @@ import { ReceiptOverlay } from "./receipt/ReceiptOverlay";
 import type { AllStats } from "../lib/types";
 import type { UpdaterState } from "../hooks/useUpdater";
 import { formatTokens, formatCost, getTotalTokens, toLocalDateStr } from "../lib/format";
+import { shortenModelName } from "../lib/statsHelpers";
 import { useI18n } from "../i18n/I18nContext";
 import { useSettings } from "../contexts/SettingsContext";
 
@@ -104,7 +105,7 @@ export function Header({ stats, updater }: Props) {
       ``,
       `## ${t("export.models")}`,
       ...Object.entries(stats.model_usage).map(
-        ([model, u]) => `- **${model}**: ${formatTokens(u.input_tokens + u.output_tokens + u.cache_read, "full")} tokens, ${formatCost(u.cost_usd)}`
+        ([model, u]) => `- **${shortenModelName(model)}**: ${formatTokens(u.input_tokens + u.output_tokens + u.cache_read, "full")} tokens, ${formatCost(u.cost_usd)}`
       ),
     ];
 

--- a/src/components/ModelBreakdown.tsx
+++ b/src/components/ModelBreakdown.tsx
@@ -1,24 +1,11 @@
 import type { ModelUsage } from "../lib/types";
 import { formatTokens, formatCost } from "../lib/format";
+import { shortenModelName } from "../lib/statsHelpers";
 import { useSettings } from "../contexts/SettingsContext";
 import { useI18n } from "../i18n/I18nContext";
 
 interface Props {
   modelUsage: Record<string, ModelUsage>;
-}
-
-function shortModelName(name: string): string {
-  // Extract family and version: "claude-opus-4-6" → "Opus 4.6", "claude-opus-5" → "Opus 5".
-  // Version digits are capped at 2 so date suffixes ("-20260320") never read as versions.
-  const match = name.match(/(opus|sonnet|haiku|fable|mythos)-(\d{1,2})(?:-(\d{1,2}))?(?!\d)/);
-  if (match) {
-    const family = match[1].charAt(0).toUpperCase() + match[1].slice(1);
-    return match[3] ? `${family} ${match[2]}.${match[3]}` : `${family} ${match[2]}`;
-  }
-  if (name.includes("opus")) return "Opus";
-  if (name.includes("sonnet")) return "Sonnet";
-  if (name.includes("haiku")) return "Haiku";
-  return name.split("-").slice(0, 2).join(" ");
 }
 
 export function ModelBreakdown({ modelUsage }: Props) {
@@ -69,7 +56,7 @@ export function ModelBreakdown({ modelUsage }: Props) {
                 marginBottom: 4,
               }}>
                 <span style={{ fontSize: 12, fontWeight: 700, color: "var(--text-primary)" }}>
-                  {shortModelName(model)}
+                  {shortenModelName(model)}
                   <span style={{ fontSize: 9, fontWeight: 500, color: "var(--text-secondary)", marginLeft: 4 }}>
                     {formatCost(usage.cost_usd)}
                   </span>

--- a/src/lib/statsHelpers.ts
+++ b/src/lib/statsHelpers.ts
@@ -165,13 +165,63 @@ export function computeStreaks(daily: DailyUsage[], year?: number): StreakInfo {
   };
 }
 
+/** Capitalize each hyphen-separated word, leaving pure-numeric segments alone. */
+function titleCase(s: string): string {
+  return s
+    .split("-")
+    .map((w) => (/^\d+$/.test(w) ? w : w.charAt(0).toUpperCase() + w.slice(1)))
+    .join(" ");
+}
+
+/**
+ * Human-readable label for a model id, e.g. `claude-opus-4-8` → "Opus 4.8".
+ *
+ * Ids reaching the frontend are normalized by the backend: lowercase, with dots
+ * and underscores folded to hyphens and any vendor prefix dropped. So `gpt-5.6-sol`
+ * arrives as `gpt-5-6-sol`, and the version separator has to be reconstructed
+ * here rather than read off the id.
+ *
+ * Version digits are capped at 2 so date suffixes ("-20260320") never read as
+ * versions.
+ */
 export function shortenModelName(name: string): string {
-  const match = name.match(/claude-(\w+)-(\d+)-(\d+)/);
-  if (match) {
-    return `${match[1].charAt(0).toUpperCase() + match[1].slice(1)} ${match[2]}.${match[3]}`;
+  const claude = name.match(
+    /(opus|sonnet|haiku|fable|mythos)-(\d{1,2})(?:-(\d{1,2}))?(?!\d)/
+  );
+  if (claude) {
+    const family = claude[1].charAt(0).toUpperCase() + claude[1].slice(1);
+    return claude[3] ? `${family} ${claude[2]}.${claude[3]}` : `${family} ${claude[2]}`;
   }
-  // Codex models
-  if (name.startsWith("gpt-")) return name;
-  if (name === "codex-mini") return "Codex Mini";
-  return name;
+
+  if (name === "codex-mini" || name === "codex-mini-latest") return "Codex Mini";
+  if (name === "codex") return "Codex";
+
+  // `gpt-4o` glues a letter to the version, so it has no `major.minor` to rebuild.
+  const gpt4o = name.match(/^gpt-4o(?:-(.+))?$/);
+  if (gpt4o) return `GPT-4o${gpt4o[1] ? " " + titleCase(gpt4o[1]) : ""}`;
+
+  // OpenAI reasoning models: `o3`, `o4-mini`.
+  const oSeries = name.match(/^(o\d)(?:-(.+))?$/);
+  if (oSeries) return `${oSeries[1].toUpperCase()}${oSeries[2] ? " " + titleCase(oSeries[2]) : ""}`;
+
+  // Families that write their version as `major-minor` and display it as
+  // `major.minor`, with an optional tier suffix:
+  //   gpt-5-6-sol → "GPT-5.6 Sol", grok-4-5 → "Grok 4.5", glm-4-6 → "GLM 4.6"
+  const FAMILIES: Array<[RegExp, string]> = [
+    [/^gpt-(\d{1,2})(?:-(\d{1,2}))?(?:-(.+))?$/, "GPT-"],
+    [/^grok-(\d{1,2})(?:-(\d{1,2}))?(?:-(.+))?$/, "Grok "],
+    [/^glm-(\d{1,2})(?:-(\d{1,2}))?(?:-(.+))?$/, "GLM "],
+    [/^gemini-(\d{1,2})(?:-(\d{1,2}))?(?:-(.+))?$/, "Gemini "],
+  ];
+  for (const [pattern, prefix] of FAMILIES) {
+    const m = name.match(pattern);
+    if (m) {
+      const version = m[2] ? `${m[1]}.${m[2]}` : m[1];
+      return `${prefix}${version}${m[3] ? " " + titleCase(m[3]) : ""}`;
+    }
+  }
+
+  // Unrecognized: title-case the hyphenated segments so it still reads as a name
+  // rather than a raw id.
+  return titleCase(name);
 }


### PR DESCRIPTION
## 문제

Claude Code를 프록시나 게이트웨이(omniroute, LiteLLM, Bedrock) 뒤에서 실행하면 로그에 기록되는 모델 ID가 변형됩니다. 변형된 표기는 `pricing.json`의 패턴에 매칭되지 않고, 표기가 다를 때마다 모델 breakdown에 별도 행으로 잡힙니다.

로컬 로그 한 달치(58,552 메시지, 1,302 파일)로 재현했습니다:

| 로그의 모델 ID | 적용된 단가 | 올바른 단가 |
|---|---|---|
| `claude-opus-4.8` | Opus 4.1 — $15/$75 | Opus 4.8 — $5/$25 |
| `anthropic-gpt-5.6-sol` | Sonnet 4.x 기본값 — $3/$15 | GPT-5.6 Sol — $5/$30 |
| `gpt-5.6-sol` | Sonnet 4.x 기본값 — $3/$15 | GPT-5.6 Sol — $5/$30 |
| `CLAUDE5_SONNET` | 매칭 실패 → 기본값 | Sonnet |

원인은 세 가지입니다.

**1. 점 표기가 매칭되지 않음.** `"claude-opus-4.8".contains("opus-4-8")`이 false라 더 넓은 `opus-4` 엔트리로 폴백하면서 3배 과다 청구됩니다. 기존 `claude_opus_48_not_billed_as_41` 테스트가 막으려 했던 바로 그 케이스인데, 하이픈 표기만 커버돼 있었습니다.

**2. Claude 형식 로그에 들어온 외부 모델.** Claude Code는 엔드포인트가 보고한 ID를 그대로 기록하므로, 게이트웨이가 OpenAI 모델로 라우팅하면 `anthropic-gpt-5.6-sol`이 로그에 남습니다. claude 테이블에 해당 엔트리가 없어 Sonnet 기본값으로 계산되는데, GPT-5.6 Sol은 이미 codex 테이블에 등록돼 있습니다.

**3. 매칭 실패 시 무음.** 어떤 패턴에도 걸리지 않을 때 아무 로그가 없어서, 새 모델 ID가 조용히 잘못 계산되고 단서가 남지 않습니다.

별개로, 집계 키가 원본 ID라서 breakdown이 **실제 8개 모델을 13행으로** 표시했습니다.

## 수정

**가격 조회** (`pricing.rs`) — 패턴 비교 시 양쪽을 소문자·하이픈 형태로 접어서 매칭합니다. `get_claude_pricing`은 Anthropic 계열이 아닌 ID를 codex/grok/kimi/glm 테이블로 라우팅합니다. Anthropic 패밀리를 **먼저** 검사해 Anthropic ID가 절대 밖으로 빠지지 않게 했고, 판별은 벤더 프리픽스가 아니라 ID 안의 모델 패밀리로 합니다 — 이 버그에서 거짓말을 하는 게 바로 그 프리픽스이기 때문입니다. 매칭 실패 시 어느 테이블에서 어떤 기본값으로 계산됐는지 ID당 한 줄씩 로그를 남깁니다.

**집계 키** (전 프로바이더) — 각 프로바이더가 파싱 지점에서 정규화하므로, 일별 토큰·`model_usage`·analytics·가격 조회가 모델당 하나의 키로 일치합니다.

Claude Code만이 아니라 **모든 프로바이더**에 적용했습니다. 프론트엔드가 프로바이더별 `model_usage`를 키로 병합하기 때문에(`useCombinedStats`), 한쪽만 정규화하면 이전에는 프로바이더 간에 병합됐던 ID가 오히려 갈라지는 회귀가 생깁니다. Kiro는 크레딧 기반이고 모델 단가가 없어 해당 없습니다.

**표시 이름** (`statsHelpers.ts`) — `shortenModelName`과 ModelBreakdown의 private `shortModelName`을 하나로 합쳤습니다. 공용 함수는 `claude-<x>-<n>-<n>`만 매칭해서 `claude-opus-5`와 모든 비Claude 모델에 원본 ID를 그대로 노출했고, Header의 마크다운 export는 헬퍼를 아예 쓰지 않았습니다. 이제 GPT/Grok/GLM/Gemini 티어, o-시리즈, gpt-4o까지 처리합니다.

### 영속화된 상태

정규화 이전 키를 담고 있는 저장소가 두 곳인데, 의도적으로 다르게 처리했습니다.

- **Claude 디스크 캐시** — 재구축 (`CACHE_VERSION` 4 → 5). 그대로 병합하면 정규화가 합치려는 행을 다시 갈라놓고, 저장된 비용도 가격 수정 이전 값입니다. 원본 로그에서 파생된 데이터라 재구축으로 잃는 게 없습니다.
- **Grok 스냅샷** — 폐기 대신 마이그레이션. 커서 기반 증분 저장소로 이미 로그에서 로테이션된 구간의 이력을 담고 있어, 버리면 그 데이터가 영구 손실됩니다. `load_history_from`이 로드 시 일별 모델 맵의 키를 다시 매기고 합쳐지는 항목을 합산합니다. 정규화가 idempotent하므로 이미 마이그레이션된 스냅샷에 재실행해도 무해합니다.

## 검증

`cargo test` 168개 통과(신규 10개), `tsc --noEmit` 통과, `npm run build` 통과.

빌드한 앱을 실행해서 캐시가 v5로 재구축되고 키가 정규화된 것을 확인했고, 앱의 일별 합계를 1,302개 JSONL 전체를 독립적으로 파싱한 결과와 대조했습니다 — 오늘과 직전 이틀은 정확히 일치합니다.

실제 로그 한 달치 비용 영향 — 문제가 된 3개 ID만 바뀌고 나머지 10개 모델은 $0.00 변동:

```
claude-opus-4.8          76 msgs   $136.43 -> $45.48   (-$90.96)
anthropic-gpt-5.6-sol   156 msgs    $73.61 -> $122.84  (+$49.22)
gpt-5.6-sol             124 msgs    $53.40 -> $89.08   (+$35.68)
```

Breakdown 행: **13 → 8**

```
claude-opus-4-8   <- claude-opus-4-8, claude-opus-4.8
claude-opus-5     <- claude-opus-5, claude/claude-opus-5, kiro/claude-opus-5
claude-sonnet-5   <- claude-sonnet-5, kiro/claude-sonnet-5
gpt-5-6-sol       <- gpt-5.6-sol, anthropic-gpt-5.6-sol
```

이 변경의 주된 리스크는 과도한 병합(over-merge)이라, 두 테스트로 막았습니다.

- `canonical_matching_preserves_existing_resolutions` — 6개 테이블의 모든 패턴이 이전과 동일한 엔트리로 해석되고, 정규화 후 서로 충돌하는 패턴이 없는지 확인
- `normalize_model_id_keeps_distinct_models_apart` — 서로 다른 12개 모델이 병합되지 않는지 확인

개발 중 기존 grok round-trip 테스트가 실제 문제를 잡아냈습니다. `meta_for` 헬퍼가 파싱 지점을 우회해 원본 ID를 주입하고 있었는데 프로덕션에서는 그런 ID가 생기지 않으므로, 헬퍼도 정규화하도록 고쳤습니다.

## 참고

`CLAUDE5_SONNET`은 여전히 `claude5-sonnet`으로 별도 행에 남습니다(1건, 0 토큰). `claude5`가 `claude-5`가 아니라서 어떤 버전 패턴에도 걸리지 않습니다. 숫자와 문자 사이에 하이픈을 넣는 규칙을 추가하면 `gpt-4o`, `kimi-k2` 같은 정상 ID가 깨질 위험이 있어 손대지 않았습니다. 다르게 처리하는 편이 좋다면 알려주세요.

이 PR과는 무관하지만 검증 중 발견한 것: 일별 합계가 실행마다 약 0.003% 흔들립니다. `collect_file_meta`가 `HashMap`을 반환해 파일 순회 순서가 실행마다 다른데 `entries.extend()`가 나중 값으로 덮어쓰고, 같은 dedup 키가 서로 다른 usage로 여러 파일에 기록된 케이스가 111건(그중 109건은 하나의 API 호출이 여러 `agent-*.jsonl`에 중복 기록된 서브에이전트 sidechain 로그) 있기 때문입니다. 기존부터 있던 동작이고 이 변경과 무관하며, 마지막 값 대신 `output_tokens`가 가장 큰 값을 유지하도록 바꾸면 해결됩니다. 이 PR의 범위를 좁게 유지하려고 포함하지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)