### PR TITLE
fix(gjc): normalize model ids like every other provider

### DIFF
--- a/src-tauri/src/providers/gjc.rs
+++ b/src-tauri/src/providers/gjc.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant, SystemTime};
 
 use serde_json::Value;
 
+use super::pricing;
 use super::traits::TokenProvider;
 use super::types::{AllStats, DailyUsage, ModelUsage};
 
@@ -182,12 +183,14 @@ impl GjcProvider {
                 .and_then(|v| v.as_f64())
                 .unwrap_or(0.0);
 
+            // Normalized so one model yields one key across providers — the
+            // frontend merges providers' model_usage by key.
             let model = message
                 .get("model")
                 .and_then(|v| v.as_str())
                 .filter(|s| !s.is_empty())
-                .unwrap_or("gjc")
-                .to_string();
+                .map(pricing::normalize_model_id)
+                .unwrap_or_else(|| "gjc".to_string());
 
             let date = extract_date_from_iso(&value)
                 .unwrap_or_else(|| path_date.clone());
@@ -484,4 +487,40 @@ fn extract_date_from_file_mtime(path: &Path) -> String {
             local.format("%Y-%m-%d").to_string()
         })
         .unwrap_or_else(|| chrono::Local::now().format("%Y-%m-%d").to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One assistant line with the given model id and a unique responseId.
+    fn line_with_model(model: &str, rid: &str) -> String {
+        format!(
+            r#"{{"id":"l-{rid}","timestamp":"2026-03-23T10:00:00Z","message":{{"role":"assistant","model":"{model}","responseId":"{rid}","usage":{{"input":1,"output":1,"cost":{{"total":0.01}}}}}}}}"#
+        )
+    }
+
+    // GJC reports whatever model id the routed endpoint returned, so gateway
+    // spellings reach this log too. They must land on the same normalized key as
+    // every other provider — the frontend merges providers' model_usage by key.
+    #[test]
+    fn parse_single_file_normalizes_gateway_model_spellings() {
+        let dir = std::env::temp_dir().join(format!("gjc-normalize-test-{}", std::process::id()));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        let path = dir.join("2026-03-23_session.jsonl");
+
+        let lines = [
+            line_with_model("claude-opus-4.8", "r1"),
+            line_with_model("anthropic-gpt-5.6-sol", "r2"),
+            line_with_model("kiro/claude-opus-5", "r3"),
+        ];
+        fs::write(&path, lines.join("\n")).expect("write jsonl");
+
+        let entries = GjcProvider::parse_single_file(&path);
+        let mut models: Vec<&str> = entries.values().map(|e| e.model.as_str()).collect();
+        models.sort_unstable();
+        assert_eq!(models, vec!["claude-opus-4-8", "claude-opus-5", "gpt-5-6-sol"]);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
 }

--- a/src-tauri/src/providers/pricing.rs
+++ b/src-tauri/src/providers/pricing.rs
@@ -976,8 +976,9 @@ mod tests {
         assert_eq!(canonical_model("claude-opus-4.8"), "claude-opus-4-8");
         assert_eq!(canonical_model("CLAUDE5_SONNET"), "claude5-sonnet");
         assert_eq!(canonical_model("claude-opus-4-8"), "claude-opus-4-8");
-        // Vendor prefixes survive: patterns match as substrings, and opencode's
-        // table matches on `anthropic/` deliberately.
+        // Vendor prefixes survive canonicalization: patterns match as
+        // substrings, so `kiro/claude-opus-5` still contains `opus-5`.
+        // Stripping the prefix is normalize_model_id's job, not this one's.
         assert_eq!(canonical_model("kiro/claude-opus-5"), "kiro/claude-opus-5");
     }
 


### PR DESCRIPTION
## 요약

PR #181 후속. #181이 모든 프로바이더의 파싱 지점에서 모델 ID를 정규화해 프론트엔드의 프로바이더 간 `model_usage` 병합이 모델당 하나의 키를 보도록 했는데, `gjc.rs`가 누락되어 raw `message.model` 문자열을 그대로 키로 쓰고 있었습니다. GJC 로그에 게이트웨이 변형 표기(`claude-opus-4.8`, `anthropic-gpt-5.6-sol`)가 남으면 같은 모델의 정규화된 행과 갈라집니다.

- `gjc.rs`: `pricing::normalize_model_id`를 파싱 지점에 적용 (#181과 동일 패턴) + 게이트웨이 표기 정규화 테스트 추가
- `pricing.rs`: `canonical_model` 테스트의 stale 주석 수정 (opencode 테이블 패턴은 `anthropic/` 프리픽스가 아니라 bare 패밀리)

GJC는 영속 캐시가 없어(in-memory TTL 캐시만) 마이그레이션이 필요 없습니다.

## 검증

`cargo test` 169개 통과 (신규 1개: `parse_single_file_normalizes_gateway_model_spellings`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
