### PR TITLE
fix: survive parse-thread panics instead of freezing stats until relaunch

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1019,8 +1019,35 @@ fn restart_app(app: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// Record panics to `~/.claude/ai-token-monitor-panic.log` (append, best-effort)
+/// on top of the default stderr report. Stderr is lost for Finder-launched apps,
+/// so before this a parse-thread panic left no trace at all — the stats just
+/// froze until relaunch, with nothing to diagnose from.
+fn install_panic_logger() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        if let Some(dir) = dirs::home_dir() {
+            let path = dir.join(".claude").join("ai-token-monitor-panic.log");
+            let thread = std::thread::current();
+            let line = format!(
+                "[{}] version={} thread={} {}\n",
+                chrono::Local::now().format("%Y-%m-%dT%H:%M:%S%z"),
+                env!("CARGO_PKG_VERSION"),
+                thread.name().unwrap_or("<unnamed>"),
+                info
+            );
+            if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&path) {
+                use std::io::Write;
+                let _ = f.write_all(line.as_bytes());
+            }
+        }
+        previous(info);
+    }));
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    install_panic_logger();
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
             // Windows에서 deep link는 새 프로세스의 CLI arg로 전달되며,

--- a/src-tauri/src/providers/claude_code.rs
+++ b/src-tauri/src/providers/claude_code.rs
@@ -66,10 +66,11 @@ pub fn invalidate_stats_cache() {
 /// Return cached stats without triggering a re-parse.
 /// Used by tray title update to avoid blocking.
 pub fn get_cached_stats() -> Option<AllStats> {
-    STATS_CACHE.lock().ok()?.as_ref().map(|c| c.stats.clone())
+    lock_unpoisoned(&STATS_CACHE).as_ref().map(|c| c.stats.clone())
 }
 
 use super::pricing;
+use super::resilience::{lock_unpoisoned, ParsingGuard};
 
 fn calculate_cost(
     pricing: &pricing::ClaudePricing,
@@ -887,9 +888,7 @@ impl TokenProvider for ClaudeCodeProvider {
             let changed = *prev != dirs_hash;
             if changed {
                 *prev = dirs_hash;
-                if let Ok(mut cache) = STATS_CACHE.lock() {
-                    *cache = None;
-                }
+                *lock_unpoisoned(&STATS_CACHE) = None;
             }
             changed
         };
@@ -898,35 +897,29 @@ impl TokenProvider for ClaudeCodeProvider {
 
         // If not invalidated, return cached stats if fresh
         if !was_invalidated {
-            if let Ok(cache) = STATS_CACHE.lock() {
-                if let Some(ref cached) = *cache {
-                    if cached.computed_at.elapsed() < CACHE_TTL {
-                        return Ok(cached.stats.clone());
-                    }
+            if let Some(ref cached) = *lock_unpoisoned(&STATS_CACHE) {
+                if cached.computed_at.elapsed() < CACHE_TTL {
+                    return Ok(cached.stats.clone());
                 }
             }
         }
 
-        // Prevent thundering herd: if another thread is already parsing, return stale cache
-        if PARSING.compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst).is_err() {
-            if let Ok(cache) = STATS_CACHE.lock() {
-                if let Some(ref cached) = *cache {
-                    return Ok(cached.stats.clone());
-                }
+        // Prevent thundering herd: if another thread is already parsing, return
+        // stale cache. The guard releases PARSING on every exit path — including
+        // an unwinding panic, which previously left the flag stuck and froze the
+        // stats until the app was relaunched.
+        let Some(_parsing) = ParsingGuard::try_acquire(&PARSING) else {
+            if let Some(ref cached) = *lock_unpoisoned(&STATS_CACHE) {
+                return Ok(cached.stats.clone());
             }
             std::thread::sleep(Duration::from_millis(100));
-            if let Ok(cache) = STATS_CACHE.lock() {
-                if let Some(ref cached) = *cache {
-                    return Ok(cached.stats.clone());
-                }
+            if let Some(ref cached) = *lock_unpoisoned(&STATS_CACHE) {
+                return Ok(cached.stats.clone());
             }
             return Err("Stats computation in progress".to_string());
-        }
+        };
 
-        // We hold the PARSING flag — ensure we clear it on exit
-        let result = self.do_fetch_stats();
-        PARSING.store(false, Ordering::SeqCst);
-        result
+        self.do_fetch_stats()
     }
 
     fn is_available(&self) -> bool {
@@ -940,21 +933,17 @@ impl ClaudeCodeProvider {
         let current_meta = self.collect_file_meta();
 
         // Check if any files actually changed since last computation
-        let (entries, file_states) = if let Ok(cache) = STATS_CACHE.lock() {
+        let (entries, file_states) = {
+            let cache = lock_unpoisoned(&STATS_CACHE);
             if let Some(ref cached) = *cache {
                 if file_states_match(&cached.file_states, &current_meta) {
                     // No files changed — refresh timestamp and return cached stats
                     drop(cache);
-                    if let Ok(mut cache) = STATS_CACHE.lock() {
-                        if let Some(ref mut cached) = *cache {
-                            cached.computed_at = Instant::now();
-                        }
-                    }
-                    eprintln!("[PERF] No files changed, reusing cache ({:?})", start.elapsed());
-                    if let Ok(cache) = STATS_CACHE.lock() {
-                        if let Some(ref cached) = *cache {
-                            return Ok(cached.stats.clone());
-                        }
+                    let mut cache = lock_unpoisoned(&STATS_CACHE);
+                    if let Some(ref mut cached) = *cache {
+                        cached.computed_at = Instant::now();
+                        eprintln!("[PERF] No files changed, reusing cache ({:?})", start.elapsed());
+                        return Ok(cached.stats.clone());
                     }
                     return Err("Cache lost during refresh".to_string());
                 }
@@ -1049,21 +1038,17 @@ impl ClaudeCodeProvider {
                 eprintln!("[PERF] Full parse completed in {:?}", full_start.elapsed());
                 (entries, file_states)
             }
-        } else {
-            return Err("Failed to acquire cache lock".to_string());
         };
 
         let stats = self.build_stats(&entries);
 
         // Update cache with entries + per-file parse state
-        if let Ok(mut cache) = STATS_CACHE.lock() {
-            *cache = Some(IncrementalCache {
-                stats: stats.clone(),
-                computed_at: Instant::now(),
-                entries,
-                file_states,
-            });
-        }
+        *lock_unpoisoned(&STATS_CACHE) = Some(IncrementalCache {
+            stats: stats.clone(),
+            computed_at: Instant::now(),
+            entries,
+            file_states,
+        });
 
         eprintln!("[PERF] Total fetch_stats: {:?}", start.elapsed());
         Ok(stats)

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -101,10 +101,11 @@ pub fn invalidate_stats_cache() {
 
 /// Return cached stats without triggering a re-parse (used by tray update).
 pub fn get_cached_stats() -> Option<AllStats> {
-    STATS_CACHE.lock().ok()?.as_ref().map(|c| c.stats.clone())
+    lock_unpoisoned(&STATS_CACHE).as_ref().map(|c| c.stats.clone())
 }
 
 use super::pricing;
+use super::resilience::{lock_unpoisoned, ParsingGuard};
 
 fn calculate_cost(pricing: &pricing::CodexPricing, input: u64, output: u64, cached: u64) -> f64 {
     // OpenAI's input_tokens includes cached_input_tokens as a subset.
@@ -679,12 +680,14 @@ impl CodexProvider {
         let start = Instant::now();
         let current_meta = self.collect_file_meta();
 
-        let (entries, file_states) = if let Ok(cache) = STATS_CACHE.lock() {
+        let (entries, file_states) = {
+            let cache = lock_unpoisoned(&STATS_CACHE);
             if let Some(ref cached) = *cache {
                 if file_states_match(&cached.file_states, &current_meta) {
                     drop(cache);
                     let rate_limits = self.resolve_rate_limits(&current_meta);
-                    if let Ok(mut cache) = STATS_CACHE.lock() {
+                    {
+                        let mut cache = lock_unpoisoned(&STATS_CACHE);
                         if let Some(ref mut cached) = *cache {
                             cached.computed_at = Instant::now();
                             cached.stats.rate_limits = rate_limits;
@@ -694,7 +697,8 @@ impl CodexProvider {
                         "[PERF][Codex] No files changed, refreshed rate limits ({:?})",
                         start.elapsed()
                     );
-                    if let Ok(cache) = STATS_CACHE.lock() {
+                    {
+                        let cache = lock_unpoisoned(&STATS_CACHE);
                         if let Some(ref cached) = *cache {
                             return Ok(cached.stats.clone());
                         }
@@ -725,14 +729,13 @@ impl CodexProvider {
                 );
                 (entries, file_states)
             }
-        } else {
-            return Err("Failed to acquire cache lock".to_string());
         };
 
         let mut stats = Self::build_stats(&entries);
         stats.rate_limits = self.resolve_rate_limits(&current_meta);
 
-        if let Ok(mut cache) = STATS_CACHE.lock() {
+        {
+            let mut cache = lock_unpoisoned(&STATS_CACHE);
             *cache = Some(IncrementalCache {
                 stats: stats.clone(),
                 computed_at: Instant::now(),
@@ -756,7 +759,8 @@ impl TokenProvider for CodexProvider {
 
         // Return cached if still fresh and not invalidated
         if !was_invalidated {
-            if let Ok(cache) = STATS_CACHE.lock() {
+            {
+                let cache = lock_unpoisoned(&STATS_CACHE);
                 if let Some(ref cached) = *cache {
                     if cached.computed_at.elapsed() < CACHE_TTL {
                         return Ok(cached.stats.clone());
@@ -765,28 +769,22 @@ impl TokenProvider for CodexProvider {
             }
         }
 
-        // Thundering herd prevention
-        if PARSING
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .is_err()
-        {
-            if let Ok(cache) = STATS_CACHE.lock() {
-                if let Some(ref cached) = *cache {
-                    return Ok(cached.stats.clone());
-                }
+        // Thundering herd prevention: serve stale cache while another thread
+        // parses. The guard releases PARSING on every exit path — including an
+        // unwinding panic, which previously left the flag stuck and froze the
+        // stats until the app was relaunched.
+        let Some(_parsing) = ParsingGuard::try_acquire(&PARSING) else {
+            if let Some(ref cached) = *lock_unpoisoned(&STATS_CACHE) {
+                return Ok(cached.stats.clone());
             }
             std::thread::sleep(Duration::from_millis(100));
-            if let Ok(cache) = STATS_CACHE.lock() {
-                if let Some(ref cached) = *cache {
-                    return Ok(cached.stats.clone());
-                }
+            if let Some(ref cached) = *lock_unpoisoned(&STATS_CACHE) {
+                return Ok(cached.stats.clone());
             }
             return Err("Codex stats computation in progress".to_string());
-        }
+        };
 
-        let result = self.do_fetch_stats();
-        PARSING.store(false, Ordering::SeqCst);
-        result
+        self.do_fetch_stats()
     }
 
     fn is_available(&self) -> bool {

--- a/src-tauri/src/providers/gjc.rs
+++ b/src-tauri/src/providers/gjc.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant, SystemTime};
 use serde_json::Value;
 
 use super::pricing;
+use super::resilience::{lock_unpoisoned, ParsingGuard};
 use super::traits::TokenProvider;
 use super::types::{AllStats, DailyUsage, ModelUsage};
 
@@ -33,7 +34,7 @@ pub fn invalidate_stats_cache() {
 
 /// Return cached stats without triggering a re-parse (used by tray update).
 pub fn get_cached_stats() -> Option<AllStats> {
-    STATS_CACHE.lock().ok()?.as_ref().map(|c| c.stats.clone())
+    lock_unpoisoned(&STATS_CACHE).as_ref().map(|c| c.stats.clone())
 }
 
 // --- Entry type ---
@@ -357,11 +358,13 @@ impl GjcProvider {
         let start = Instant::now();
         let current_meta = self.collect_file_meta();
 
-        let entries = if let Ok(cache) = STATS_CACHE.lock() {
+        let entries = {
+            let cache = lock_unpoisoned(&STATS_CACHE);
             if let Some(ref cached) = *cache {
                 if cached.file_meta == current_meta {
                     drop(cache);
-                    if let Ok(mut cache) = STATS_CACHE.lock() {
+                    {
+                        let mut cache = lock_unpoisoned(&STATS_CACHE);
                         if let Some(ref mut cached) = *cache {
                             cached.computed_at = Instant::now();
                         }
@@ -370,7 +373,8 @@ impl GjcProvider {
                         "[PERF][GJC] No files changed, reusing cache ({:?})",
                         start.elapsed()
                     );
-                    if let Ok(cache) = STATS_CACHE.lock() {
+                    {
+                        let cache = lock_unpoisoned(&STATS_CACHE);
                         if let Some(ref cached) = *cache {
                             return Ok(cached.stats.clone());
                         }
@@ -396,13 +400,12 @@ impl GjcProvider {
                 );
                 entries
             }
-        } else {
-            return Err("Failed to acquire cache lock".to_string());
         };
 
         let stats = Self::build_stats(&entries);
 
-        if let Ok(mut cache) = STATS_CACHE.lock() {
+        {
+            let mut cache = lock_unpoisoned(&STATS_CACHE);
             *cache = Some(IncrementalCache {
                 stats: stats.clone(),
                 computed_at: Instant::now(),
@@ -425,7 +428,8 @@ impl TokenProvider for GjcProvider {
         let was_invalidated = CACHE_INVALIDATED.swap(false, Ordering::Relaxed);
 
         if !was_invalidated {
-            if let Ok(cache) = STATS_CACHE.lock() {
+            {
+                let cache = lock_unpoisoned(&STATS_CACHE);
                 if let Some(ref cached) = *cache {
                     if cached.computed_at.elapsed() < CACHE_TTL {
                         return Ok(cached.stats.clone());
@@ -434,28 +438,22 @@ impl TokenProvider for GjcProvider {
             }
         }
 
-        // Thundering herd prevention
-        if PARSING
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .is_err()
-        {
-            if let Ok(cache) = STATS_CACHE.lock() {
-                if let Some(ref cached) = *cache {
-                    return Ok(cached.stats.clone());
-                }
+        // Thundering herd prevention: serve stale cache while another thread
+        // parses. The guard releases PARSING on every exit path — including an
+        // unwinding panic, which previously left the flag stuck and froze the
+        // stats until the app was relaunched.
+        let Some(_parsing) = ParsingGuard::try_acquire(&PARSING) else {
+            if let Some(ref cached) = *lock_unpoisoned(&STATS_CACHE) {
+                return Ok(cached.stats.clone());
             }
             std::thread::sleep(Duration::from_millis(100));
-            if let Ok(cache) = STATS_CACHE.lock() {
-                if let Some(ref cached) = *cache {
-                    return Ok(cached.stats.clone());
-                }
+            if let Some(ref cached) = *lock_unpoisoned(&STATS_CACHE) {
+                return Ok(cached.stats.clone());
             }
             return Err("GJC stats computation in progress".to_string());
-        }
+        };
 
-        let result = self.do_fetch_stats();
-        PARSING.store(false, Ordering::SeqCst);
-        result
+        self.do_fetch_stats()
     }
 
     fn is_available(&self) -> bool {

--- a/src-tauri/src/providers/grok.rs
+++ b/src-tauri/src/providers/grok.rs
@@ -29,6 +29,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::pricing;
+use super::resilience::{lock_unpoisoned, ParsingGuard};
 use super::traits::TokenProvider;
 use super::types::{AllStats, AnalyticsData, DailyUsage, ModelUsage, ProjectUsage};
 
@@ -73,7 +74,7 @@ pub fn invalidate_stats_cache() {
 
 /// Return cached stats without triggering a re-parse (used by tray update).
 pub fn get_cached_stats() -> Option<AllStats> {
-    STATS_CACHE.lock().ok()?.as_ref().map(|c| c.stats.clone())
+    lock_unpoisoned(&STATS_CACHE).as_ref().map(|c| c.stats.clone())
 }
 
 /// Cost for one request. xAI bills every token in a request at the higher rate
@@ -579,7 +580,8 @@ impl GrokProvider {
         // the snapshot remains and nothing can add to it. Refresh computed_at on
         // the way out (as codex.rs does) so the TTL check keeps absorbing calls
         // instead of routing every one of them back through here.
-        if let Ok(mut cache) = STATS_CACHE.lock() {
+        {
+            let mut cache = lock_unpoisoned(&STATS_CACHE);
             if let Some(ref mut cached) = *cache {
                 if cached.log_meta == current_meta {
                     cached.computed_at = Instant::now();
@@ -609,7 +611,8 @@ impl GrokProvider {
 
         let stats = Self::build_stats(&history);
 
-        if let Ok(mut cache) = STATS_CACHE.lock() {
+        {
+            let mut cache = lock_unpoisoned(&STATS_CACHE);
             *cache = Some(IncrementalCache {
                 stats: stats.clone(),
                 computed_at: Instant::now(),
@@ -636,7 +639,8 @@ impl TokenProvider for GrokProvider {
         let was_invalidated = CACHE_INVALIDATED.swap(false, Ordering::Relaxed);
 
         if !was_invalidated {
-            if let Ok(cache) = STATS_CACHE.lock() {
+            {
+                let cache = lock_unpoisoned(&STATS_CACHE);
                 if let Some(ref cached) = *cache {
                     if cached.computed_at.elapsed() < CACHE_TTL {
                         return Ok(cached.stats.clone());
@@ -645,28 +649,22 @@ impl TokenProvider for GrokProvider {
             }
         }
 
-        // Thundering herd prevention
-        if PARSING
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .is_err()
-        {
-            if let Ok(cache) = STATS_CACHE.lock() {
-                if let Some(ref cached) = *cache {
-                    return Ok(cached.stats.clone());
-                }
+        // Thundering herd prevention: serve stale cache while another thread
+        // parses. The guard releases PARSING on every exit path — including an
+        // unwinding panic, which previously left the flag stuck and froze the
+        // stats until the app was relaunched.
+        let Some(_parsing) = ParsingGuard::try_acquire(&PARSING) else {
+            if let Some(ref cached) = *lock_unpoisoned(&STATS_CACHE) {
+                return Ok(cached.stats.clone());
             }
             std::thread::sleep(Duration::from_millis(100));
-            if let Ok(cache) = STATS_CACHE.lock() {
-                if let Some(ref cached) = *cache {
-                    return Ok(cached.stats.clone());
-                }
+            if let Some(ref cached) = *lock_unpoisoned(&STATS_CACHE) {
+                return Ok(cached.stats.clone());
             }
             return Err("Grok stats computation in progress".to_string());
-        }
+        };
 
-        let result = self.do_fetch_stats();
-        PARSING.store(false, Ordering::SeqCst);
-        result
+        self.do_fetch_stats()
     }
 
     fn is_available(&self) -> bool {

--- a/src-tauri/src/providers/kimi.rs
+++ b/src-tauri/src/providers/kimi.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant, SystemTime};
 use serde_json::Value;
 
 use super::pricing;
+use super::resilience::{lock_unpoisoned, ParsingGuard};
 use super::traits::TokenProvider;
 use super::types::{AllStats, DailyUsage, ModelUsage};
 
@@ -33,7 +34,7 @@ pub fn invalidate_stats_cache() {
 
 /// Return cached stats without triggering a re-parse (used by tray update).
 pub fn get_cached_stats() -> Option<AllStats> {
-    STATS_CACHE.lock().ok()?.as_ref().map(|c| c.stats.clone())
+    lock_unpoisoned(&STATS_CACHE).as_ref().map(|c| c.stats.clone())
 }
 
 fn calculate_cost(pricing: &pricing::KimiPricing, input: u64, output: u64, cached: u64) -> f64 {
@@ -345,11 +346,13 @@ impl KimiProvider {
         let start = Instant::now();
         let current_meta = self.collect_file_meta();
 
-        let entries = if let Ok(cache) = STATS_CACHE.lock() {
+        let entries = {
+            let cache = lock_unpoisoned(&STATS_CACHE);
             if let Some(ref cached) = *cache {
                 if cached.file_meta == current_meta {
                     drop(cache);
-                    if let Ok(mut cache) = STATS_CACHE.lock() {
+                    {
+                        let mut cache = lock_unpoisoned(&STATS_CACHE);
                         if let Some(ref mut cached) = *cache {
                             cached.computed_at = Instant::now();
                         }
@@ -358,7 +361,8 @@ impl KimiProvider {
                         "[PERF][Kimi] No files changed, reusing cache ({:?})",
                         start.elapsed()
                     );
-                    if let Ok(cache) = STATS_CACHE.lock() {
+                    {
+                        let cache = lock_unpoisoned(&STATS_CACHE);
                         if let Some(ref cached) = *cache {
                             return Ok(cached.stats.clone());
                         }
@@ -384,13 +388,12 @@ impl KimiProvider {
                 );
                 entries
             }
-        } else {
-            return Err("Failed to acquire cache lock".to_string());
         };
 
         let stats = Self::build_stats(&entries);
 
-        if let Ok(mut cache) = STATS_CACHE.lock() {
+        {
+            let mut cache = lock_unpoisoned(&STATS_CACHE);
             *cache = Some(IncrementalCache {
                 stats: stats.clone(),
                 computed_at: Instant::now(),
@@ -413,7 +416,8 @@ impl TokenProvider for KimiProvider {
         let was_invalidated = CACHE_INVALIDATED.swap(false, Ordering::Relaxed);
 
         if !was_invalidated {
-            if let Ok(cache) = STATS_CACHE.lock() {
+            {
+                let cache = lock_unpoisoned(&STATS_CACHE);
                 if let Some(ref cached) = *cache {
                     if cached.computed_at.elapsed() < CACHE_TTL {
                         return Ok(cached.stats.clone());
@@ -422,28 +426,22 @@ impl TokenProvider for KimiProvider {
             }
         }
 
-        // Thundering herd prevention
-        if PARSING
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .is_err()
-        {
-            if let Ok(cache) = STATS_CACHE.lock() {
-                if let Some(ref cached) = *cache {
-                    return Ok(cached.stats.clone());
-                }
+        // Thundering herd prevention: serve stale cache while another thread
+        // parses. The guard releases PARSING on every exit path — including an
+        // unwinding panic, which previously left the flag stuck and froze the
+        // stats until the app was relaunched.
+        let Some(_parsing) = ParsingGuard::try_acquire(&PARSING) else {
+            if let Some(ref cached) = *lock_unpoisoned(&STATS_CACHE) {
+                return Ok(cached.stats.clone());
             }
             std::thread::sleep(Duration::from_millis(100));
-            if let Ok(cache) = STATS_CACHE.lock() {
-                if let Some(ref cached) = *cache {
-                    return Ok(cached.stats.clone());
-                }
+            if let Some(ref cached) = *lock_unpoisoned(&STATS_CACHE) {
+                return Ok(cached.stats.clone());
             }
             return Err("Kimi stats computation in progress".to_string());
-        }
+        };
 
-        let result = self.do_fetch_stats();
-        PARSING.store(false, Ordering::SeqCst);
-        result
+        self.do_fetch_stats()
     }
 
     fn is_available(&self) -> bool {

--- a/src-tauri/src/providers/kiro.rs
+++ b/src-tauri/src/providers/kiro.rs
@@ -37,6 +37,7 @@ use std::time::{Duration, Instant};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use super::resilience::lock_unpoisoned;
 use super::traits::TokenProvider;
 use super::types::{AllStats, AnalyticsData, DailyUsage, ModelUsage, ProjectUsage, ToolCount};
 
@@ -71,16 +72,14 @@ pub fn invalidate_stats_cache() {
 
 /// Return cached stats without triggering a re-parse.
 pub fn get_cached_stats() -> Option<AllStats> {
-    STATS_CACHE.lock().ok()?.as_ref().map(|c| c.stats.clone())
+    lock_unpoisoned(&STATS_CACHE).as_ref().map(|c| c.stats.clone())
 }
 
 /// Return the cached Kiro-specific breakdown, re-parsing if the cache is cold.
 pub fn get_breakdown() -> Result<KiroBreakdown, String> {
     let provider = KiroProvider::new();
     provider.compute()?;
-    STATS_CACHE
-        .lock()
-        .map_err(|_| "kiro cache poisoned".to_string())?
+    lock_unpoisoned(&STATS_CACHE)
         .as_ref()
         .map(|c| c.breakdown.clone())
         .ok_or_else(|| "kiro breakdown unavailable".to_string())
@@ -208,11 +207,9 @@ impl KiroProvider {
     fn compute(&self) -> Result<(), String> {
         let was_invalidated = CACHE_INVALIDATED.swap(false, Ordering::Relaxed);
         if !was_invalidated {
-            if let Ok(cache) = STATS_CACHE.lock() {
-                if let Some(ref cached) = *cache {
-                    if cached.computed_at.elapsed() < CACHE_TTL {
-                        return Ok(());
-                    }
+            if let Some(ref cached) = *lock_unpoisoned(&STATS_CACHE) {
+                if cached.computed_at.elapsed() < CACHE_TTL {
+                    return Ok(());
                 }
             }
         }
@@ -228,13 +225,11 @@ impl KiroProvider {
         let breakdown = build_breakdown(&turns, session_store_turns, sqlite_store_turns);
         let stats = build_all_stats(&turns, &breakdown);
 
-        if let Ok(mut cache) = STATS_CACHE.lock() {
-            *cache = Some(StatsCache {
-                stats,
-                breakdown,
-                computed_at: Instant::now(),
-            });
-        }
+        *lock_unpoisoned(&STATS_CACHE) = Some(StatsCache {
+            stats,
+            breakdown,
+            computed_at: Instant::now(),
+        });
         Ok(())
     }
 
@@ -418,9 +413,7 @@ impl TokenProvider for KiroProvider {
 
     fn fetch_stats(&self) -> Result<AllStats, String> {
         self.compute()?;
-        STATS_CACHE
-            .lock()
-            .map_err(|_| "kiro cache poisoned".to_string())?
+        lock_unpoisoned(&STATS_CACHE)
             .as_ref()
             .map(|c| c.stats.clone())
             .ok_or_else(|| "kiro stats unavailable".to_string())

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -7,5 +7,6 @@ pub mod kiro;
 pub mod kimi;
 pub mod opencode;
 pub mod pricing;
+pub(crate) mod resilience;
 pub mod traits;
 pub mod types;

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant, SystemTime};
 use serde_json::Value;
 
 use super::pricing;
+use super::resilience::{lock_unpoisoned, ParsingGuard};
 use super::traits::TokenProvider;
 use super::types::{AllStats, DailyUsage, ModelUsage};
 
@@ -34,7 +35,7 @@ pub fn invalidate_stats_cache() {
 
 /// Return cached stats without triggering a re-parse (used by tray update).
 pub fn get_cached_stats() -> Option<AllStats> {
-    STATS_CACHE.lock().ok()?.as_ref().map(|c| c.stats.clone())
+    lock_unpoisoned(&STATS_CACHE).as_ref().map(|c| c.stats.clone())
 }
 
 // --- Entry type ---
@@ -419,11 +420,13 @@ impl OpenCodeProvider {
         let (entries, db_mtime, json_meta) = if self.has_sqlite_db() {
             // Check if DB has changed since last parse
             let current_mtime = self.db_mtime();
-            if let Ok(cache) = STATS_CACHE.lock() {
+            {
+                let cache = lock_unpoisoned(&STATS_CACHE);
                 if let Some(ref cached) = *cache {
                     if cached.db_mtime == current_mtime {
                         drop(cache);
-                        if let Ok(mut cache) = STATS_CACHE.lock() {
+                        {
+                            let mut cache = lock_unpoisoned(&STATS_CACHE);
                             if let Some(ref mut cached) = *cache {
                                 cached.computed_at = Instant::now();
                             }
@@ -432,7 +435,8 @@ impl OpenCodeProvider {
                             "[PERF][OpenCode] DB unchanged, reusing cache ({:?})",
                             start.elapsed()
                         );
-                        if let Ok(cache) = STATS_CACHE.lock() {
+                        {
+                            let cache = lock_unpoisoned(&STATS_CACHE);
                             if let Some(ref cached) = *cache {
                                 return Ok(cached.stats.clone());
                             }
@@ -452,11 +456,13 @@ impl OpenCodeProvider {
         } else if self.has_json_storage() {
             // JSON fallback — check file metadata
             let current_meta = self.collect_json_meta();
-            if let Ok(cache) = STATS_CACHE.lock() {
+            {
+                let cache = lock_unpoisoned(&STATS_CACHE);
                 if let Some(ref cached) = *cache {
                     if cached.json_meta == current_meta {
                         drop(cache);
-                        if let Ok(mut cache) = STATS_CACHE.lock() {
+                        {
+                            let mut cache = lock_unpoisoned(&STATS_CACHE);
                             if let Some(ref mut cached) = *cache {
                                 cached.computed_at = Instant::now();
                             }
@@ -465,7 +471,8 @@ impl OpenCodeProvider {
                             "[PERF][OpenCode] JSON files unchanged, reusing cache ({:?})",
                             start.elapsed()
                         );
-                        if let Ok(cache) = STATS_CACHE.lock() {
+                        {
+                            let cache = lock_unpoisoned(&STATS_CACHE);
                             if let Some(ref cached) = *cache {
                                 return Ok(cached.stats.clone());
                             }
@@ -488,7 +495,8 @@ impl OpenCodeProvider {
 
         let stats = Self::build_stats(&entries);
 
-        if let Ok(mut cache) = STATS_CACHE.lock() {
+        {
+            let mut cache = lock_unpoisoned(&STATS_CACHE);
             *cache = Some(StatsCache {
                 stats: stats.clone(),
                 computed_at: Instant::now(),
@@ -512,7 +520,8 @@ impl TokenProvider for OpenCodeProvider {
 
         // Return cached if still fresh and not invalidated
         if !was_invalidated {
-            if let Ok(cache) = STATS_CACHE.lock() {
+            {
+                let cache = lock_unpoisoned(&STATS_CACHE);
                 if let Some(ref cached) = *cache {
                     if cached.computed_at.elapsed() < CACHE_TTL {
                         return Ok(cached.stats.clone());
@@ -521,28 +530,22 @@ impl TokenProvider for OpenCodeProvider {
             }
         }
 
-        // Thundering herd prevention
-        if PARSING
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .is_err()
-        {
-            if let Ok(cache) = STATS_CACHE.lock() {
-                if let Some(ref cached) = *cache {
-                    return Ok(cached.stats.clone());
-                }
+        // Thundering herd prevention: serve stale cache while another thread
+        // parses. The guard releases PARSING on every exit path — including an
+        // unwinding panic, which previously left the flag stuck and froze the
+        // stats until the app was relaunched.
+        let Some(_parsing) = ParsingGuard::try_acquire(&PARSING) else {
+            if let Some(ref cached) = *lock_unpoisoned(&STATS_CACHE) {
+                return Ok(cached.stats.clone());
             }
             std::thread::sleep(Duration::from_millis(100));
-            if let Ok(cache) = STATS_CACHE.lock() {
-                if let Some(ref cached) = *cache {
-                    return Ok(cached.stats.clone());
-                }
+            if let Some(ref cached) = *lock_unpoisoned(&STATS_CACHE) {
+                return Ok(cached.stats.clone());
             }
             return Err("OpenCode stats computation in progress".to_string());
-        }
+        };
 
-        let result = self.do_fetch_stats();
-        PARSING.store(false, Ordering::SeqCst);
-        result
+        self.do_fetch_stats()
     }
 
     fn is_available(&self) -> bool {

--- a/src-tauri/src/providers/resilience.rs
+++ b/src-tauri/src/providers/resilience.rs
@@ -53,32 +53,35 @@ pub(crate) fn lock_unpoisoned<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
 mod tests {
     use super::*;
 
-    static TEST_FLAG: AtomicBool = AtomicBool::new(false);
+    // Each test gets its own flag: tests run in parallel, and a shared flag
+    // makes one test's acquire look like the other's "already held".
 
     // The whole point of the guard: a panicking parse must not leave the flag
     // set, or every fetch after the panic serves stale data forever.
     #[test]
     fn parsing_guard_releases_on_panic() {
+        static FLAG: AtomicBool = AtomicBool::new(false);
         let result = std::panic::catch_unwind(|| {
-            let _guard = ParsingGuard::try_acquire(&TEST_FLAG).expect("flag free");
+            let _guard = ParsingGuard::try_acquire(&FLAG).expect("flag free");
             panic!("simulated parse crash");
         });
         assert!(result.is_err(), "the parse did panic");
         assert!(
-            !TEST_FLAG.load(Ordering::SeqCst),
+            !FLAG.load(Ordering::SeqCst),
             "flag must be released by unwind, not stuck forever"
         );
         // And the flag is immediately reusable.
-        let guard = ParsingGuard::try_acquire(&TEST_FLAG);
+        let guard = ParsingGuard::try_acquire(&FLAG);
         assert!(guard.is_some(), "next fetch must be able to parse again");
     }
 
     #[test]
     fn parsing_guard_excludes_concurrent_holders() {
-        let first = ParsingGuard::try_acquire(&TEST_FLAG).expect("flag free");
-        assert!(ParsingGuard::try_acquire(&TEST_FLAG).is_none(), "held flags stay exclusive");
+        static FLAG: AtomicBool = AtomicBool::new(false);
+        let first = ParsingGuard::try_acquire(&FLAG).expect("flag free");
+        assert!(ParsingGuard::try_acquire(&FLAG).is_none(), "held flags stay exclusive");
         drop(first);
-        assert!(ParsingGuard::try_acquire(&TEST_FLAG).is_some(), "released flags are reusable");
+        assert!(ParsingGuard::try_acquire(&FLAG).is_some(), "released flags are reusable");
     }
 
     // A panic while holding the cache mutex must not make the cache unreachable.

--- a/src-tauri/src/providers/resilience.rs
+++ b/src-tauri/src/providers/resilience.rs
@@ -1,0 +1,101 @@
+//! Shared crash-resilience primitives for provider stats pipelines.
+//!
+//! Every provider guards its parse with a `static PARSING: AtomicBool` (so only
+//! one thread parses at a time) and keeps results in a `static STATS_CACHE:
+//! Mutex<...>`. Both are unwind-fragile in their raw form:
+//!
+//! - a panic between `PARSING.store(true)` and `PARSING.store(false)` leaves the
+//!   flag set forever, so every later fetch takes the "someone else is parsing"
+//!   path and returns stale data until the app restarts;
+//! - a panic while holding the cache mutex poisons it, and the widespread
+//!   `if let Ok(cache) = STATS_CACHE.lock()` pattern then silently skips the
+//!   cache — or worse, silently skips *writing* it — on every call thereafter.
+//!
+//! Together these turn one panic anywhere in a parse into "the numbers never
+//! move again until relaunch", with nothing in the UI to say so. Observed in the
+//! field on 2026-08-04 (macOS, stats frozen while logs kept growing; a relaunch
+//! fixed it). [`ParsingGuard`] releases the flag on unwind, and
+//! [`lock_unpoisoned`] treats a poisoned mutex as recoverable — every site
+//! replaces the whole cached value rather than mutating it in place, so a
+//! half-finished update cannot be observed.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+/// RAII holder of a provider's `PARSING` flag: released on drop, including
+/// drops that happen because a parse panicked and is unwinding.
+pub(crate) struct ParsingGuard(&'static AtomicBool);
+
+impl ParsingGuard {
+    /// Claim `flag`, or return `None` when another thread already holds it
+    /// (the caller then serves stale cache instead of double-parsing).
+    pub(crate) fn try_acquire(flag: &'static AtomicBool) -> Option<Self> {
+        flag.compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+            .then_some(Self(flag))
+    }
+}
+
+impl Drop for ParsingGuard {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::SeqCst);
+    }
+}
+
+/// Lock `mutex`, recovering the data if a previous holder panicked. Poisoning
+/// is just a flag on the mutex — the data inside is whatever the last complete
+/// write left there, which for the stats caches is always a consistent value.
+pub(crate) fn lock_unpoisoned<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    static TEST_FLAG: AtomicBool = AtomicBool::new(false);
+
+    // The whole point of the guard: a panicking parse must not leave the flag
+    // set, or every fetch after the panic serves stale data forever.
+    #[test]
+    fn parsing_guard_releases_on_panic() {
+        let result = std::panic::catch_unwind(|| {
+            let _guard = ParsingGuard::try_acquire(&TEST_FLAG).expect("flag free");
+            panic!("simulated parse crash");
+        });
+        assert!(result.is_err(), "the parse did panic");
+        assert!(
+            !TEST_FLAG.load(Ordering::SeqCst),
+            "flag must be released by unwind, not stuck forever"
+        );
+        // And the flag is immediately reusable.
+        let guard = ParsingGuard::try_acquire(&TEST_FLAG);
+        assert!(guard.is_some(), "next fetch must be able to parse again");
+    }
+
+    #[test]
+    fn parsing_guard_excludes_concurrent_holders() {
+        let first = ParsingGuard::try_acquire(&TEST_FLAG).expect("flag free");
+        assert!(ParsingGuard::try_acquire(&TEST_FLAG).is_none(), "held flags stay exclusive");
+        drop(first);
+        assert!(ParsingGuard::try_acquire(&TEST_FLAG).is_some(), "released flags are reusable");
+    }
+
+    // A panic while holding the cache mutex must not make the cache unreachable.
+    #[test]
+    fn lock_unpoisoned_recovers_after_a_panic() {
+        let mutex = Mutex::new(41);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _held = mutex.lock().unwrap();
+            panic!("simulated crash while holding the cache");
+        }));
+        assert!(result.is_err());
+        assert!(mutex.lock().is_err(), "the mutex really is poisoned");
+
+        let mut guard = lock_unpoisoned(&mutex);
+        assert_eq!(*guard, 41, "the last complete value survives");
+        *guard = 42;
+        drop(guard);
+        assert_eq!(*lock_unpoisoned(&mutex), 42);
+    }
+}


### PR DESCRIPTION
## 문제

파싱 스레드 어디서든 패닉이 한 번 발생하면 앱의 숫자가 **재시작 전까지 영구 동결**됩니다. 2026-08-04 실사용에서 관측됐습니다 — 로그는 계속 쌓이는데 토큰/비용이 전혀 안 올라가고, 아무 흔적도 없이 앱 재시작으로만 복구.

원인은 두 겹입니다:

1. `static PARSING: AtomicBool`이 파싱 성공 리턴 후에만 해제됨 → 패닉 unwind 시 플래그가 영구히 true로 남아, 이후 모든 fetch가 "다른 스레드가 파싱 중" 경로로 빠져 stale 캐시만 반환
2. `STATS_CACHE` 뮤텍스를 쥔 채 패닉하면 poisoning → 광범위하게 쓰인 `if let Ok(cache) = STATS_CACHE.lock()` 패턴이 이후 읽기/쓰기를 전부 조용히 건너뜀

## 수정

- **`providers/resilience.rs` 신설**: RAII `ParsingGuard`(unwind 포함 모든 경로에서 플래그 해제) + `lock_unpoisoned`(poisoned 뮤텍스 복구 — 모든 사이트가 캐시를 통째로 교체하므로 찢어진 값 노출 불가)
- 파싱하는 **7개 프로바이더 전부**(claude_code, codex, gjc, grok, kimi, opencode, kiro) 두 프리미티브로 전환
- **패닉 훅**: `~/.claude/ai-token-monitor-panic.log`에 append — Finder 실행 앱은 stderr가 유실되므로, 다음 패닉은 진단 가능한 흔적을 남김

## 검증

`cargo test` 172개 통과(신규 3개: guard unwind 해제, 동시성 배제, poison 복구), `tsc --noEmit` 통과. feature-dev:code-reviewer 리뷰 완료 — 지적된 kiro.rs 누락 반영, self-deadlock/조기 해제 없음 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)