### PR TITLE
fix(leaderboard): refetch own row after upload instead of device-local patch

### DIFF
--- a/src/hooks/useLeaderboardSync.ts
+++ b/src/hooks/useLeaderboardSync.ts
@@ -113,59 +113,35 @@ export function useLeaderboardSync({ provider, period, userId, anchorDate }: Use
     }
   }, [period, provider, anchorDate]);
 
-  // When a snapshot upload completes, optimistically patch only the user's own
-  // row instead of refetching the whole leaderboard. The next scheduled poll
-  // (every 15 min) will reconcile any drift. This avoids ~1 extra RPC per
-  // local Claude/Codex write cluster-wide.
+  // When a snapshot upload completes, force-refetch the leaderboard so the
+  // user's row reflects the upload immediately.
   //
-  // Scope: only `today` can be updated precisely from a single-day signature.
-  // For `week`/`month` the detail values are *today's totals*, so we apply the
-  // delta between the row's current "today slice" and the new one — but we
-  // don't have per-day breakdown server-side here. The simplest correct
-  // behavior is to no-op for non-today periods and let the poll handle it.
+  // This used to optimistically patch the user's row with the upload payload
+  // instead. That payload is THIS DEVICE's totals only, while the server row
+  // merges every device the account uploads from (`device_snapshots`) — so for
+  // anyone running the app on two machines the patch visibly collapsed their
+  // row to one device's numbers (e.g. $1901 → $161) and then pinned the wrong
+  // value into the 30-minute cache. Only the server knows the merged total, so
+  // the honest immediate update is a refetch. Cost is bounded: uploads fire at
+  // most every 15 min per provider, and this handler only runs while the
+  // leaderboard is actually being viewed.
   useEffect(() => {
     if (!userId) return;
     const handler = (e: Event) => {
       const detail = (e as CustomEvent<SnapshotUploadedDetail>).detail;
       if (!detail || detail.provider !== provider) return;
-      if (period !== "today") return;
-      // The detail carries totals for the uploaded row's date — only patch the
-      // list when that exact day is the one being viewed.
-      const viewed = anchorDate ?? toLocalDateStr(new Date());
-      if (detail.today !== viewed) return;
-      // Discard any RPC that started before this upload — its pre-upload rows
-      // would overwrite the fresher patch. The next poll reconciles fully.
-      requestSeqRef.current++;
-      setLoading(false);
-      setLeaderboard((prev) => {
-        const idx = prev.findIndex((entry) => entry.user_id === userId);
-        if (idx < 0) return prev;
-        const next = prev.slice();
-        next[idx] = {
-          ...next[idx],
-          total_tokens: detail.total_tokens,
-          cost_usd: detail.cost_usd,
-          messages: detail.messages,
-          sessions: detail.sessions,
-        };
-        next.sort((a, b) => b.total_tokens - a.total_tokens);
-        // Mirror the patch into the matching cache entry so a visibility
-        // refresh within the TTL doesn't restore pre-upload totals.
-        // (Idempotent — safe under StrictMode double-invocation.)
-        if (
-          cacheRef.current &&
-          cacheRef.current.period === period &&
-          cacheRef.current.provider === provider &&
-          cacheRef.current.anchorDate === anchorDate
-        ) {
-          cacheRef.current = { ...cacheRef.current, data: next };
-        }
-        return next;
-      });
+      if (period === "grid") return;
+      // For `today`, only refetch when the uploaded day is the one on screen;
+      // week/month always contain today, so they refetch unconditionally.
+      if (period === "today") {
+        const viewed = anchorDate ?? toLocalDateStr(new Date());
+        if (detail.today !== viewed) return;
+      }
+      fetchLeaderboard(true);
     };
     window.addEventListener(SNAPSHOT_UPLOADED_EVENT, handler);
     return () => window.removeEventListener(SNAPSHOT_UPLOADED_EVENT, handler);
-  }, [provider, period, userId, anchorDate]);
+  }, [provider, period, userId, anchorDate, fetchLeaderboard]);
 
   // Auto-refresh with visibility-aware polling
   useEffect(() => {


### PR DESCRIPTION
## 문제

업로드 직후 리더보드가 사용자 자신의 행을 **업로드 페이로드(= 이 기기 값만)**로 낙관적 갱신합니다. 서버 행은 계정의 모든 디바이스를 `device_snapshots`로 병합하므로, **두 대 이상에서 앱을 쓰는 사용자는 업로드 때마다 자기 행이 한 기기 값으로 축소되어 보이고**(실관측: $1901 → $161), 그 값이 30분 캐시에 고정되어 다음 폴링까지 지속됩니다.

## 수정

병합 합계는 서버만 알 수 있으므로, 패치 대신 `fetchLeaderboard(true)` 강제 재조회로 교체. 비용은 제한적입니다 — 업로드는 프로바이더당 최대 15분에 1회이고, 핸들러는 리더보드가 화면에 떠 있을 때만 동작합니다. week/month 기간도 (오늘을 항상 포함하므로) 폴링을 기다리지 않고 즉시 갱신됩니다.

## 검증

`tsc --noEmit` + `npm run build` 통과. 서버 병합이 정상임은 프로덕션 DB에서 직접 확인 (오늘 행: M4+M5 디바이스 항목 공존, snapshot_totals 합산 일치).

🤖 Generated with [Claude Code](https://claude.com/claude-code)