### PR TITLE
feat(leaderboard): per-device upload toggle, separate from participation

### DIFF
--- a/src-tauri/src/providers/types.rs
+++ b/src-tauri/src/providers/types.rs
@@ -108,6 +108,14 @@ pub struct UserPreferences {
     pub number_format: String,
     pub show_tray_cost: bool,
     pub leaderboard_opted_in: bool,
+    /// Whether THIS machine uploads its usage to the leaderboard. Separate from
+    /// `leaderboard_opted_in` (participation/identity): a user running the app
+    /// on two machines that see overlapping logs (e.g. one syncs the other's
+    /// session files) needs to keep viewing and chatting everywhere while only
+    /// one machine uploads — otherwise the shared usage is counted once per
+    /// uploading device.
+    #[serde(default = "default_true")]
+    pub leaderboard_upload_enabled: bool,
     #[serde(default)]
     pub device_id: Option<String>,
     #[serde(default = "default_theme")]
@@ -286,6 +294,7 @@ impl Default for UserPreferences {
             number_format: "compact".to_string(),
             show_tray_cost: true,
             leaderboard_opted_in: false,
+            leaderboard_upload_enabled: true,
             device_id: None,
             theme: default_theme(),
             color_mode: default_color_mode(),

--- a/src/components/LeaderboardUploader.tsx
+++ b/src/components/LeaderboardUploader.tsx
@@ -21,7 +21,11 @@ import type { LeaderboardProvider } from "../lib/types";
 export function LeaderboardUploader() {
   const { user } = useAuth();
   const { prefs } = useSettings();
-  const optedIn = !!prefs.leaderboard_opted_in;
+  // Participation is per-account; uploading is per-device. A machine with
+  // uploads disabled still views, chats, and keeps its identity — it just
+  // never contributes rows, so overlapping logs on another machine are not
+  // counted twice.
+  const optedIn = !!prefs.leaderboard_opted_in && prefs.leaderboard_upload_enabled !== false;
 
   // Stats hooks are always called (rules of hooks) but uploads are gated by
   // `optedIn` and each provider's include flag inside `useSnapshotUploader`.

--- a/src/components/SettingsOverlay.tsx
+++ b/src/components/SettingsOverlay.tsx
@@ -453,6 +453,18 @@ function AccountTab({
             />
           </SettingRow>
 
+          {prefs.leaderboard_opted_in && (
+            <SettingRow
+              label={t("settings.uploadFromThisDevice")}
+              description={t("settings.uploadFromThisDeviceHint")}
+            >
+              <ToggleSwitch
+                checked={prefs.leaderboard_upload_enabled !== false}
+                onChange={(v) => updatePrefs({ leaderboard_upload_enabled: v })}
+              />
+            </SettingRow>
+          )}
+
           {user ? (
             <>
             <div style={{

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -16,6 +16,7 @@ const defaultPrefs: UserPreferences = {
   number_format: "compact",
   show_tray_cost: true,
   leaderboard_opted_in: false,
+  leaderboard_upload_enabled: true,
   device_id: undefined,
   include_claude: true,
   include_codex: false,

--- a/src/dev/mockTauri.ts
+++ b/src/dev/mockTauri.ts
@@ -61,6 +61,7 @@ const mockPrefs: UserPreferences = {
   number_format: "compact",
   show_tray_cost: true,
   leaderboard_opted_in: false,
+  leaderboard_upload_enabled: true,
   include_claude: true,
   include_codex: false,
   include_opencode: false,

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -125,6 +125,8 @@
   "settings.autostart": "Beim Start ausführen",
   "settings.leaderboard": "Rangliste",
   "settings.shareUsageData": "Nutzungsdaten teilen",
+  "settings.uploadFromThisDevice": "Nutzung von diesem Gerät hochladen",
+  "settings.uploadFromThisDeviceHint": "Wenn deaktiviert, wird die Nutzung dieses Geräts nicht zur Bestenliste hochgeladen. Ansehen, Chat und Profil funktionieren weiterhin. Wenn mehrere Geräte dieselben Logs sehen, lassen Sie das Hochladen nur auf einem Gerät aktiviert, um Doppelzählungen zu vermeiden.",
   "settings.signedIn": "Angemeldet",
   "settings.signOut": "Abmelden",
   "settings.restoreHistory": "Verlauf wiederherstellen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -131,6 +131,8 @@
   "settings.autostart": "Launch on Startup",
   "settings.leaderboard": "Leaderboard",
   "settings.shareUsageData": "Share Usage Data",
+  "settings.uploadFromThisDevice": "Upload usage from this device",
+  "settings.uploadFromThisDeviceHint": "When off, this device's usage is not uploaded to the leaderboard. Viewing, chat, and your profile still work. If multiple devices see the same logs, keep uploads on for only one of them to avoid double counting.",
   "settings.signedIn": "Signed in",
   "settings.signOut": "Sign out",
   "settings.restoreHistory": "Restore history",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -125,6 +125,8 @@
   "settings.autostart": "Iniciar al arrancar",
   "settings.leaderboard": "Clasificación",
   "settings.shareUsageData": "Compartir datos de uso",
+  "settings.uploadFromThisDevice": "Subir uso desde este dispositivo",
+  "settings.uploadFromThisDeviceHint": "Si está desactivado, el uso de este dispositivo no se sube a la clasificación. Ver, chatear y tu perfil siguen funcionando. Si varios dispositivos ven los mismos registros, mantén la subida activada solo en uno para evitar el doble conteo.",
   "settings.signedIn": "Sesión iniciada",
   "settings.signOut": "Cerrar sesión",
   "settings.restoreHistory": "Restaurar historial",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -125,6 +125,8 @@
   "settings.autostart": "Lancer au démarrage",
   "settings.leaderboard": "Classement",
   "settings.shareUsageData": "Partager les données",
+  "settings.uploadFromThisDevice": "Envoyer l'utilisation depuis cet appareil",
+  "settings.uploadFromThisDeviceHint": "Si désactivé, l'utilisation de cet appareil n'est pas envoyée au classement. La consultation, le chat et votre profil restent disponibles. Si plusieurs appareils voient les mêmes journaux, n'activez l'envoi que sur un seul pour éviter le double comptage.",
   "settings.signedIn": "Connecté",
   "settings.signOut": "Déconnexion",
   "settings.restoreHistory": "Restaurer l'historique",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -125,6 +125,8 @@
   "settings.autostart": "Avvia all'accensione",
   "settings.leaderboard": "Classifica",
   "settings.shareUsageData": "Condividi dati di utilizzo",
+  "settings.uploadFromThisDevice": "Carica l'utilizzo da questo dispositivo",
+  "settings.uploadFromThisDeviceHint": "Se disattivato, l'utilizzo di questo dispositivo non viene caricato in classifica. Visualizzazione, chat e profilo restano disponibili. Se più dispositivi vedono gli stessi log, mantieni il caricamento attivo su uno solo per evitare doppi conteggi.",
   "settings.signedIn": "Accesso effettuato",
   "settings.signOut": "Esci",
   "settings.restoreHistory": "Ripristina cronologia",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -125,6 +125,8 @@
   "settings.autostart": "起動時に自動実行",
   "settings.leaderboard": "リーダーボード",
   "settings.shareUsageData": "使用データを共有",
+  "settings.uploadFromThisDevice": "このデバイスから使用量をアップロード",
+  "settings.uploadFromThisDeviceHint": "オフにすると、このデバイスの使用量はリーダーボードにアップロードされません。閲覧・チャット・プロフィールはそのまま利用できます。複数のデバイスが同じログを共有している場合は、二重集計を防ぐため1台のみオンにしてください。",
   "settings.signedIn": "サインイン済み",
   "settings.signOut": "サインアウト",
   "settings.restoreHistory": "履歴の復元",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -131,6 +131,8 @@
   "settings.autostart": "부팅 시 자동 실행",
   "settings.leaderboard": "리더보드",
   "settings.shareUsageData": "사용 데이터 공유",
+  "settings.uploadFromThisDevice": "이 기기에서 사용량 업로드",
+  "settings.uploadFromThisDeviceHint": "끄면 이 기기의 사용량은 리더보드에 올라가지 않습니다. 보기·채팅·프로필은 그대로 유지됩니다. 여러 기기가 같은 로그를 공유할 때 중복 집계를 막으려면 한 기기에서만 켜두세요.",
   "settings.signedIn": "로그인됨",
   "settings.signOut": "로그아웃",
   "settings.restoreHistory": "기록 복원",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -125,6 +125,8 @@
   "settings.autostart": "Başlangıçta Başlat",
   "settings.leaderboard": "Sıralama",
   "settings.shareUsageData": "Kullanım Verilerini Paylaş",
+  "settings.uploadFromThisDevice": "Bu cihazdan kullanım yükle",
+  "settings.uploadFromThisDeviceHint": "Kapalıyken bu cihazın kullanımı liderlik tablosuna yüklenmez. Görüntüleme, sohbet ve profiliniz çalışmaya devam eder. Birden fazla cihaz aynı günlükleri görüyorsa, çift sayımı önlemek için yüklemeyi yalnızca birinde açık tutun.",
   "settings.signedIn": "Giriş yapıldı",
   "settings.signOut": "Çıkış Yap",
   "settings.restoreHistory": "Geçmişi geri yükle",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -125,6 +125,8 @@
   "settings.autostart": "开机时自动启动",
   "settings.leaderboard": "排行榜",
   "settings.shareUsageData": "共享使用数据",
+  "settings.uploadFromThisDevice": "从此设备上传用量",
+  "settings.uploadFromThisDeviceHint": "关闭后，此设备的用量不会上传到排行榜。浏览、聊天和个人资料仍然可用。如果多台设备共享相同的日志，请只在一台设备上开启上传以避免重复统计。",
   "settings.signedIn": "已登录",
   "settings.signOut": "退出登录",
   "settings.restoreHistory": "恢复历史记录",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -125,6 +125,8 @@
   "settings.autostart": "開機時自動啟動",
   "settings.leaderboard": "排行榜",
   "settings.shareUsageData": "分享使用資料",
+  "settings.uploadFromThisDevice": "從此裝置上傳用量",
+  "settings.uploadFromThisDeviceHint": "關閉後，此裝置的用量不會上傳到排行榜。瀏覽、聊天和個人資料仍然可用。如果多台裝置共享相同的日誌，請只在一台裝置上開啟上傳以避免重複統計。",
   "settings.signedIn": "已登入",
   "settings.signOut": "登出",
   "settings.restoreHistory": "還原歷史記錄",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -86,6 +86,8 @@ export interface UserPreferences {
   number_format: "compact" | "full";
   show_tray_cost: boolean;
   leaderboard_opted_in: boolean;
+  /** Whether THIS machine uploads its usage — participation stays per-account, uploads are per-device. */
+  leaderboard_upload_enabled?: boolean;
   device_id?: string;
   include_claude: boolean;
   include_codex: boolean;


### PR DESCRIPTION
## 문제

`leaderboard_opted_in` 하나가 서로 다른 두 결정을 묶고 있습니다: **리더보드 참여**(정체성·보기·채팅)와 **이 기기 사용량 업로드**. 두 대 이상에서 앱을 쓰고 로그가 겹치는 사용자(한쪽이 다른 쪽 세션 파일을 동기화하는 구성)는 "모든 기기에서 참여하되 업로드는 한 기기만" 할 방법이 없습니다 — 참여를 끄면 리더보드 탭에 참여 CTA가 다시 떠서 언젠가 클릭되고, 그 순간 이중 집계가 조용히 재개됩니다 (2026-08-05 실사용 재현: 옵트아웃 다음 날 CTA 클릭으로 업로드 재개 → 오늘 행에 +$2,369 중복).

## 수정

- 새 설정 `leaderboard_upload_enabled` (기본 true, 기존 prefs 파일은 serde default로 안전) — **업로더만** 게이트
- 설정 UI: 리더보드 섹션에 "이 기기에서 사용량 업로드" 토글 (참여 중일 때만 표시) + 멀티 디바이스 안내 힌트, 10개 로케일 전부
- 업로드 꺼진 기기도 보기·채팅·프로필·랭킹 확인은 전부 동작

## 검증

`cargo test` 172개, `tsc --noEmit`, `npm run build` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)